### PR TITLE
Add local merge request review command

### DIFF
--- a/.agents/plans/8.mr-review-cli-command.md
+++ b/.agents/plans/8.mr-review-cli-command.md
@@ -6,8 +6,13 @@ Add `reviewphin mr review` so operators and local development can submit a real
 ReviewPhin review without exposing webhooks.
 
 The CLI creates a persisted interaction job for an existing storage-backed
-runner and, by default, watches persisted results. The CLI does not start an
-HTTP server or execute review jobs.
+runner and, by default, watches persisted results. It does not start an HTTP
+server, construct a review worker, claim work, or execute review jobs.
+
+The claim-based queue, terminal `expired` status, claim-token/run linkage, and
+`REVIEWPHIN_MAX_QUEUED_JOB_AGE_MS` configuration already exist. This change
+must use those contracts without changing the storage schema or contract
+revision.
 
 ## CLI Interface
 
@@ -26,52 +31,80 @@ reviewphin mr review \
   [--run-log-dir <path>]
 ```
 
-Defaults and validation:
+Validation and defaults:
 
-- `--watch` is enabled.
-- `--trigger-comment-url` infers `--code-review-id` where possible.
+- Exactly one tenant selector and exactly one trigger selector are required.
+- `--watch` is enabled by default. Supplying both `--watch` and `--no-watch`
+  is an error.
+- `--code-review-id` and `--trigger-comment-id` are positive integers.
 - `--trigger-comment-id`, `--trigger-text`, and `--trigger-text-file` require
   `--code-review-id`.
-- Platform comment triggers use normal dedupe unless `--force-new` is set.
-- Text-only triggers always create a fresh local review job.
+- `--trigger-text` and UTF-8 content read from `--trigger-text-file` are
+  trimmed and must not be empty. File paths resolve from the current working
+  directory.
+- `--trigger-comment-url` accepts only these canonical forms:
+  - GitLab:
+    `https://<host>/<project>/-/merge_requests/<iid>#note_<note-id>`
+  - GitHub issue comment:
+    `https://<host>/<owner>/<repo>/pull/<number>#issuecomment-<comment-id>`
+  - GitHub review comment:
+    `https://<host>/<owner>/<repo>/pull/<number>#discussion_r<comment-id>`
+- A supported comment URL supplies both comment id and code-review id. If
+  `--code-review-id` is also supplied, it must match the URL.
+- The selected platform verifies that the URL host/project or repository
+  matches the resolved tenant. Unsupported URL forms fail with guidance to use
+  `--trigger-comment-id` and `--code-review-id`.
+- `--run-log-dir` defaults to `RUN_LOG_DIR`; it only controls where the watcher
+  looks for live logs and does not configure the external runner.
+- The watcher uses the existing `REVIEWPHIN_JOB_POLL_INTERVAL_MS` value. Do not
+  add a separate CLI polling option in this revision.
 
-There is no `--run-worker` option or automatic fallback to local execution in
-this revision.
+There is no `--run-worker` option, automatic fallback to local execution, or
+watch timeout in this revision.
 
-## CLI Flow
+## Submission Flow
 
-1. Open the configured storage provider and platform registry using existing CLI
-   bootstrap helpers. Do not construct `ReviewWorker` or
-   `StorageBackedJobRunner`.
-2. Resolve the tenant.
-3. Ask the platform to create a local interaction job input.
-4. Persist via `createOrGetInteractionJob`.
-5. If `--no-watch`, print the job id, close storage, and exit.
-6. If watching, call the read-only watcher until the target reaches
-   `completed`, `failed`, `cancelled`, or `expired`.
-7. Close storage.
+1. Initialize the platform registry using `PLATFORM_MODULES`, matching the
+   existing CLI setup.
+2. Open storage with the existing `withStorage` helper.
+3. Resolve the tenant and its ready platform connection. Add
+   `TenantRegistry.getResolvedTenantByKey` alongside the existing id lookup so
+   both selectors share ready-connection validation.
+4. Resolve the tenant's platform and call its optional
+   `createLocalInteractionJob`.
+5. Add the resolved tenant id and persist with `createOrGetInteractionJob`.
+6. When the job was created, construct its platform trigger lifecycle and run
+   `queued()` through the same best-effort lifecycle synchronization used by
+   webhook submission. Reused jobs do not repeat `queued()`.
+7. Print whether the job was created or reused.
+8. If `--no-watch`, print the submission summary and return without waiting.
+9. Otherwise watch the persisted job and selected run until they settle.
 
-Use `try/finally` so CLI errors or interruption always close storage. The CLI
-never claims work, so submission and watching are safe with both atomic and
-single-worker adapters.
+The platform hook owns platform API calls and trigger construction; the CLI
+does not import GitLab or GitHub client details.
 
-Install temporary `SIGINT` and `SIGTERM` handlers while watching. The first
-signal aborts the watcher through an `AbortSignal`, waits for it to stop, closes
-the storage provider, removes the handlers, and then exits without changing the
-job. A second signal may terminate immediately.
+`withStorage` already closes providers in `finally`. Temporary watch signal
+handlers must be removed before its callback returns.
 
-The command assumes an existing ReviewPhin runner is connected to the same
-storage backend. It prints that it is waiting for an external runner while the
-job remains queued. There is no reliable generic way to detect that a runner is
-online, so the CLI must not claim the job or report a false runner-health error.
-The operator can interrupt watch mode without cancelling the persisted job.
+## Dedupe and `--force-new`
 
-`mr review --watch` exits with a clear message if the target job expires while
-queued.
+- Comment selectors use the same canonical dedupe key as the equivalent
+  platform comment trigger.
+- For GitLab, treat the fetched note as an `update` when `updated_at` differs
+  from `created_at`; otherwise treat it as `create`. This preserves the
+  existing revision-aware GitLab dedupe behavior.
+- Without `--force-new`, an existing job is returned and watch mode watches
+  that job, including an already-terminal job.
+- With `--force-new`, derive the final dedupe key from the canonical key plus
+  the local request id. Trigger semantics and lifecycle remain unchanged.
+- Text selectors always use the local request id in the dedupe key and
+  therefore always create a fresh job. `--force-new` does not change that
+  behavior.
 
-## Local Trigger Support
+## Local Text Trigger
 
-Add `src/review/local-trigger.ts` with schema:
+Add `src/review/local-trigger.ts` with a Zod schema, exported type, parser, and
+serializer for:
 
 ```ts
 {
@@ -79,142 +112,266 @@ Add `src/review/local-trigger.ts` with schema:
   source: "cli",
   requestId: string,
   codeReviewId: number,
-  instruction: string | null,
+  instruction: string,
   createdAt: string
 }
 ```
 
-Extend `ManualReviewTriggerContext` with optional:
+Use the serialized value for both `triggerJson` and `payloadJson`. The local
+job has `commentId: null`, the platform's current code-review head SHA, and a
+dedupe key containing `requestId`.
+
+Extend `ManualReviewTriggerContext` with:
 
 ```ts
-instruction?: string | null;
-body?: string | null;
+instruction: string | null;
 ```
 
-Update GitLab and GitHub runtimes:
+Existing provider-owned manual triggers, such as the GitHub Check Run action,
+set it to `null`. Do not add a separate `body` field.
 
-- If `job.triggerJson.kind === "reviewphin-local-review"`, build a
-  `manual-review` trigger with `source: "cli"` and the instruction text.
-- Planning still returns `reviewNeeded: true`, `replyNeeded: false`.
-- Review and final findings publication still use the normal worker path.
+Update GitLab and GitHub runtimes so a local trigger builds:
 
-Local text triggers use a no-op trigger lifecycle.
+```ts
+{
+  kind: "manual-review",
+  provider: "<platform-slug>",
+  source: "cli",
+  instruction: trigger.instruction,
+  metadata: {
+    requestId: trigger.requestId,
+    codeReviewId: trigger.codeReviewId,
+    createdAt: trigger.createdAt
+  }
+}
+```
 
-Text-only triggers do not publish a reply because there is no trigger comment
-target; they still publish review findings normally.
+Planning remains `reviewNeeded: true` and `replyNeeded: false`. Include the
+instruction in the compact prompt trigger and the manual-review scope text so
+it actually guides the review. Text-only jobs publish normal review findings
+and summaries but no trigger-comment reply.
+
+Add a shared no-op `PlatformTriggerLifecycle` implementation. GitLab and
+GitHub return it only for `reviewphin-local-review`; native comment and Check
+Run triggers retain their existing reactions/status updates. Move the worker's
+existing best-effort lifecycle synchronization into the same shared module so
+webhook submission, CLI submission, and worker phases log lifecycle failures
+consistently without failing the job.
 
 ## Platform Local Job Creation
 
-Add optional platform API:
-
-```ts
-createLocalInteractionJob(input: {
-  resolvedTenant: ResolvedTenant;
-  storage: StorageHelpers;
-  selector: LocalReviewSelector;
-  forceNew: boolean;
-}): Promise<CreateInteractionJobInput>;
-```
-
-`LocalReviewSelector`:
+Add provider-neutral types near `IPlatform`:
 
 ```ts
 type LocalReviewSelector =
   | { kind: "comment-url"; url: string; codeReviewId?: number }
   | { kind: "comment-id"; commentId: number; codeReviewId: number }
   | { kind: "text"; text: string; codeReviewId: number };
+
+type PlatformInteractionJobInput = Omit<
+  CreateInteractionJobInput,
+  "tenantId" | "triggerJson"
+> & {
+  triggerJson: string;
+};
 ```
 
-GitLab:
+Use `PlatformInteractionJobInput` for both the existing
+`createInteractionJob` return and the new local hook. The CLI, not the
+platform, supplies `tenantId`.
 
-- Comment input fetches MR notes/discussions, locates the note, builds a
-  synthetic note webhook payload, then reuses existing trigger
-  classification/job creation.
-- Text input fetches MR head SHA and creates a local manual-review job.
+Add the optional platform API:
 
-GitHub:
+```ts
+createLocalInteractionJob?(input: {
+  resolvedTenant: ResolvedTenant;
+  storage: StorageHelpers;
+  selector: LocalReviewSelector;
+  forceNew: boolean;
+  requestId: string;
+  createdAt: string;
+}): Promise<PlatformInteractionJobInput>;
+```
 
-- Comment input fetches issue comments, review comments, review threads, and
-  PR, locates the comment, builds a synthetic GitHub webhook payload, then
-  reuses existing trigger classification/job creation.
-- Text input fetches PR head SHA and creates a local manual-review job.
+The CLI reports a clear unsupported-platform error when this method is absent.
+Do not make it mandatory for existing custom providers.
 
-Unsupported custom platforms return a clear CLI error.
+### GitLab
 
-## Watch Output
+- Parse and validate canonical URLs against the connection base URL and the
+  tenant project returned by `getProject`.
+- Fetch the merge request, versions, notes, and discussions. Resolve the head
+  SHA from `diff_refs.head_sha`, falling back to the newest version by
+  `created_at`; fail if neither supplies a head. Locate the selected note across
+  both note collections and reject missing, system, or bot-authored notes
+  through the normal classifier.
+- For comment selectors, build the minimal valid `GitLabNoteHookPayload` from
+  the fetched project, merge request, note, and discussion context. Reuse
+  `classifyGitLabWebhookTrigger` and `createInteractionJob`; fail clearly when
+  the comment is not a recognized ReviewPhin trigger.
+- For text selectors, use the same current-head resolution and create the local
+  manual-review input directly.
 
-Add `src/cli/review-watch.ts`.
+### GitHub
 
-Watch mode:
+- Parse canonical URLs, then validate them against the configured repository
+  and the fetched pull request `html_url`.
+- Fetch the pull request, issue comments, review comments, and review threads.
+  Locate the comment id in issue or review comments and preserve the correct
+  `TriggerCommentReference`, including the review-comment root/thread id.
+- Build the minimal normalized `GitHubWebhookPayload` for the located comment.
+  Reuse `classifyWebhookTrigger` and `createInteractionJob`; fail clearly when
+  the comment is not a recognized ReviewPhin trigger.
+- For text selectors, use the pull request head SHA and create the local
+  manual-review input directly.
 
-- Polls the target job and related run rows.
-- Never calls claim, renewal, transition, or worker APIs.
-- Once a run exists, tails `RUN_LOG_DIR/<runId>/app.ndjson` when that path is
+Keep URL parsing in small exported helpers with focused tests. Do not add
+general platform URL discovery or accept arbitrary web URLs.
+
+## Watcher
+
+Add `src/cli/review-watch.ts`. It receives storage, job id, whether submission
+created or reused the job, run-log root, poll interval, output mode, and an
+`AbortSignal`; it has no runner or worker dependency. Share its
+attempt-selection and summary-building helper with the no-watch path.
+
+The watcher:
+
+- Reads the target job and related runs/findings only through entity-store
+  `get`/`list` operations.
+- Never calls claim, renewal, transition, expiration, or worker APIs.
+- Prints job status changes rather than every poll. While queued, state that it
+  is waiting for an external runner connected to the same storage backend.
+- Once a run is selected, tails `<run-log-root>/<runId>/app.ndjson` when
   locally accessible.
-- If the runner is remote or its log directory is not shared, continues with
-  persisted status and final results without treating missing logs as an error.
-- Prints parsed readable lines, not raw JSON.
-- Final summary includes job id, run id, status, run log directory, finding
-  count, error if any, and whether live logs were available.
-- If status is `expired`, final summary says the job exceeded the configured
-  maximum age while queued. It must not imply that no earlier attempt ran.
-
-`--json` outputs only a final structured summary and no queued-status or log-tail
-progress.
+- Parses complete NDJSON lines as
+  `{ timestamp, level, message, data? }` and prints timestamp, uppercase level,
+  message, and compact JSON data when present. Retain an incomplete final line
+  for the next read.
+- Treats missing or inaccessible live logs as unavailable, not as job failure.
+  Malformed complete lines produce a concise watcher warning and watching
+  continues.
+- Has no implicit timeout. A queued job only becomes `expired` when an external
+  runner applies the configured queue-age policy.
 
 Select the displayed attempt deterministically:
 
-- while the job is `in_progress`, prefer the run whose
-  `interactionJobClaimToken` matches the current `claimToken`;
-- while queued for retry, use `latestInteractionRunId` to show the previous
-  attempt until a new run starts;
-- for a terminal job, use `latestInteractionRunId` as the final attempt;
-- when `latestInteractionRunId` is null, report a null run id, zero findings,
-  and no run-log path.
+- While the job is `in_progress`, select the newest run for that job whose
+  `interactionJobClaimToken` equals the current job `claimToken`, ordered by
+  `startedAt` and then id descending.
+- While queued for retry, select `latestInteractionRunId` so the prior attempt
+  remains visible until the next claim creates a run.
+- For a terminal job, select `latestInteractionRunId`.
+- When no run is selected, report a null run id/status/path, zero findings, and
+  no live logs.
 
-After the job becomes terminal, wait until the selected run is also terminal
-before emitting the final summary. Expiration before the first run has no run to
-settle.
+After a job becomes terminal, wait for the selected run to become terminal
+before returning. Count findings whose `interactionRunId` is the selected run.
+Expiration before the first run has no run to settle. If the selected run
+disappears, fail with a storage-consistency error rather than silently choosing
+another run.
+
+The final summary shape is the same for human and JSON modes:
+
+```ts
+{
+  jobId: string,
+  created: boolean,
+  jobStatus: InteractionJobStatus,
+  runId: string | null,
+  runStatus: InteractionRunStatus | null,
+  runLogDirectory: string | null,
+  findingCount: number,
+  error: string | null,
+  liveLogsAvailable: boolean
+}
+```
+
+`--json` writes exactly one JSON summary to stdout and suppresses queued/status
+progress, live log lines, and human submission text. `--no-watch --json` uses
+the same shape based on the current persisted state without waiting; it reports
+`liveLogsAvailable: false` because it does not tail or probe the log. Whenever a
+run is selected, `runLogDirectory` is its absolute expected directory even if
+the log is unavailable. `liveLogsAvailable` becomes true after the watcher
+successfully opens `app.ndjson`. Set `error` from `job.lastError`, falling back
+to the selected run's error.
+
+## Signals and Exit Codes
+
+Install temporary `SIGINT` and `SIGTERM` handlers only while watching.
+
+- The first signal aborts polling through the watcher `AbortSignal`, waits for
+  it to stop, removes both handlers, lets `withStorage` close storage, and
+  returns `130` for `SIGINT` or `143` for `SIGTERM`.
+- It does not cancel or otherwise mutate the persisted job.
+- A second signal may terminate immediately.
+
+Return codes without a signal:
+
+- `0`: submission succeeded with `--no-watch`, or a watched job completed.
+- `1`: validation/platform/storage failure, or a watched job ended as
+  `failed`, `cancelled`, or `expired`.
+
+The existing CLI entry point prints command usage after any nonzero return.
+Suppress that automatic usage output for recognized `mr review` executions so
+operational failures and signal exits do not append help text; explicit
+`mr review --help` still prints usage. This is also required to keep JSON mode
+to one stdout object.
+
+In human mode, terminal failure output includes `lastError`. Expiration says
+the job exceeded the configured maximum queued age and must not imply that no
+earlier retry attempt ran.
 
 ## Docs
 
 Update:
 
-- `docs/src/content/docs/management/cli-reference.md`
-- `docs/src/content/docs/deployment/run-locally.md`
-- `docs/src/content/docs/development/review-flow.md`
-- `docs/src/content/docs/development/custom-platforms.md`
-- `docs/src/content/docs/deployment/environment-variables.md`
+- `docs/src/content/docs/management/cli-reference.md`: full command, selectors,
+  URL forms, dedupe, output, exit behavior, and external-runner requirement.
+- `docs/src/content/docs/deployment/run-locally.md`: show submitting a review
+  to the already-running local worker without exposing a webhook.
+- `docs/src/content/docs/development/review-flow.md`: include CLI-created jobs
+  as another persisted trigger source and explain local text trigger behavior.
+- `docs/src/content/docs/development/custom-platforms.md`: document the
+  optional local-job hook and the unsupported-provider behavior.
 
-Document `REVIEWPHIN_MAX_QUEUED_JOB_AGE_MS` with default `21600000` where the
-watch expiration behavior is described. Also document that:
+`REVIEWPHIN_MAX_QUEUED_JOB_AGE_MS` and its `21600000` default are already
+documented in the environment-variable and review-flow pages. Do not duplicate
+or rewrite that material unless implementation changes it.
 
-- a runner must already use the same storage backend;
-- leaving watch mode does not cancel the job;
-- live logs require a locally accessible or shared run-log directory;
-- final persisted status and findings remain available without live logs.
+Document that leaving watch mode does not cancel the job, live logs require a
+locally accessible/shared run-log directory, and persisted status/findings
+remain available when live logs are unavailable.
 
 ## Tests
 
-Add or update coverage for:
+Add or update focused coverage for:
 
-- CLI help and validation for `mr review`.
-- Expired target job makes CLI watch exit clearly.
-- CLI watch runs without HTTP server.
-- CLI submission and watch do not construct or invoke a job runner.
-- Watch mode observes an external runner moving the target through queued,
-  in-progress, and terminal states.
-- Interrupting watch leaves the persisted job queued or in progress.
-- signal handling aborts polling and closes storage before normal signal exit.
-- Missing or inaccessible run logs do not fail watch mode.
-- retries switch from the previous attempt to the current token-matching run.
-- terminal summaries use `latestInteractionRunId` and wait for that run to
-  settle.
-- `--json` emits only the final structured summary.
-- CLI can create GitLab/GitHub comment-triggered jobs.
-- CLI can create text-only local manual review jobs.
-- Local manual trigger reaches normal review planning and publication path.
-- Watcher parses `app.ndjson`.
+- CLI help, selector exclusivity, numeric/text validation, watch defaults, and
+  `--watch`/`--no-watch` conflict.
+- GitLab and GitHub canonical URL parsing plus tenant/repository and explicit
+  code-review-id mismatches.
+- Missing and unrecognized comment triggers produce clear errors.
+- Comment jobs use normal dedupe, `--force-new` creates a distinct job, and
+  text selectors are always fresh.
+- CLI submission/watch do not start an HTTP server or construct/invoke a job
+  runner.
+- GitLab/GitHub comment selectors create jobs that retain native trigger
+  lifecycle behavior.
+- Local text jobs use the no-op lifecycle, reach manual-review planning and
+  normal publication, and include their instruction in the review prompt.
+- Watch observes an external runner through queued, in-progress, retry, and
+  terminal states.
+- Attempt selection follows claim token while active and
+  `latestInteractionRunId` while queued/terminal.
+- Terminal output waits for the selected run, counts only its findings, and
+  handles expiration before the first run.
+- Missing/inaccessible logs and malformed NDJSON do not fail watch mode.
+- `--json` emits exactly one object in both watch and no-watch modes.
+- SIGINT/SIGTERM abort polling, close storage, preserve job state, remove
+  handlers, and return the specified code.
+- Failed, cancelled, and expired jobs return `1`; completed and no-watch
+  submissions return `0`.
 
 Verification:
 
@@ -224,12 +381,11 @@ pnpm typecheck
 pnpm docs:build
 ```
 
-## Assumptions
+## Scope Boundaries
 
-- CLI submission and watching never start an HTTP server or job runner.
-- An existing runner uses the same storage backend and processes the submitted
-  job.
-- A database backup is executable only when a runner is configured to use that
-  restored storage.
-- The storage-backed queue architecture exists or is implemented alongside this
-  command.
+- No HTTP server or in-process runner is started by this command.
+- No storage contract revision or adapter migration is required.
+- No runner-health probe, cancellation command, watch timeout, arbitrary URL
+  discovery, or custom-platform fallback is added.
+- The runner connected to the selected storage backend remains the only
+  component that claims, retries, expires, and executes jobs.

--- a/docs/src/content/docs/deployment/run-locally.md
+++ b/docs/src/content/docs/deployment/run-locally.md
@@ -71,7 +71,22 @@ pnpm cli platform connection add \
 
 Continue with [platform connections](../../management/platform-connections/) and [tenants](../../management/tenants/).
 
+## 6. Submit a review without a webhook
+
+With the local worker still running, submit a review through the same SQLite database:
+
+```bash
+pnpm cli mr review \
+  --key https://gitlab.example.com::123 \
+  --code-review-id 42 \
+  --trigger-text "Review the current changes."
+```
+
+The CLI persists the job and watches the already-running worker process it. It does not start another worker. Pressing `Ctrl+C` stops the watch but leaves the job queued or running.
+
+Live log lines appear when the CLI and worker can access the same `RUN_LOG_DIR`. Persisted status and findings remain available when they cannot. See [`mr review`](../../management/cli-reference/#mr-review) for comment selectors, JSON output, and storage overrides.
+
 ## Next steps
 
-- Local instances are not reachable by GitLab or GitHub yet. Expose the worker with a [tunnel](../exposing-webhooks/#tunnels-for-local-and-docker) before configuring webhooks.
+- To receive platform-triggered reviews, expose the worker with a [tunnel](../exposing-webhooks/#tunnels-for-local-and-docker) before configuring webhooks.
 - Previewing the GitHub setup screens without starting the App flow? `pnpm dev` logs a `/github/setup/samples` URL with sample data.

--- a/docs/src/content/docs/development/custom-platforms.md
+++ b/docs/src/content/docs/development/custom-platforms.md
@@ -26,6 +26,27 @@ A platform module must export a factory as `createPlatform(context)` or a defaul
 
 Platform slugs must be unique across all loaded modules. Startup fails if two providers return the same slug. Providers expose separate tenant and connection registration schemas, and runtime methods receive resolved tenant and connection context.
 
+## Local review submission
+
+`mr review` is optional for custom providers. Implement `createLocalInteractionJob` to support it:
+
+```ts
+createLocalInteractionJob(input: {
+  resolvedTenant: ResolvedTenant;
+  storage: StorageHelpers;
+  selector: LocalReviewSelector;
+  forceNew: boolean;
+  requestId: string;
+  createdAt: string;
+}): Promise<PlatformInteractionJobInput>;
+```
+
+The selector is one canonical comment URL, a comment ID plus code review ID, or local instruction text plus code review ID. The provider owns platform API access, tenant and URL verification, comment classification, head-SHA resolution, trigger construction, and canonical deduplication. For comment selectors, return the same trigger and dedupe identity as the equivalent webhook. For text selectors, include the request ID so each submission is fresh.
+
+The CLI adds the resolved tenant ID, persists the job, and synchronizes its queued lifecycle. Return a no-op lifecycle for provider-neutral local text triggers; keep native lifecycle behavior for reconstructed comments.
+
+Providers that omit this hook continue to load normally. `mr review` reports that local submission is unsupported for those providers.
+
 ## Setup routes
 
 If a provider implements `getSetupHandler()`, ReviewPhin mounts it at:

--- a/docs/src/content/docs/development/review-flow.md
+++ b/docs/src/content/docs/development/review-flow.md
@@ -6,10 +6,9 @@ description: From webhook to published review.
 ReviewPhin turns platform events into idempotent review work. The review worker uses three logical roles — Router, Reviewer, and Chatter — across the pipeline below.
 
 ```text
-Platform event
-  -> /webhooks/<platform>      Router: parse + validate signature
-  -> tenant resolution          map event to a configured tenant
-  -> trigger classification     review? follow-up? lifecycle? ignore?
+Platform event -> /webhooks/<platform> -> validate + classify
+CLI request    -> mr review             -> resolve + construct trigger
+  -> tenant resolution          map trigger to a configured tenant
   -> interaction job            deduplicated, persisted
   -> review worker              runner claims a leased job
   -> model harness              Reviewer (context-analyst -> review-author)
@@ -27,7 +26,9 @@ The tenant registry maps the platform event to a configured tenant.
 
 ## Interaction jobs and the runner
 
-Webhooks and other trigger sources write persisted interaction jobs; they never enqueue process-local work. The persisted queue is the source of truth.
+Webhooks, provider-owned actions, and `mr review` write persisted interaction jobs; they never enqueue process-local work. The persisted queue is the source of truth. The CLI uses the configured platform connection to verify a selected comment and preserves that platform's normal trigger lifecycle.
+
+A CLI text selector creates a local manual-review trigger instead of a synthetic comment. Its instruction is included in review scope and prompt context. It always requests review work, never requests a trigger-comment reply, and still publishes normal findings and a summary.
 
 Each enabled runner process polls for work, while storage permits only one active review:
 

--- a/docs/src/content/docs/management/cli-reference.md
+++ b/docs/src/content/docs/management/cli-reference.md
@@ -368,6 +368,69 @@ reviewphin storage migrate \
 
 ---
 
+## Review commands
+
+### `mr review`
+
+Submit a review to the persisted queue without exposing a webhook. A separate ReviewPhin runner connected to the same storage backend must already be running; this command never starts a server or review worker.
+
+```bash
+reviewphin mr review \
+  --key https://gitlab.example.com::123 \
+  --trigger-comment-url \
+    https://gitlab.example.com/group/project/-/merge_requests/42#note_9001
+```
+
+You can also submit a new instruction that is not attached to a platform comment:
+
+```bash
+reviewphin mr review \
+  --tenant-id tenant_01ABC \
+  --code-review-id 42 \
+  --trigger-text "Focus on authorization boundary regressions."
+```
+
+Exactly one tenant selector and one trigger selector are required.
+
+| Flag                        | Required  | Description                                                                                                 |
+| --------------------------- | --------- | ----------------------------------------------------------------------------------------------------------- |
+| `--tenant-id`               | Yes\*     | Internal tenant ID.                                                                                         |
+| `--key`                     | Yes\*     | Stable tenant key printed by `tenant list`.                                                                 |
+| `--trigger-comment-url`     | Yes\*\*   | Canonical GitLab merge request note or GitHub pull request comment URL.                                     |
+| `--trigger-comment-id`      | Yes\*\*   | Positive platform comment ID. Requires `--code-review-id`.                                                  |
+| `--trigger-text`            | Yes\*\*   | Review instruction. It is trimmed and must not be empty. Requires `--code-review-id`.                       |
+| `--trigger-text-file`       | Yes\*\*   | UTF-8 instruction file, resolved from the current directory. Requires `--code-review-id`.                   |
+| `--code-review-id`          | Sometimes | Positive merge request IID or pull request number. A comment URL supplies it; an explicit value must match. |
+| `--force-new`               | No        | Create a distinct job for a comment that would otherwise reuse its canonical job.                           |
+| `--watch`                   | No        | Watch persisted job and run state. This is the default.                                                     |
+| `--no-watch`                | No        | Return after persistence without waiting.                                                                   |
+| `--json`                    | No        | Write exactly one JSON summary to stdout.                                                                   |
+| `--sqlite-database-path`    | No        | Override the SQLite path.                                                                                   |
+| `--storage-provider-module` | No        | Override the storage adapter module.                                                                        |
+| `--run-log-dir`             | No        | Location where the watcher looks for live `app.ndjson` logs. Defaults to `RUN_LOG_DIR`.                     |
+
+\* Provide either `--tenant-id` or `--key`.
+
+\*\* Provide one of the four trigger selectors.
+
+Supported comment URLs are:
+
+```text
+https://<gitlab-host>/<project>/-/merge_requests/<iid>#note_<note-id>
+https://<github-host>/<owner>/<repo>/pull/<number>#issuecomment-<comment-id>
+https://<github-host>/<owner>/<repo>/pull/<number>#discussion_r<comment-id>
+```
+
+ReviewPhin verifies the URL against the resolved tenant and fetches the comment through that platform connection. Unsupported URL shapes should be submitted with `--trigger-comment-id` and `--code-review-id`.
+
+Comment submissions use the same deduplication identity as webhook submissions. Repeating one reuses the existing job, including a terminal job; `--force-new` derives a distinct identity. Text instructions always include a new local request ID and therefore always create a fresh job.
+
+Watch mode reports persisted status changes and follows the selected attempt through retries. It tails live logs only when the configured run-log directory is locally accessible or shared with the runner. Missing live logs do not affect persisted status or findings. Leaving watch mode with `SIGINT` or `SIGTERM` does not cancel the job.
+
+The final summary contains `jobId`, `created`, `jobStatus`, `runId`, `runStatus`, `runLogDirectory`, `findingCount`, `error`, and `liveLogsAvailable`. Exit code `0` means a no-watch submission succeeded or a watched job completed. Validation and operational errors, or watched jobs ending as failed, cancelled, or expired, return `1`; interrupted watches return `130` for `SIGINT` and `143` for `SIGTERM`.
+
+---
+
 ## Diagnostic commands
 
 ### `mr describe`

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-import { access, readdir, rm } from "node:fs/promises";
+import { access, readFile, readdir, rm } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { createInterface } from "node:readline/promises";
 import { pathToFileURL } from "node:url";
@@ -22,6 +22,7 @@ import {
 } from "./storage/runtime.js";
 import { listAll, type StorageHelpers } from "./storage/storage-helpers.js";
 import { createInteractionJobDedupeKey } from "./utils/ids.js";
+import { createId } from "./utils/ids.js";
 import { createLogger } from "./logger.js";
 import type {
   DiscussionMappingRecord,
@@ -39,8 +40,18 @@ import type {
 } from "./storage/contract/index.js";
 import {
   getPlatforms,
+  getPlatformBySlug,
   initializePlatformRegistry,
 } from "./platforms/platform-registry.js";
+import type { LocalReviewSelector } from "./platforms/IPlatform.js";
+import { syncPlatformTriggerLifecycle } from "./platforms/trigger-lifecycle.js";
+import { TenantRegistry } from "./tenants/tenant-registry.js";
+import {
+  buildReviewWatchSummary,
+  ReviewWatchAbortedError,
+  watchReviewJob,
+  type ReviewWatchSummary,
+} from "./cli/review-watch.js";
 import { getGitLabTenantConfig } from "./platforms/gitlab/tenant-config.js";
 
 interface ParsedCliArgs {
@@ -204,6 +215,68 @@ const mergeRequestDescribeSchema = z
         message:
           "Provide --trigger-comment-updated-at or --trigger-comment-body for update trigger dedupe checks.",
         path: ["triggerNoteUpdatedAt"],
+      });
+    }
+  });
+
+const mergeRequestReviewSchema = z
+  .object({
+    tenantId: z.string().min(1).optional(),
+    tenantKey: z.string().min(1).optional(),
+    triggerCommentUrl: z.string().min(1).optional(),
+    triggerCommentId: z.coerce.number().int().positive().optional(),
+    triggerText: z.string().trim().min(1).optional(),
+    triggerTextFile: z.string().min(1).optional(),
+    codeReviewId: z.coerce.number().int().positive().optional(),
+    forceNew: z.boolean(),
+    watchRequested: z.boolean(),
+    noWatchRequested: z.boolean(),
+    json: z.boolean(),
+  })
+  .superRefine((value, ctx) => {
+    if (
+      Number(value.tenantId !== undefined) +
+        Number(value.tenantKey !== undefined) !==
+      1
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Provide exactly one of --tenant-id or --key.",
+        path: ["tenantId"],
+      });
+    }
+    const triggerCount = [
+      value.triggerCommentUrl,
+      value.triggerCommentId,
+      value.triggerText,
+      value.triggerTextFile,
+    ].filter((entry) => entry !== undefined).length;
+    if (triggerCount !== 1) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "Provide exactly one trigger selector: --trigger-comment-url, --trigger-comment-id, --trigger-text, or --trigger-text-file.",
+        path: ["triggerCommentUrl"],
+      });
+    }
+    if (value.watchRequested && value.noWatchRequested) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Provide either --watch or --no-watch, not both.",
+        path: ["watchRequested"],
+      });
+    }
+    if (
+      (value.triggerCommentId !== undefined ||
+        value.triggerText !== undefined ||
+        value.triggerTextFile !== undefined) &&
+      value.codeReviewId === undefined
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "--trigger-comment-id, --trigger-text, and --trigger-text-file require --code-review-id.",
+        path: ["codeReviewId"],
       });
     }
   });
@@ -410,10 +483,13 @@ export async function runCli(
 ): Promise<number> {
   loadLocalEnvFile();
   const config = loadConfig();
-  const logger = createLogger(config.logLevel);
-
   const { positionals, options } = parseCliArgs(argv);
   const [resource, action, subAction] = positionals;
+  const logger = createLogger(
+    resource === "mr" && action === "review" && Object.hasOwn(options, "json")
+      ? "silent"
+      : config.logLevel,
+  );
 
   if (options.help === true || options.help === "true") {
     printHelp(positionals);
@@ -1074,6 +1150,10 @@ export async function runCli(
     return runCodeReviewDescribeCommand(options, config);
   }
 
+  if (resource === "mr" && action === "review") {
+    return runMergeRequestReviewCommand(options, config, logger);
+  }
+
   if (resource === "metrics" && action === "sessions") {
     const config = loadConfig();
     const runLogDir =
@@ -1275,6 +1355,7 @@ function printHelp(
     "model-profile clear-default [--sqlite-database-path <path>] [--storage-provider-module <module>]",
     "storage migrate --from-storage-provider-module <module> [--from-sqlite-database-path <path>] --to-storage-provider-module <module> [--to-sqlite-database-path <path>]",
     "mr describe (--tenant-id <id> | --key <key>) --code-review-id <id> [--current-interaction-job-id <id>] [--trigger-comment-id <id> --trigger-comment-action <create|update> [--trigger-comment-updated-at <iso>] [--trigger-comment-body <text>]] [--json] [--sqlite-database-path <path>] [--storage-provider-module <module>]",
+    "mr review (--tenant-id <id> | --key <tenant-key>) (--trigger-comment-url <url> | --trigger-comment-id <id> | --trigger-text <text> | --trigger-text-file <path>) [--code-review-id <id>] [--force-new] [--watch | --no-watch] [--json] [--sqlite-database-path <path>] [--storage-provider-module <module>] [--run-log-dir <path>]",
     "metrics sessions [--run-log-dir <path>]",
   );
 
@@ -1393,6 +1474,197 @@ async function runCodeReviewDescribeCommand(
     );
     return 0;
   });
+}
+
+async function runMergeRequestReviewCommand(
+  options: Record<string, string | boolean>,
+  config: ReturnType<typeof loadConfig>,
+  logger: ReturnType<typeof createLogger>,
+): Promise<number> {
+  const input = mergeRequestReviewSchema.parse({
+    tenantId: options["tenant-id"],
+    tenantKey: options.key,
+    triggerCommentUrl: options["trigger-comment-url"],
+    triggerCommentId: options["trigger-comment-id"],
+    triggerText: options["trigger-text"],
+    triggerTextFile: options["trigger-text-file"],
+    codeReviewId: options["code-review-id"],
+    forceNew: Object.hasOwn(options, "force-new"),
+    watchRequested: Object.hasOwn(options, "watch"),
+    noWatchRequested: Object.hasOwn(options, "no-watch"),
+    json: Object.hasOwn(options, "json"),
+  });
+  const selector = await resolveLocalReviewSelector(input);
+  await initializePlatformRegistry({
+    platformModules: config.platformModules,
+    env: process.env,
+    logger: logger.child({ component: "platform-registry" }),
+  });
+
+  return withStorage(options, config, async (storage) => {
+    const tenantRegistry = new TenantRegistry({ storage });
+    const resolvedTenant = input.tenantId
+      ? await tenantRegistry.getResolvedTenantById(input.tenantId)
+      : input.tenantKey
+        ? await tenantRegistry.getResolvedTenantByKey(input.tenantKey)
+        : null;
+    if (!resolvedTenant) {
+      throw new Error(
+        input.tenantId
+          ? `Tenant ${input.tenantId} was not found or its platform connection is not ready.`
+          : `Tenant ${input.tenantKey} was not found or its platform connection is not ready.`,
+      );
+    }
+    const platform = getPlatformBySlug(resolvedTenant.tenant.platform);
+    if (!platform) {
+      throw new Error(
+        `Platform ${resolvedTenant.tenant.platform} is not registered.`,
+      );
+    }
+    if (!platform.createLocalInteractionJob) {
+      throw new Error(
+        `Platform ${resolvedTenant.tenant.platform} does not support local review submission.`,
+      );
+    }
+
+    const requestId = createId("local-review");
+    const interactionJob = await platform.createLocalInteractionJob({
+      resolvedTenant,
+      storage,
+      selector,
+      forceNew: input.forceNew,
+      requestId,
+      createdAt: new Date().toISOString(),
+    });
+    const submitted = await storage.createOrGetInteractionJob({
+      ...interactionJob,
+      tenantId: resolvedTenant.tenant.id,
+    });
+    if (submitted.created) {
+      const lifecycle = platform.createTriggerLifecycle({
+        resolvedTenant,
+        job: submitted.job,
+        logger,
+      });
+      await syncPlatformTriggerLifecycle({
+        logger,
+        job: submitted.job,
+        phase: "queued",
+        update: () => lifecycle.queued(),
+      });
+    }
+
+    if (!input.json) {
+      process.stdout.write(
+        `Interaction job ${submitted.job.id} ${
+          submitted.created ? "created" : "reused"
+        }.\n`,
+      );
+    }
+    const runLogRoot =
+      typeof options["run-log-dir"] === "string"
+        ? resolve(options["run-log-dir"])
+        : config.runLogDir;
+    if (input.noWatchRequested) {
+      const summary = await buildReviewWatchSummary({
+        storage,
+        jobId: submitted.job.id,
+        created: submitted.created,
+        runLogRoot,
+      });
+      printReviewSubmissionSummary(summary, input.json);
+      return 0;
+    }
+
+    const controller = new AbortController();
+    let signalExitCode: 130 | 143 | null = null;
+    const handleSigint = () => {
+      signalExitCode ??= 130;
+      controller.abort();
+    };
+    const handleSigterm = () => {
+      signalExitCode ??= 143;
+      controller.abort();
+    };
+    process.on("SIGINT", handleSigint);
+    process.on("SIGTERM", handleSigterm);
+    try {
+      const summary = await watchReviewJob({
+        storage,
+        jobId: submitted.job.id,
+        created: submitted.created,
+        runLogRoot,
+        pollIntervalMs: config.jobPollIntervalMs,
+        outputMode: input.json ? "json" : "human",
+        signal: controller.signal,
+      });
+      return summary.jobStatus === "completed" ? 0 : 1;
+    } catch (error) {
+      if (error instanceof ReviewWatchAbortedError && signalExitCode) {
+        return signalExitCode;
+      }
+      throw error;
+    } finally {
+      process.removeListener("SIGINT", handleSigint);
+      process.removeListener("SIGTERM", handleSigterm);
+    }
+  });
+}
+
+async function resolveLocalReviewSelector(
+  input: z.infer<typeof mergeRequestReviewSchema>,
+): Promise<LocalReviewSelector> {
+  if (input.triggerCommentUrl !== undefined) {
+    return {
+      kind: "comment-url",
+      url: input.triggerCommentUrl,
+      ...(input.codeReviewId !== undefined
+        ? { codeReviewId: input.codeReviewId }
+        : {}),
+    };
+  }
+  if (input.triggerCommentId !== undefined && input.codeReviewId !== undefined) {
+    return {
+      kind: "comment-id",
+      commentId: input.triggerCommentId,
+      codeReviewId: input.codeReviewId,
+    };
+  }
+  let text = input.triggerText;
+  if (input.triggerTextFile !== undefined) {
+    text = (
+      await readFile(resolve(process.cwd(), input.triggerTextFile), "utf8")
+    ).trim();
+  }
+  if (!text || text.trim().length === 0 || input.codeReviewId === undefined) {
+    throw new Error("The selected review instruction must not be empty.");
+  }
+  return {
+    kind: "text",
+    text: text.trim(),
+    codeReviewId: input.codeReviewId,
+  };
+}
+
+function printReviewSubmissionSummary(
+  summary: ReviewWatchSummary,
+  json: boolean,
+): void {
+  if (json) {
+    process.stdout.write(`${JSON.stringify(summary)}\n`);
+    return;
+  }
+  process.stdout.write(
+    [
+      `jobStatus: ${summary.jobStatus}`,
+      `runId: ${summary.runId ?? "(none)"}`,
+      `runStatus: ${summary.runStatus ?? "(none)"}`,
+      `runLogDirectory: ${summary.runLogDirectory ?? "(none)"}`,
+      `findingCount: ${summary.findingCount}`,
+      `error: ${summary.error ?? "(none)"}`,
+      `liveLogsAvailable: ${summary.liveLogsAvailable}`,
+    ].join("\n") + "\n",
+  );
 }
 
 async function resolveDescribeTenant(
@@ -2823,17 +3095,24 @@ export async function runCliEntry(
 ): Promise<number> {
   try {
     const exitCode = await runCli(argv);
-    if (exitCode !== 0) {
+    if (exitCode !== 0 && !isMergeRequestReviewInvocation(argv)) {
       const { positionals } = parseCliArgs(argv);
       printHelp(positionals, false);
     }
     return exitCode;
   } catch (error: unknown) {
     const { positionals } = parseCliArgs(argv);
-    printHelp(positionals, false);
+    if (!isMergeRequestReviewInvocation(argv)) {
+      printHelp(positionals, false);
+    }
     const message = error instanceof Error ? error.message : String(error);
     process.stderr.write(`${message}\n`);
     return 1;
+  }
+
+  function isMergeRequestReviewInvocation(argv: string[]): boolean {
+    const { positionals } = parseCliArgs(argv);
+    return positionals[0] === "mr" && positionals[1] === "review";
   }
 }
 

--- a/src/cli/review-watch.ts
+++ b/src/cli/review-watch.ts
@@ -96,7 +96,7 @@ export async function watchReviewJob(input: {
   let previousJobStatus: InteractionJobStatus | null = null;
   let previousRunStatus: InteractionRunStatus | null = null;
   let previousRunId: string | null = null;
-  let tail = createLogTailState(null);
+  let tail = createLogTailState();
 
   for (;;) {
     throwIfAborted(input.signal);
@@ -111,7 +111,7 @@ export async function watchReviewJob(input: {
     if (state.run?.id !== previousRunId) {
       previousRunId = state.run?.id ?? null;
       previousRunStatus = null;
-      tail = createLogTailState(previousRunId);
+      tail = createLogTailState();
     }
     if (
       input.outputMode === "human" &&
@@ -202,16 +202,14 @@ async function summarizeReviewWatchState(input: {
 }
 
 interface LogTailState {
-  runId: string | null;
   byteOffset: number;
   bufferedText: string;
   decoder: StringDecoder;
   liveLogsAvailable: boolean;
 }
 
-function createLogTailState(runId: string | null): LogTailState {
+function createLogTailState(): LogTailState {
   return {
-    runId,
     byteOffset: 0,
     bufferedText: "",
     decoder: new StringDecoder("utf8"),

--- a/src/cli/review-watch.ts
+++ b/src/cli/review-watch.ts
@@ -1,0 +1,378 @@
+import { readFile } from "node:fs/promises";
+import { isAbsolute, join, resolve } from "node:path";
+import { StringDecoder } from "node:string_decoder";
+
+import type {
+  InteractionJobRecord,
+  InteractionJobStatus,
+  InteractionRunRecord,
+  InteractionRunStatus,
+} from "../storage/contract/index.js";
+import { listAll, type StorageHelpers } from "../storage/storage-helpers.js";
+
+const TERMINAL_JOB_STATUSES = new Set<InteractionJobStatus>([
+  "completed",
+  "failed",
+  "cancelled",
+  "expired",
+]);
+const TERMINAL_RUN_STATUSES = new Set<InteractionRunStatus>([
+  "completed",
+  "failed",
+  "cancelled",
+]);
+
+export interface ReviewWatchSummary {
+  jobId: string;
+  created: boolean;
+  jobStatus: InteractionJobStatus;
+  runId: string | null;
+  runStatus: InteractionRunStatus | null;
+  runLogDirectory: string | null;
+  findingCount: number;
+  error: string | null;
+  liveLogsAvailable: boolean;
+}
+
+export class ReviewWatchAbortedError extends Error {
+  public constructor() {
+    super("Review watch aborted.");
+    this.name = "ReviewWatchAbortedError";
+  }
+}
+
+export function selectReviewAttempt(
+  job: InteractionJobRecord,
+  runs: readonly InteractionRunRecord[],
+): InteractionRunRecord | null {
+  if (job.status === "in_progress") {
+    if (!job.claimToken) {
+      return null;
+    }
+    return (
+      runs
+        .filter((run) => run.interactionJobClaimToken === job.claimToken)
+        .sort(compareRunsNewestFirst)[0] ?? null
+    );
+  }
+
+  if (!job.latestInteractionRunId) {
+    return null;
+  }
+  const selected =
+    runs.find((run) => run.id === job.latestInteractionRunId) ?? null;
+  if (!selected) {
+    throw new Error(
+      `Storage consistency error: interaction job ${job.id} references missing run ${job.latestInteractionRunId}.`,
+    );
+  }
+  return selected;
+}
+
+export async function buildReviewWatchSummary(input: {
+  storage: StorageHelpers;
+  jobId: string;
+  created: boolean;
+  runLogRoot: string;
+  liveLogsAvailable?: boolean | undefined;
+}): Promise<ReviewWatchSummary> {
+  const state = await loadReviewWatchState(input.storage, input.jobId);
+  return summarizeReviewWatchState({
+    ...input,
+    ...state,
+    liveLogsAvailable: input.liveLogsAvailable ?? false,
+  });
+}
+
+export async function watchReviewJob(input: {
+  storage: StorageHelpers;
+  jobId: string;
+  created: boolean;
+  runLogRoot: string;
+  pollIntervalMs: number;
+  outputMode: "human" | "json";
+  signal: AbortSignal;
+}): Promise<ReviewWatchSummary> {
+  let previousJobStatus: InteractionJobStatus | null = null;
+  let previousRunStatus: InteractionRunStatus | null = null;
+  let previousRunId: string | null = null;
+  let tail = createLogTailState(null);
+
+  for (;;) {
+    throwIfAborted(input.signal);
+    const state = await loadReviewWatchState(input.storage, input.jobId);
+    if (
+      input.outputMode === "human" &&
+      state.job.status !== previousJobStatus
+    ) {
+      printJobStatus(state.job);
+      previousJobStatus = state.job.status;
+    }
+    if (state.run?.id !== previousRunId) {
+      previousRunId = state.run?.id ?? null;
+      previousRunStatus = null;
+      tail = createLogTailState(previousRunId);
+    }
+    if (
+      input.outputMode === "human" &&
+      state.run &&
+      state.run.status !== previousRunStatus
+    ) {
+      process.stdout.write(`Run ${state.run.id}: ${state.run.status}\n`);
+      previousRunStatus = state.run.status;
+    }
+    if (state.run) {
+      await tailRunLog({
+        tail,
+        path: join(resolve(input.runLogRoot), state.run.id, "app.ndjson"),
+        outputMode: input.outputMode,
+      });
+    }
+
+    const jobTerminal = TERMINAL_JOB_STATUSES.has(state.job.status);
+    const runSettled =
+      state.run === null || TERMINAL_RUN_STATUSES.has(state.run.status);
+    if (jobTerminal && runSettled) {
+      const summary = await summarizeReviewWatchState({
+        storage: input.storage,
+        jobId: input.jobId,
+        created: input.created,
+        runLogRoot: input.runLogRoot,
+        job: state.job,
+        run: state.run,
+        liveLogsAvailable: tail.liveLogsAvailable,
+      });
+      printFinalSummary(summary, input.outputMode);
+      return summary;
+    }
+
+    await waitForNextPoll(input.pollIntervalMs, input.signal);
+  }
+}
+
+async function loadReviewWatchState(
+  storage: StorageHelpers,
+  jobId: string,
+): Promise<{
+  job: InteractionJobRecord;
+  run: InteractionRunRecord | null;
+}> {
+  const job = await storage.stores.interactionJobs.get(jobId);
+  if (!job) {
+    throw new Error(`Interaction job ${jobId} was not found in storage.`);
+  }
+  const runs = await listAll(storage.stores.interactionRuns, {
+    filters: { interactionJobId: { eq: jobId } },
+    order: [
+      { field: "startedAt", direction: "desc" },
+      { field: "id", direction: "desc" },
+    ],
+  });
+  return { job, run: selectReviewAttempt(job, runs) };
+}
+
+async function summarizeReviewWatchState(input: {
+  storage: StorageHelpers;
+  jobId: string;
+  created: boolean;
+  runLogRoot: string;
+  job: InteractionJobRecord;
+  run: InteractionRunRecord | null;
+  liveLogsAvailable: boolean;
+}): Promise<ReviewWatchSummary> {
+  const findings = input.run
+    ? await listAll(input.storage.stores.reviewFindings, {
+        filters: { interactionRunId: { eq: input.run.id } },
+      })
+    : [];
+  const runLogDirectory = input.run
+    ? resolveRunLogDirectory(input.runLogRoot, input.run.id)
+    : null;
+  return {
+    jobId: input.jobId,
+    created: input.created,
+    jobStatus: input.job.status,
+    runId: input.run?.id ?? null,
+    runStatus: input.run?.status ?? null,
+    runLogDirectory,
+    findingCount: findings.length,
+    error: input.job.lastError ?? input.run?.error ?? null,
+    liveLogsAvailable: input.liveLogsAvailable,
+  };
+}
+
+interface LogTailState {
+  runId: string | null;
+  byteOffset: number;
+  bufferedText: string;
+  decoder: StringDecoder;
+  liveLogsAvailable: boolean;
+}
+
+function createLogTailState(runId: string | null): LogTailState {
+  return {
+    runId,
+    byteOffset: 0,
+    bufferedText: "",
+    decoder: new StringDecoder("utf8"),
+    liveLogsAvailable: false,
+  };
+}
+
+async function tailRunLog(input: {
+  tail: LogTailState;
+  path: string;
+  outputMode: "human" | "json";
+}): Promise<void> {
+  let content: Buffer;
+  try {
+    content = await readFile(input.path);
+    input.tail.liveLogsAvailable = true;
+  } catch (error) {
+    if (isUnavailableLogError(error)) {
+      return;
+    }
+    throw error;
+  }
+  if (content.length < input.tail.byteOffset) {
+    input.tail.byteOffset = 0;
+    input.tail.bufferedText = "";
+    input.tail.decoder = new StringDecoder("utf8");
+  }
+  if (content.length === input.tail.byteOffset) {
+    return;
+  }
+
+  const chunk = content.subarray(input.tail.byteOffset);
+  input.tail.byteOffset = content.length;
+  input.tail.bufferedText += input.tail.decoder.write(chunk);
+  const lines = input.tail.bufferedText.split(/\r?\n/);
+  input.tail.bufferedText = lines.pop() ?? "";
+  for (const line of lines) {
+    if (line.trim().length === 0) {
+      continue;
+    }
+    try {
+      const entry = parseLogEntry(line);
+      if (input.outputMode === "human") {
+        const data =
+          entry.data === undefined ? "" : ` ${JSON.stringify(entry.data)}`;
+        process.stdout.write(
+          `${entry.timestamp} ${entry.level.toUpperCase()} ${entry.message}${data}\n`,
+        );
+      }
+    } catch {
+      process.stderr.write(
+        `Warning: skipped malformed live log line from ${input.path}.\n`,
+      );
+    }
+  }
+}
+
+function parseLogEntry(line: string): {
+  timestamp: string;
+  level: string;
+  message: string;
+  data?: unknown;
+} {
+  const value: unknown = JSON.parse(line);
+  if (
+    !value ||
+    typeof value !== "object" ||
+    !("timestamp" in value) ||
+    typeof value.timestamp !== "string" ||
+    !("level" in value) ||
+    typeof value.level !== "string" ||
+    !("message" in value) ||
+    typeof value.message !== "string"
+  ) {
+    throw new Error("Invalid live log entry.");
+  }
+  return {
+    timestamp: value.timestamp,
+    level: value.level,
+    message: value.message,
+    ...("data" in value ? { data: value.data } : {}),
+  };
+}
+
+function printJobStatus(job: InteractionJobRecord): void {
+  if (job.status === "queued") {
+    process.stdout.write(
+      `Job ${job.id}: queued; waiting for an external runner connected to the same storage backend.\n`,
+    );
+    return;
+  }
+  process.stdout.write(`Job ${job.id}: ${job.status}\n`);
+}
+
+function printFinalSummary(
+  summary: ReviewWatchSummary,
+  outputMode: "human" | "json",
+): void {
+  if (outputMode === "json") {
+    process.stdout.write(`${JSON.stringify(summary)}\n`);
+    return;
+  }
+  process.stdout.write(
+    `Review ${summary.jobStatus}: ${summary.findingCount} finding(s)${
+      summary.runId ? ` in run ${summary.runId}` : ""
+    }.\n`,
+  );
+  if (summary.error) {
+    process.stdout.write(`Error: ${summary.error}\n`);
+  }
+  if (summary.jobStatus === "expired") {
+    process.stdout.write(
+      "The job exceeded the configured maximum queued age.\n",
+    );
+  }
+}
+
+function resolveRunLogDirectory(runLogRoot: string, runId: string): string {
+  const root = isAbsolute(runLogRoot) ? runLogRoot : resolve(runLogRoot);
+  return resolve(root, runId);
+}
+
+function compareRunsNewestFirst(
+  left: InteractionRunRecord,
+  right: InteractionRunRecord,
+): number {
+  return (
+    right.startedAt.localeCompare(left.startedAt) ||
+    right.id.localeCompare(left.id)
+  );
+}
+
+function waitForNextPoll(
+  pollIntervalMs: number,
+  signal: AbortSignal,
+): Promise<void> {
+  throwIfAborted(signal);
+  return new Promise((resolvePromise, reject) => {
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolvePromise();
+    }, pollIntervalMs);
+    const onAbort = () => {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+      reject(new ReviewWatchAbortedError());
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+function throwIfAborted(signal: AbortSignal): void {
+  if (signal.aborted) {
+    throw new ReviewWatchAbortedError();
+  }
+}
+
+function isUnavailableLogError(error: unknown): error is NodeJS.ErrnoException {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    ["ENOENT", "EACCES", "EPERM", "EISDIR"].includes(String(error.code))
+  );
+}

--- a/src/cli/review-watch.ts
+++ b/src/cli/review-watch.ts
@@ -1,4 +1,4 @@
-import { readFile } from "node:fs/promises";
+import { open } from "node:fs/promises";
 import { isAbsolute, join, resolve } from "node:path";
 import { StringDecoder } from "node:string_decoder";
 
@@ -224,9 +224,9 @@ async function tailRunLog(input: {
   path: string;
   outputMode: "human" | "json";
 }): Promise<void> {
-  let content: Buffer;
+  let file;
   try {
-    content = await readFile(input.path);
+    file = await open(input.path, "r");
     input.tail.liveLogsAvailable = true;
   } catch (error) {
     if (isUnavailableLogError(error)) {
@@ -234,17 +234,42 @@ async function tailRunLog(input: {
     }
     throw error;
   }
-  if (content.length < input.tail.byteOffset) {
-    input.tail.byteOffset = 0;
-    input.tail.bufferedText = "";
-    input.tail.decoder = new StringDecoder("utf8");
-  }
-  if (content.length === input.tail.byteOffset) {
-    return;
+
+  let chunk: Buffer;
+  try {
+    const { size } = await file.stat();
+    if (size < input.tail.byteOffset) {
+      input.tail.byteOffset = 0;
+      input.tail.bufferedText = "";
+      input.tail.decoder = new StringDecoder("utf8");
+    }
+    if (size === input.tail.byteOffset) {
+      return;
+    }
+
+    chunk = Buffer.allocUnsafe(size - input.tail.byteOffset);
+    let totalBytesRead = 0;
+    while (totalBytesRead < chunk.length) {
+      const { bytesRead } = await file.read(
+        chunk,
+        totalBytesRead,
+        chunk.length - totalBytesRead,
+        input.tail.byteOffset + totalBytesRead,
+      );
+      if (bytesRead === 0) {
+        break;
+      }
+      totalBytesRead += bytesRead;
+    }
+    chunk = chunk.subarray(0, totalBytesRead);
+    input.tail.byteOffset += totalBytesRead;
+  } finally {
+    await file.close();
   }
 
-  const chunk = content.subarray(input.tail.byteOffset);
-  input.tail.byteOffset = content.length;
+  if (chunk.length === 0) {
+    return;
+  }
   input.tail.bufferedText += input.tail.decoder.write(chunk);
   const lines = input.tail.bufferedText.split(/\r?\n/);
   input.tail.bufferedText = lines.pop() ?? "";

--- a/src/jobs/review-worker.ts
+++ b/src/jobs/review-worker.ts
@@ -9,6 +9,7 @@ import type {
   ResolvedTenant,
 } from "../platforms/IPlatform.js";
 import { getPlatformBySlug } from "../platforms/platform-registry.js";
+import { syncPlatformTriggerLifecycle } from "../platforms/trigger-lifecycle.js";
 import type {
   DiscussionReconciler,
   ReconcileSummary,
@@ -155,9 +156,12 @@ export class ReviewWorker {
         job: createdJob.job,
         logger: this.logger,
       });
-      await this.syncTriggerLifecycle(createdJob.job, "queued", () =>
-        lifecycle.queued(),
-      );
+      await syncPlatformTriggerLifecycle({
+        logger: this.logger,
+        job: createdJob.job,
+        phase: "queued",
+        update: () => lifecycle.queued(),
+      });
     }
 
     return createdJob;
@@ -257,9 +261,12 @@ export class ReviewWorker {
     });
 
     context.assertOwned();
-    await this.syncTriggerLifecycle(job, "in_progress", () =>
-      triggerLifecycle.inProgress(),
-    );
+    await syncPlatformTriggerLifecycle({
+      logger: this.logger,
+      job,
+      phase: "in_progress",
+      update: () => triggerLifecycle.inProgress(),
+    });
     context.assertOwned();
 
     let interactionRunId: string | null = null;
@@ -799,14 +806,18 @@ export class ReviewWorker {
       if (!this.claimIsOwned(context, job, "completed", interactionRunId)) {
         return;
       }
-      await this.syncTriggerLifecycle(job, "completed", () =>
-        triggerLifecycle.completed(
+      await syncPlatformTriggerLifecycle({
+        logger: this.logger,
+        job,
+        phase: "completed",
+        update: () =>
+          triggerLifecycle.completed(
           runRuntime.buildTriggerOutcome({
             reviewResult,
             reconcileSummary,
           }),
-        ),
-      );
+          ),
+      });
       if (!this.claimIsOwned(context, job, "completed", interactionRunId)) {
         return;
       }
@@ -936,11 +947,15 @@ export class ReviewWorker {
       if (!this.claimIsOwned(context, job, phase, interactionRunId)) {
         return;
       }
-      await this.syncTriggerLifecycle(job, phase, () =>
-        phase === "retry"
-          ? triggerLifecycle.retry(errorMessage)
-          : triggerLifecycle.failed(errorMessage),
-      );
+      await syncPlatformTriggerLifecycle({
+        logger: this.logger,
+        job,
+        phase,
+        update: () =>
+          phase === "retry"
+            ? triggerLifecycle.retry(errorMessage)
+            : triggerLifecycle.failed(errorMessage),
+      });
 
       if (!this.claimIsOwned(context, job, phase, interactionRunId)) {
         return;
@@ -1157,24 +1172,6 @@ export class ReviewWorker {
     });
   }
 
-  private async syncTriggerLifecycle(
-    job: InteractionJobRecord,
-    phase: string,
-    update: () => Promise<void>,
-  ): Promise<void> {
-    try {
-      await update();
-    } catch (error) {
-      this.logger.warn(
-        {
-          err: error,
-          interactionJobId: job.id,
-          triggerLifecyclePhase: phase,
-        },
-        "failed to synchronize provider trigger lifecycle",
-      );
-    }
-  }
 }
 
 function getErrorMessage(error: unknown): string {

--- a/src/platforms/IPlatform.ts
+++ b/src/platforms/IPlatform.ts
@@ -21,6 +21,7 @@ import type {
   WebhookReviewTrigger,
 } from "../review/types.js";
 import type {
+  CreateInteractionJobInput,
   DiscussionMappingRecord,
   InteractionJobRecord,
   PlatformConnectionRecord,
@@ -43,6 +44,18 @@ export interface ResolvedTenant {
   tenant: TenantRecord;
   connection: PlatformConnectionRecord;
 }
+
+export type LocalReviewSelector =
+  | { kind: "comment-url"; url: string; codeReviewId?: number | undefined }
+  | { kind: "comment-id"; commentId: number; codeReviewId: number }
+  | { kind: "text"; text: string; codeReviewId: number };
+
+export type PlatformInteractionJobInput = Omit<
+  CreateInteractionJobInput,
+  "tenantId" | "triggerJson"
+> & {
+  triggerJson: string;
+};
 
 export interface PlatformSetupContext {
   pathSuffix: string;
@@ -217,14 +230,15 @@ export interface IPlatform {
     payload: unknown;
     trigger: WebhookReviewTrigger;
     storage: StorageHelpers;
-  }): Promise<{
-    dedupeKey: string;
-    codeReviewId: number;
-    commentId: number | null;
-    triggerJson: string;
-    headSha: string;
-    payloadJson: string;
-  }>;
+  }): Promise<PlatformInteractionJobInput>;
+  createLocalInteractionJob?(input: {
+    resolvedTenant: ResolvedTenant;
+    storage: StorageHelpers;
+    selector: LocalReviewSelector;
+    forceNew: boolean;
+    requestId: string;
+    createdAt: string;
+  }): Promise<PlatformInteractionJobInput>;
   createTriggerLifecycle(input: {
     resolvedTenant: ResolvedTenant;
     job: InteractionJobRecord;

--- a/src/platforms/github/platform.ts
+++ b/src/platforms/github/platform.ts
@@ -7,6 +7,8 @@ import { z } from "zod";
 import type { HarnessRunLoggingContext } from "../../harness/types.js";
 import type {
   IPlatform,
+  LocalReviewSelector,
+  PlatformInteractionJobInput,
   PlatformSetupHandler,
   PlatformWebhookRequest,
   ResolvedTenant,
@@ -19,6 +21,11 @@ import type {
 } from "../../storage/contract/current.js";
 import type { StorageHelpers } from "../../storage/storage-helpers.js";
 import type { WebhookReviewTrigger } from "../../review/types.js";
+import type { TriggerCommentReference } from "../../review/types.js";
+import {
+  isLocalReviewTrigger,
+  serializeLocalReviewTrigger,
+} from "../../review/local-trigger.js";
 import { listAll } from "../../storage/storage-helpers.js";
 import {
   githubConnectionRegistrationSchema,
@@ -33,6 +40,10 @@ import {
   GitHubClient,
   type GitHubAppApi,
   type GitHubAppFactoryConfig,
+  type GitHubIssueComment,
+  type GitHubPullRequest,
+  type GitHubReviewComment,
+  type GitHubReviewThread,
 } from "./client.js";
 import {
   renderGitHubSetupErrorPage,
@@ -48,6 +59,7 @@ import {
 } from "./tenant-config.js";
 import { createTenantKey } from "../../utils/ids.js";
 import { sha256 } from "../../utils/hash.js";
+import { NoOpPlatformTriggerLifecycle } from "../trigger-lifecycle.js";
 import {
   getGitHubSignatureHeader,
   isGitHubWebhookPayload,
@@ -69,6 +81,10 @@ import {
   extractGitHubReviewCommand,
   githubCommentTriggerSchema,
 } from "./comment-trigger.js";
+import {
+  parseGitHubCommentUrl,
+  type GitHubCommentUrl,
+} from "./url.js";
 
 const ONE_HOUR_MS = 60 * 60 * 1000;
 
@@ -646,7 +662,7 @@ export default class GitHubPlatform implements IPlatform {
     payload: unknown;
     trigger: WebhookReviewTrigger;
     storage: StorageHelpers;
-  }) {
+  }): Promise<PlatformInteractionJobInput> {
     if (!isGitHubWebhookPayload(input.payload)) {
       throw new Error("GitHub interaction jobs require a GitHub webhook");
     }
@@ -745,11 +761,152 @@ export default class GitHubPlatform implements IPlatform {
     };
   }
 
+  public async createLocalInteractionJob(input: {
+    resolvedTenant: ResolvedTenant;
+    storage: StorageHelpers;
+    selector: LocalReviewSelector;
+    forceNew: boolean;
+    requestId: string;
+    createdAt: string;
+  }): Promise<PlatformInteractionJobInput> {
+    const connectionConfig = readyGitHubConnectionConfigSchema.parse(
+      JSON.parse(
+        input.resolvedTenant.connection.platformConnectionConfigJson,
+      ) as unknown,
+    );
+    const tenantConfig = getGitHubTenantConfig(input.resolvedTenant.tenant);
+    const client = this.createClient(connectionConfig);
+    let urlSelection: GitHubCommentUrl | null = null;
+    let codeReviewId: number;
+    if (input.selector.kind === "comment-url") {
+      urlSelection = parseGitHubCommentUrl(input.selector.url);
+      codeReviewId = urlSelection.codeReviewId;
+    } else {
+      codeReviewId = input.selector.codeReviewId;
+    }
+    if (
+      input.selector.kind === "comment-url" &&
+      input.selector.codeReviewId !== undefined &&
+      input.selector.codeReviewId !== codeReviewId
+    ) {
+      throw new Error(
+        `--code-review-id ${input.selector.codeReviewId} does not match GitHub comment URL pull request ${codeReviewId}.`,
+      );
+    }
+
+    const pullRequest = await client.getPullRequest(
+      tenantConfig.repositoryFullName,
+      codeReviewId,
+    );
+    validateGitHubLocalSelection({
+      tenantRepository: tenantConfig.repositoryFullName,
+      pullRequest,
+      codeReviewId,
+      urlSelection,
+    });
+
+    if (input.selector.kind === "text") {
+      const triggerJson = serializeLocalReviewTrigger({
+        kind: "reviewphin-local-review",
+        source: "cli",
+        requestId: input.requestId,
+        codeReviewId,
+        instruction: input.selector.text,
+        createdAt: input.createdAt,
+      });
+      return {
+        dedupeKey: sha256(
+          [
+            "reviewphin-local-review",
+            input.resolvedTenant.tenant.id,
+            codeReviewId,
+            input.requestId,
+          ].join("::"),
+        ),
+        codeReviewId,
+        commentId: null,
+        triggerJson,
+        headSha: pullRequest.head.sha,
+        payloadJson: triggerJson,
+      };
+    }
+
+    let commentId: number;
+    if (input.selector.kind === "comment-id") {
+      commentId = input.selector.commentId;
+    } else {
+      if (!urlSelection) {
+        throw new Error("GitHub comment URL selection was not resolved.");
+      }
+      commentId = urlSelection.commentId;
+    }
+    const [issueComments, reviewComments, reviewThreads] = await Promise.all([
+      client.listIssueComments(tenantConfig.repositoryFullName, codeReviewId),
+      client.listReviewComments(tenantConfig.repositoryFullName, codeReviewId),
+      client.listReviewThreads(tenantConfig.repositoryFullName, codeReviewId),
+    ]);
+    const located = locateGitHubLocalComment({
+      commentId,
+      issueComments,
+      reviewComments,
+      reviewThreads,
+      expectedKind: urlSelection?.kind,
+    });
+    if (!located) {
+      throw new Error(
+        `GitHub comment ${commentId} was not found on pull request ${codeReviewId}.`,
+      );
+    }
+    if (urlSelection && located.comment.html_url !== urlSelection.url) {
+      throw new Error(
+        "GitHub comment URL does not match the selected comment in the resolved tenant repository.",
+      );
+    }
+    const payload = buildLocalGitHubCommentPayload({
+      requestId: input.requestId,
+      connectionInstallationId: connectionConfig.installationId,
+      repositoryId: tenantConfig.repositoryId,
+      repositoryFullName: tenantConfig.repositoryFullName,
+      pullRequest,
+      located,
+    });
+    const trigger = await this.classifyWebhookTrigger(
+      input.resolvedTenant,
+      payload,
+    );
+    if (!trigger || trigger.kind === "check-run-requested-action") {
+      throw new Error(
+        `GitHub comment ${commentId} is not a recognized ReviewPhin review trigger.`,
+      );
+    }
+    const nativeTrigger: WebhookReviewTrigger = {
+      ...trigger,
+      comment: located.reference,
+    };
+    const interactionJob = await this.createInteractionJob({
+      resolvedTenant: input.resolvedTenant,
+      payload,
+      trigger: nativeTrigger,
+      storage: input.storage,
+    });
+    return input.forceNew
+      ? {
+          ...interactionJob,
+          dedupeKey: sha256(
+            `${interactionJob.dedupeKey}::${input.requestId}`,
+          ),
+        }
+      : interactionJob;
+  }
+
   public createTriggerLifecycle(input: {
     resolvedTenant: ResolvedTenant;
     job: InteractionJobRecord;
   }) {
     const parsedTrigger: unknown = JSON.parse(input.job.triggerJson);
+    if (isLocalReviewTrigger(parsedTrigger)) {
+      return new NoOpPlatformTriggerLifecycle();
+    }
     if (githubCommentTriggerSchema.safeParse(parsedTrigger).success) {
       const config = readyGitHubConnectionConfigSchema.parse(
         JSON.parse(
@@ -1026,4 +1183,165 @@ export default class GitHubPlatform implements IPlatform {
       return null;
     }
   }
+}
+
+type LocatedGitHubComment =
+    | {
+        eventName: "issue_comment";
+        comment: GitHubIssueComment;
+        reference: TriggerCommentReference;
+      }
+    | {
+        eventName: "pull_request_review_comment";
+        comment: GitHubReviewComment;
+        reference: TriggerCommentReference;
+      };
+
+function validateGitHubLocalSelection(input: {
+    tenantRepository: string;
+    pullRequest: GitHubPullRequest;
+    codeReviewId: number;
+    urlSelection: GitHubCommentUrl | null;
+  }): void {
+    if (input.pullRequest.number !== input.codeReviewId) {
+      throw new Error(
+        `GitHub pull request ${input.codeReviewId} does not match the resolved tenant repository.`,
+      );
+    }
+    if (!input.urlSelection) {
+      return;
+    }
+    const selectedRepository =
+      `${input.urlSelection.owner}/${input.urlSelection.repository}`.toLowerCase();
+    if (selectedRepository !== input.tenantRepository.toLowerCase()) {
+      throw new Error(
+        "GitHub comment URL repository does not match the resolved tenant.",
+      );
+    }
+    const selectedUrl = new URL(input.urlSelection.url);
+    selectedUrl.hash = "";
+    const pullRequestUrl = new URL(input.pullRequest.html_url);
+    if (
+      selectedUrl.origin !== pullRequestUrl.origin ||
+      selectedUrl.pathname.toLowerCase() !==
+        pullRequestUrl.pathname.toLowerCase()
+    ) {
+      throw new Error(
+        "GitHub comment URL host, repository, or pull request does not match the resolved tenant.",
+      );
+    }
+  }
+
+function locateGitHubLocalComment(input: {
+    commentId: number;
+    issueComments: GitHubIssueComment[];
+    reviewComments: GitHubReviewComment[];
+    reviewThreads: GitHubReviewThread[];
+    expectedKind?: GitHubCommentUrl["kind"] | undefined;
+  }): LocatedGitHubComment | null {
+    const issueComment = input.issueComments.find(
+      (comment) => comment.id === input.commentId,
+    );
+    if (issueComment && input.expectedKind !== "review-comment") {
+      return {
+        eventName: "issue_comment",
+        comment: issueComment,
+        reference: {
+          kind: "code-review-comment",
+          commentId: input.commentId,
+        },
+      };
+    }
+    const reviewComment = input.reviewComments.find(
+      (comment) => comment.id === input.commentId,
+    );
+    if (!reviewComment || input.expectedKind === "issue-comment") {
+      return null;
+    }
+    const thread = input.reviewThreads.find((entry) =>
+      entry.comments.nodes.some(
+        (comment) => comment.databaseId === input.commentId,
+      ),
+    );
+    return {
+      eventName: "pull_request_review_comment",
+      comment: reviewComment,
+      reference: {
+        kind: "discussion-comment",
+        discussionId:
+          thread?.id ??
+          `review-comment:${reviewComment.in_reply_to_id ?? reviewComment.id}`,
+        commentId: input.commentId,
+      },
+    };
+  }
+
+function buildLocalGitHubCommentPayload(input: {
+    requestId: string;
+    connectionInstallationId: number;
+    repositoryId: number;
+    repositoryFullName: string;
+    pullRequest: GitHubPullRequest;
+    located: LocatedGitHubComment;
+  }): GitHubWebhookPayload {
+    const user = input.located.comment.user;
+    const body = {
+      action: "created",
+      installation: { id: input.connectionInstallationId },
+      repository: {
+        id: input.repositoryId,
+        full_name: input.repositoryFullName,
+      },
+      ...(input.located.eventName === "issue_comment"
+        ? {
+            issue: {
+              number: input.pullRequest.number,
+              pull_request: {},
+            },
+          }
+        : {
+            pull_request: {
+              number: input.pullRequest.number,
+              head: { sha: input.pullRequest.head.sha },
+            },
+          }),
+      comment: {
+        id: input.located.comment.id,
+        body: input.located.comment.body ?? "",
+        ...(input.located.eventName === "pull_request_review_comment" &&
+        input.located.comment.in_reply_to_id
+          ? { in_reply_to_id: input.located.comment.in_reply_to_id }
+          : {}),
+        user: user
+          ? {
+              id: user.id,
+              login: user.login,
+              ...(user.type ? { type: user.type } : {}),
+            }
+          : null,
+      },
+    };
+    return {
+      body,
+      deliveryId: input.requestId,
+      eventName: input.located.eventName,
+      action: "created",
+      installationId: input.connectionInstallationId,
+      repositoryId: input.repositoryId,
+      requestedActionIdentifier: null,
+      checkRunId: null,
+      checkRunHeadSha: null,
+      checkRunAppId: null,
+      pullRequestNumber: input.pullRequest.number,
+      pullRequestHeadSha: input.pullRequest.head.sha,
+      issueIsPullRequest: input.located.eventName === "issue_comment",
+      commentId: input.located.comment.id,
+      commentBody: input.located.comment.body ?? "",
+      commentAuthorLogin: user?.login ?? null,
+      commentAuthorType: user?.type ?? null,
+      commentInReplyToId:
+        input.located.eventName === "pull_request_review_comment"
+          ? (input.located.comment.in_reply_to_id ?? null)
+          : null,
+    };
 }

--- a/src/platforms/github/review-runtime.ts
+++ b/src/platforms/github/review-runtime.ts
@@ -56,6 +56,7 @@ import type {
   HydratedGitHubPullRequestContext,
 } from "./review-types.js";
 import { buildGitHubCheckRunReviewTriggerContext } from "./trigger-lifecycle.js";
+import { localReviewTriggerSchema } from "../../review/local-trigger.js";
 import { GitHubWorkspaceMaterializer } from "./workspace.js";
 import {
   buildGitHubCommentReviewTriggerContext,
@@ -158,6 +159,23 @@ export class GitHubPlatformReviewRuntime implements PlatformReviewRuntime {
     priorDiscussions: ProviderDiscussionContext[];
     mappings: DiscussionMappingRecord[];
   }): ReviewContext["trigger"] {
+    const localTrigger = localReviewTriggerSchema.safeParse(
+      JSON.parse(input.job.triggerJson),
+    );
+    if (localTrigger.success) {
+      const trigger = localTrigger.data;
+      return {
+        kind: "manual-review",
+        provider: "github",
+        source: "cli",
+        instruction: trigger.instruction,
+        metadata: {
+          requestId: trigger.requestId,
+          codeReviewId: trigger.codeReviewId,
+          createdAt: trigger.createdAt,
+        },
+      };
+    }
     if (
       githubCommentTriggerSchema.safeParse(JSON.parse(input.job.triggerJson))
         .success

--- a/src/platforms/github/trigger-lifecycle.ts
+++ b/src/platforms/github/trigger-lifecycle.ts
@@ -28,6 +28,7 @@ export function buildGitHubCheckRunReviewTriggerContext(
     kind: "manual-review",
     provider: "github",
     source: "check-run-requested-action",
+    instruction: null,
     metadata: {
       deliveryId: trigger.deliveryId,
       checkRunId: trigger.checkRunId,

--- a/src/platforms/github/url.ts
+++ b/src/platforms/github/url.ts
@@ -1,0 +1,50 @@
+export type GitHubCommentUrlKind = "issue-comment" | "review-comment";
+
+export interface GitHubCommentUrl {
+  url: string;
+  kind: GitHubCommentUrlKind;
+  owner: string;
+  repository: string;
+  codeReviewId: number;
+  commentId: number;
+}
+
+export function parseGitHubCommentUrl(value: string): GitHubCommentUrl {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw unsupportedGitHubCommentUrl();
+  }
+
+  const pathMatch = parsed.pathname.match(
+    /^\/([^/]+)\/([^/]+)\/pull\/([1-9]\d*)$/,
+  );
+  const issueMatch = parsed.hash.match(/^#issuecomment-([1-9]\d*)$/);
+  const reviewMatch = parsed.hash.match(/^#discussion_r([1-9]\d*)$/);
+  if (
+    parsed.protocol !== "https:" ||
+    parsed.username !== "" ||
+    parsed.password !== "" ||
+    parsed.search !== "" ||
+    !pathMatch ||
+    (!issueMatch && !reviewMatch)
+  ) {
+    throw unsupportedGitHubCommentUrl();
+  }
+
+  return {
+    url: parsed.toString(),
+    kind: issueMatch ? "issue-comment" : "review-comment",
+    owner: decodeURIComponent(pathMatch[1]!),
+    repository: decodeURIComponent(pathMatch[2]!),
+    codeReviewId: Number(pathMatch[3]),
+    commentId: Number((issueMatch ?? reviewMatch)![1]),
+  };
+}
+
+function unsupportedGitHubCommentUrl(): Error {
+  return new Error(
+    "Unsupported GitHub comment URL. Use a canonical pull request issue or review comment URL, or provide --trigger-comment-id with --code-review-id.",
+  );
+}

--- a/src/platforms/gitlab/platform.ts
+++ b/src/platforms/gitlab/platform.ts
@@ -7,10 +7,16 @@ import type {
   TenantRecord,
 } from "../../storage/contract/current.js";
 import type { WebhookReviewTrigger } from "../../review/types.js";
+import {
+  isLocalReviewTrigger,
+  serializeLocalReviewTrigger,
+} from "../../review/local-trigger.js";
 import type { InteractionRunArtifacts } from "../../review/run-artifacts.js";
 import type { StorageHelpers } from "../../storage/storage-helpers.js";
 import type {
   IPlatform,
+  LocalReviewSelector,
+  PlatformInteractionJobInput,
   PlatformSetupHandler,
   PlatformWebhookRequest,
   ResolvedTenant,
@@ -19,12 +25,24 @@ import {
   createInteractionJobDedupeKey,
   createTenantKey,
 } from "../../utils/ids.js";
-import { constantTimeEqual } from "../../utils/hash.js";
+import { constantTimeEqual, sha256 } from "../../utils/hash.js";
 import { parseGitLabNoteHook } from "./webhook.js";
 import { extractWebhookHeadSha } from "./webhook.js";
 import { extractWebhookGitLabBaseUrl } from "./webhook.js";
-import type { GitLabNoteHookPayload } from "./types.js";
-import { normalizeGitLabBaseUrl } from "./url.js";
+import type {
+  GitLabDiscussion,
+  GitLabMergeRequest,
+  GitLabMergeRequestVersion,
+  GitLabNote,
+  GitLabNoteHookPayload,
+  GitLabProject,
+} from "./types.js";
+import {
+  normalizeGitLabBaseUrl,
+  parseGitLabNoteUrl,
+  type GitLabNoteUrl,
+  urlMatchesGitLabBase,
+} from "./url.js";
 import { GitLabClient } from "./client.js";
 import {
   getGitLabConnectionConfig,
@@ -33,6 +51,7 @@ import {
 import { classifyGitLabWebhookTrigger } from "./trigger.js";
 import { GitLabReviewRuntime } from "./review-runtime.js";
 import { GitLabTriggerLifecycle } from "./trigger-lifecycle.js";
+import { NoOpPlatformTriggerLifecycle } from "../trigger-lifecycle.js";
 import { createGitLabProjectMemoryBackendForTenant } from "./project-memory-backend.js";
 
 function validateTenantBot(botInfo: unknown): botInfo is {
@@ -178,14 +197,7 @@ export default class GitLabPlatform implements IPlatform {
     payload: unknown;
     trigger: WebhookReviewTrigger;
     storage: StorageHelpers;
-  }): Promise<{
-    dedupeKey: string;
-    codeReviewId: number;
-    commentId: number | null;
-    triggerJson: string;
-    headSha: string;
-    payloadJson: string;
-  }> {
+  }): Promise<PlatformInteractionJobInput> {
     const parsedPayload = parseGitLabNoteHook(input.payload);
     if (!("comment" in input.trigger)) {
       throw new Error("GitLab interaction jobs require a comment trigger");
@@ -214,16 +226,185 @@ export default class GitLabPlatform implements IPlatform {
       payloadJson: JSON.stringify(parsedPayload),
     };
   }
+  async createLocalInteractionJob(input: {
+    resolvedTenant: ResolvedTenant;
+    storage: StorageHelpers;
+    selector: LocalReviewSelector;
+    forceNew: boolean;
+    requestId: string;
+    createdAt: string;
+  }): Promise<PlatformInteractionJobInput> {
+    const tenantConfig = getGitLabTenantConfig(input.resolvedTenant.tenant);
+    const connectionConfig = getGitLabConnectionConfig(
+      input.resolvedTenant.connection,
+    );
+    const client = this.createGitLabClient(input.resolvedTenant);
+    let urlSelection: GitLabNoteUrl | null = null;
+    let codeReviewId: number;
+    if (input.selector.kind === "comment-url") {
+      urlSelection = parseGitLabNoteUrl(input.selector.url);
+      codeReviewId = urlSelection.codeReviewId;
+    } else {
+      codeReviewId = input.selector.codeReviewId;
+    }
+    if (
+      input.selector.kind === "comment-url" &&
+      input.selector.codeReviewId !== undefined &&
+      input.selector.codeReviewId !== codeReviewId
+    ) {
+      throw new Error(
+        `--code-review-id ${input.selector.codeReviewId} does not match GitLab comment URL merge request ${codeReviewId}.`,
+      );
+    }
+
+    const [project, mergeRequest, versions] = await Promise.all([
+      client.getProject(tenantConfig.projectId),
+      client.getCodeReview(tenantConfig.projectId, codeReviewId),
+      client.listCodeReviewVersions(tenantConfig.projectId, codeReviewId),
+    ]);
+    this.validateLocalMergeRequest({
+      project,
+      mergeRequest,
+      codeReviewId,
+      tenantProjectId: tenantConfig.projectId,
+      url: urlSelection?.url,
+      baseUrl: connectionConfig.baseUrl,
+    });
+    const headSha = resolveGitLabHeadSha(mergeRequest, versions);
+
+    if (input.selector.kind === "text") {
+      const triggerJson = serializeLocalReviewTrigger({
+        kind: "reviewphin-local-review",
+        source: "cli",
+        requestId: input.requestId,
+        codeReviewId,
+        instruction: input.selector.text,
+        createdAt: input.createdAt,
+      });
+      return {
+        dedupeKey: sha256(
+          [
+            "reviewphin-local-review",
+            input.resolvedTenant.tenant.id,
+            codeReviewId,
+            input.requestId,
+          ].join("::"),
+        ),
+        codeReviewId,
+        commentId: null,
+        triggerJson,
+        headSha,
+        payloadJson: triggerJson,
+      };
+    }
+
+    let commentId: number;
+    if (input.selector.kind === "comment-id") {
+      commentId = input.selector.commentId;
+    } else {
+      if (!urlSelection) {
+        throw new Error("GitLab comment URL selection was not resolved.");
+      }
+      commentId = urlSelection.commentId;
+    }
+    const [notes, discussions] = await Promise.all([
+      client.listCodeReviewNotes(tenantConfig.projectId, codeReviewId),
+      client.listCodeReviewDiscussions(tenantConfig.projectId, codeReviewId),
+    ]);
+    const note = findGitLabNote(notes, discussions, commentId);
+    if (!note) {
+      throw new Error(
+        `GitLab comment ${commentId} was not found on merge request ${codeReviewId}.`,
+      );
+    }
+    const payload = buildLocalGitLabNotePayload({
+      project,
+      mergeRequest,
+      note,
+      headSha,
+    });
+    const trigger = await classifyGitLabWebhookTrigger({
+      payload,
+      tenant: input.resolvedTenant.tenant,
+      connection: input.resolvedTenant.connection,
+      client: {
+        listCodeReviewDiscussions: async () => discussions,
+      },
+    });
+    if (!trigger) {
+      throw new Error(
+        `GitLab comment ${commentId} is not a recognized ReviewPhin review trigger.`,
+      );
+    }
+    const interactionJob = await this.createInteractionJob({
+      resolvedTenant: input.resolvedTenant,
+      payload,
+      trigger,
+      storage: input.storage,
+    });
+    return input.forceNew
+      ? {
+          ...interactionJob,
+          dedupeKey: sha256(
+            `${interactionJob.dedupeKey}::${input.requestId}`,
+          ),
+        }
+      : interactionJob;
+  }
   createTriggerLifecycle(input: {
     resolvedTenant: ResolvedTenant;
     job: InteractionJobRecord;
     logger: Logger;
   }) {
+    if (
+      typeof input.job.triggerJson === "string" &&
+      input.job.triggerJson.includes('"reviewphin-local-review"') &&
+      isLocalReviewTrigger(JSON.parse(input.job.triggerJson))
+    ) {
+      return new NoOpPlatformTriggerLifecycle();
+    }
     return new GitLabTriggerLifecycle(
       input.resolvedTenant,
       input.job,
       input.logger,
     );
+  }
+
+  private validateLocalMergeRequest(input: {
+    project: GitLabProject;
+    mergeRequest: GitLabMergeRequest;
+    codeReviewId: number;
+    tenantProjectId: number;
+    url?: string | undefined;
+    baseUrl: string;
+  }): void {
+    if (
+      input.project.id !== input.tenantProjectId ||
+      input.mergeRequest.project_id !== input.tenantProjectId ||
+      input.mergeRequest.iid !== input.codeReviewId
+    ) {
+      throw new Error(
+        `GitLab merge request ${input.codeReviewId} does not match the resolved tenant project.`,
+      );
+    }
+    if (!input.url) {
+      return;
+    }
+    if (!urlMatchesGitLabBase(input.url, input.baseUrl)) {
+      throw new Error(
+        "GitLab comment URL host or instance path does not match the resolved tenant connection.",
+      );
+    }
+    const actual = new URL(input.url);
+    actual.hash = "";
+    if (
+      actual.toString().replace(/\/+$/, "") !==
+      input.mergeRequest.web_url.replace(/\/+$/, "")
+    ) {
+      throw new Error(
+        "GitLab comment URL project or merge request does not match the resolved tenant.",
+      );
+    }
   }
   getReviewSummaryInstructions(resolvedTenant: ResolvedTenant): string[] {
     const connectionConfig = getGitLabConnectionConfig(
@@ -234,6 +415,7 @@ export default class GitLabPlatform implements IPlatform {
       `- You can ask \`@${connectionConfig.botUsername}\` for help or to clarify anything regarding this codebase`,
     ];
   }
+
   createReviewRuntime(input: {
     storage: StorageHelpers;
     logger: Logger;
@@ -332,4 +514,83 @@ export default class GitLabPlatform implements IPlatform {
       return null;
     }
   }
+}
+
+function resolveGitLabHeadSha(
+  mergeRequest: GitLabMergeRequest,
+  versions: GitLabMergeRequestVersion[],
+): string {
+  if (mergeRequest.diff_refs?.head_sha) {
+    return mergeRequest.diff_refs.head_sha;
+  }
+  const newestVersion = [...versions].sort(
+    (left, right) =>
+      Date.parse(right.created_at) - Date.parse(left.created_at) ||
+      right.id - left.id,
+  )[0];
+  if (newestVersion?.head_commit_sha) {
+    return newestVersion.head_commit_sha;
+  }
+  throw new Error(
+    `GitLab merge request ${mergeRequest.iid} did not provide a current head SHA.`,
+  );
+}
+
+function findGitLabNote(
+  notes: GitLabNote[],
+  discussions: GitLabDiscussion[],
+  commentId: number,
+): GitLabNote | null {
+  return (
+    notes.find((note) => note.id === commentId) ??
+    discussions
+      .flatMap((discussion) => discussion.notes)
+      .find((note) => note.id === commentId) ??
+    null
+  );
+}
+
+function buildLocalGitLabNotePayload(input: {
+  project: GitLabProject;
+  mergeRequest: GitLabMergeRequest;
+  note: GitLabNote;
+  headSha: string;
+}): GitLabNoteHookPayload {
+  const action =
+    input.note.updated_at !== input.note.created_at ? "update" : "create";
+  return {
+    object_kind: "note",
+    event_type: "note",
+    project: {
+      id: input.project.id,
+      web_url: input.project.web_url,
+      path_with_namespace: input.project.path_with_namespace,
+    },
+    repository: {
+      homepage: input.project.web_url,
+    },
+    merge_request: {
+      iid: input.mergeRequest.iid,
+      title: input.mergeRequest.title,
+      description: input.mergeRequest.description,
+      source_branch: input.mergeRequest.source_branch,
+      target_branch: input.mergeRequest.target_branch,
+      last_commit: { id: input.headSha },
+      ...(input.mergeRequest.diff_refs
+        ? { diff_refs: input.mergeRequest.diff_refs }
+        : {}),
+    },
+    object_attributes: {
+      id: input.note.id,
+      note: input.note.body,
+      noteable_type: "MergeRequest",
+      action,
+      author_id: input.note.author.id,
+      system: input.note.system,
+      created_at: input.note.created_at,
+      updated_at: input.note.updated_at,
+      url: `${input.mergeRequest.web_url}#note_${input.note.id}`,
+    },
+    user: input.note.author,
+  };
 }

--- a/src/platforms/gitlab/review-runtime.ts
+++ b/src/platforms/gitlab/review-runtime.ts
@@ -23,6 +23,7 @@ import type {
   ReviewResult,
   TriggerCommentReference,
 } from "../../review/types.js";
+import { localReviewTriggerSchema } from "../../review/local-trigger.js";
 import { buildScopedReviewContext } from "../../review/review-scope.js";
 import type { InteractionRunArtifacts } from "../../review/run-artifacts.js";
 import type {
@@ -157,6 +158,25 @@ export class GitLabReviewRuntime implements PlatformReviewRuntime {
     priorDiscussions: ProviderDiscussionContext[];
     mappings: DiscussionMappingRecord[];
   }): ReviewContext["trigger"] {
+    const localTrigger =
+      typeof input.job.triggerJson === "string" &&
+      input.job.triggerJson.includes('"reviewphin-local-review"')
+        ? localReviewTriggerSchema.safeParse(JSON.parse(input.job.triggerJson))
+        : { success: false as const };
+    if (localTrigger.success) {
+      const trigger = localTrigger.data;
+      return {
+        kind: "manual-review",
+        provider: "gitlab",
+        source: "cli",
+        instruction: trigger.instruction,
+        metadata: {
+          requestId: trigger.requestId,
+          codeReviewId: trigger.codeReviewId,
+          createdAt: trigger.createdAt,
+        },
+      };
+    }
     const context = this.unwrapContext(input.context);
     return buildGitLabReviewTriggerContext({
       payload: input.payload as never,

--- a/src/platforms/gitlab/url.ts
+++ b/src/platforms/gitlab/url.ts
@@ -49,6 +49,48 @@ export function urlMatchesGitLabBase(
   return candidatePath === basePath || candidatePath.startsWith(`${basePath}/`);
 }
 
+export interface GitLabNoteUrl {
+  url: string;
+  codeReviewId: number;
+  commentId: number;
+}
+
+export function parseGitLabNoteUrl(value: string): GitLabNoteUrl {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw unsupportedGitLabNoteUrl();
+  }
+
+  const pathMatch = parsed.pathname.match(
+    /^\/.+\/-\/merge_requests\/([1-9]\d*)$/,
+  );
+  const fragmentMatch = parsed.hash.match(/^#note_([1-9]\d*)$/);
+  if (
+    parsed.protocol !== "https:" ||
+    parsed.username !== "" ||
+    parsed.password !== "" ||
+    parsed.search !== "" ||
+    !pathMatch ||
+    !fragmentMatch
+  ) {
+    throw unsupportedGitLabNoteUrl();
+  }
+
+  return {
+    url: parsed.toString(),
+    codeReviewId: Number(pathMatch[1]),
+    commentId: Number(fragmentMatch[1]),
+  };
+}
+
+function unsupportedGitLabNoteUrl(): Error {
+  return new Error(
+    "Unsupported GitLab comment URL. Use the canonical merge request note URL or provide --trigger-comment-id with --code-review-id.",
+  );
+}
+
 function stripTrailingSlashes(value: string): string {
   if (value === "/") {
     return "";

--- a/src/platforms/trigger-lifecycle.ts
+++ b/src/platforms/trigger-lifecycle.ts
@@ -1,0 +1,39 @@
+import type { Logger } from "pino";
+
+import type { InteractionJobRecord } from "../storage/contract/index.js";
+import type {
+  PlatformTriggerLifecycle,
+  PlatformTriggerOutcome,
+} from "./IPlatform.js";
+
+export class NoOpPlatformTriggerLifecycle implements PlatformTriggerLifecycle {
+  public async queued(): Promise<void> {}
+
+  public async inProgress(): Promise<void> {}
+
+  public async completed(_outcome?: PlatformTriggerOutcome): Promise<void> {}
+
+  public async retry(_error: string): Promise<void> {}
+
+  public async failed(_error: string): Promise<void> {}
+}
+
+export async function syncPlatformTriggerLifecycle(input: {
+  logger: Logger;
+  job: InteractionJobRecord;
+  phase: string;
+  update: () => Promise<void>;
+}): Promise<void> {
+  try {
+    await input.update();
+  } catch (error) {
+    input.logger.warn(
+      {
+        err: error,
+        interactionJobId: input.job.id,
+        triggerLifecyclePhase: input.phase,
+      },
+      "failed to synchronize provider trigger lifecycle",
+    );
+  }
+}

--- a/src/prompts/prompt-builders.ts
+++ b/src/prompts/prompt-builders.ts
@@ -404,6 +404,9 @@ function buildCompactTrigger(trigger: ReviewContext["trigger"]) {
       kind: trigger.kind,
       provider: trigger.provider,
       source: trigger.source,
+      instruction: trigger.instruction
+        ? truncate(trigger.instruction, 1_000)
+        : null,
       metadata: trigger.metadata,
     };
   }

--- a/src/review/local-trigger.ts
+++ b/src/review/local-trigger.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+export const localReviewTriggerSchema = z.object({
+  kind: z.literal("reviewphin-local-review"),
+  source: z.literal("cli"),
+  requestId: z.string().min(1),
+  codeReviewId: z.number().int().positive(),
+  instruction: z.string().trim().min(1),
+  createdAt: z.string().datetime({ offset: true }),
+});
+
+export type LocalReviewTrigger = z.infer<typeof localReviewTriggerSchema>;
+
+export function isLocalReviewTrigger(
+  value: unknown,
+): value is LocalReviewTrigger {
+  return localReviewTriggerSchema.safeParse(value).success;
+}
+
+export function parseLocalReviewTrigger(value: unknown): LocalReviewTrigger {
+  return localReviewTriggerSchema.parse(value);
+}
+
+export function serializeLocalReviewTrigger(
+  trigger: LocalReviewTrigger,
+): string {
+  return JSON.stringify(localReviewTriggerSchema.parse(trigger));
+}

--- a/src/review/review-scope.ts
+++ b/src/review/review-scope.ts
@@ -72,9 +72,7 @@ export function buildScopedReviewContext(
     input.previousReview?.changesJson ?? null,
   );
   const explicitFullRescan = hasExplicitFullRescanInstruction(
-    input.trigger.kind === "manual-review"
-      ? null
-      : input.trigger.instruction,
+    input.trigger.instruction,
   );
   const mode = determineReviewMode(
     input.trigger,
@@ -554,7 +552,9 @@ function buildScopeSummary(
 
     if (input.trigger.kind === "manual-review") {
       parts.push(
-        "A provider-owned manual action requested another review pass.",
+        input.trigger.instruction
+          ? `A manual action requested another review pass with this instruction: ${input.trigger.instruction}`
+          : "A provider-owned manual action requested another review pass.",
       );
     } else if (input.trigger.kind === "summary-follow-up") {
       parts.push(
@@ -592,6 +592,9 @@ function buildScopeSummary(
   }
 
   return [
+    ...(input.trigger.kind === "manual-review" && input.trigger.instruction
+      ? [`Apply this manual review instruction: ${input.trigger.instruction}`]
+      : []),
     input.previousReview
       ? "A fresh full rescan was explicitly requested even though a previous review exists."
       : "This is the first full review request for this code review.",

--- a/src/review/types.ts
+++ b/src/review/types.ts
@@ -322,6 +322,7 @@ export interface ManualReviewTriggerContext {
   kind: "manual-review";
   provider: string;
   source: string;
+  instruction: string | null;
   metadata: Record<string, string | number | boolean | null>;
 }
 

--- a/src/tenants/tenant-registry.ts
+++ b/src/tenants/tenant-registry.ts
@@ -24,6 +24,15 @@ export class TenantRegistry {
     return tenant ? this.resolveTenant(tenant) : null;
   }
 
+  public async getResolvedTenantByKey(
+    tenantKey: string,
+  ): Promise<ResolvedTenant | null> {
+    const tenant = await this.storage.stores.tenants.find({
+      key: { eq: tenantKey },
+    });
+    return tenant ? this.resolveTenant(tenant) : null;
+  }
+
   public async resolveWebhookTenant(
     platform: IPlatform,
     payload: unknown,

--- a/test/cli-help.test.ts
+++ b/test/cli-help.test.ts
@@ -92,6 +92,45 @@ describe("CLI help", () => {
     expect(help).toContain("[--clear-text-generation-reasoning-effort]");
   });
 
+  it("documents mr review selectors and watch controls", async () => {
+    vi.stubEnv("REVIEWPHIN_CLI_COMMAND", "pnpm cli");
+    const output = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+
+    await expect(runCli(["mr", "review", "--help"])).resolves.toBe(0);
+
+    const help = output.mock.calls.join("");
+    expect(help).toContain("pnpm cli mr review ");
+    expect(help).toContain("--trigger-comment-url <url>");
+    expect(help).toContain("--trigger-text-file <path>");
+    expect(help).toContain("[--watch | --no-watch]");
+  });
+
+  it("validates mr review selectors without appending usage", async () => {
+    const output = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    const errors = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+
+    await expect(
+      runCliEntry([
+        "mr",
+        "review",
+        "--tenant-id",
+        "tenant_1",
+        "--trigger-text",
+        "review",
+        "--watch",
+        "--no-watch",
+      ]),
+    ).resolves.toBe(1);
+
+    expect(output.mock.calls.join("")).not.toContain("Usage:");
+    expect(errors.mock.calls.join("")).toContain(
+      "Provide either --watch or --no-watch",
+    );
+    expect(errors.mock.calls.join("")).toContain(
+      "--trigger-text-file require --code-review-id",
+    );
+  });
+
   it("includes --help in every displayed usage entry", async () => {
     vi.stubEnv("REVIEWPHIN_CLI_COMMAND", "pnpm cli");
     const output = vi.spyOn(process.stdout, "write").mockReturnValue(true);

--- a/test/github-review-runtime.test.ts
+++ b/test/github-review-runtime.test.ts
@@ -236,6 +236,7 @@ describe("GitHubPlatformReviewRuntime", () => {
       kind: "manual-review",
       provider: "github",
       source: "check-run-requested-action",
+      instruction: null,
       metadata: {
         deliveryId: "delivery-1",
         checkRunId: 1357,

--- a/test/github-trigger-lifecycle.test.ts
+++ b/test/github-trigger-lifecycle.test.ts
@@ -67,6 +67,7 @@ describe("GitHub Check Run trigger lifecycle", () => {
       kind: "manual-review",
       provider: "github",
       source: "check-run-requested-action",
+      instruction: null,
       metadata: {
         deliveryId: "delivery-1",
         checkRunId: 1357,

--- a/test/github-url.test.ts
+++ b/test/github-url.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { parseGitHubCommentUrl } from "../src/platforms/github/url.js";
+
+describe("GitHub comment URL helpers", () => {
+  it("parses canonical issue and review comment urls", () => {
+    expect(
+      parseGitHubCommentUrl(
+        "https://github.com/octo/repo/pull/17#issuecomment-42",
+      ),
+    ).toEqual({
+      url: "https://github.com/octo/repo/pull/17#issuecomment-42",
+      kind: "issue-comment",
+      owner: "octo",
+      repository: "repo",
+      codeReviewId: 17,
+      commentId: 42,
+    });
+    expect(
+      parseGitHubCommentUrl(
+        "https://github.com/octo/repo/pull/17#discussion_r99",
+      ),
+    ).toEqual(
+      expect.objectContaining({
+        kind: "review-comment",
+        codeReviewId: 17,
+        commentId: 99,
+      }),
+    );
+  });
+
+  it("rejects non-canonical GitHub urls", () => {
+    for (const value of [
+      "http://github.com/octo/repo/pull/17#issuecomment-42",
+      "https://github.com/octo/repo/issues/17#issuecomment-42",
+      "https://github.com/octo/repo/pull/17",
+      "https://github.com/octo/repo/pull/17?diff=split#discussion_r99",
+    ]) {
+      expect(() => parseGitHubCommentUrl(value)).toThrow(
+        /Unsupported GitHub comment URL/,
+      );
+    }
+  });
+});

--- a/test/gitlab-url.test.ts
+++ b/test/gitlab-url.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildGitLabApiUrl,
   normalizeGitLabBaseUrl,
+  parseGitLabNoteUrl,
   urlMatchesGitLabBase,
 } from "../src/platforms/gitlab/url.js";
 import {
@@ -32,6 +33,29 @@ describe("GitLab URL helpers", () => {
         "https://gitlab.example.com/gitlab",
       ),
     ).toBe(true);
+  });
+
+  it("parses only canonical merge request note urls", () => {
+    expect(
+      parseGitLabNoteUrl(
+        "https://gitlab.example.com/group/project/-/merge_requests/17#note_42",
+      ),
+    ).toEqual({
+      url: "https://gitlab.example.com/group/project/-/merge_requests/17#note_42",
+      codeReviewId: 17,
+      commentId: 42,
+    });
+
+    for (const value of [
+      "http://gitlab.example.com/group/project/-/merge_requests/17#note_42",
+      "https://gitlab.example.com/group/project/-/merge_requests/17",
+      "https://gitlab.example.com/group/project/-/issues/17#note_42",
+      "https://gitlab.example.com/group/project/-/merge_requests/17?x=1#note_42",
+    ]) {
+      expect(() => parseGitLabNoteUrl(value)).toThrow(
+        /Unsupported GitLab comment URL/,
+      );
+    }
   });
 
   it("matches webhook payload urls against a path-prefixed tenant base url", () => {

--- a/test/interaction-plan.test.ts
+++ b/test/interaction-plan.test.ts
@@ -13,6 +13,7 @@ describe("buildInteractionPlan", () => {
         kind: "manual-review",
         provider: "github",
         source: "check-run-requested-action",
+        instruction: null,
         metadata: {
           checkRunId: 1357,
           actionIdentifier: "run_review",

--- a/test/local-review-platforms.test.ts
+++ b/test/local-review-platforms.test.ts
@@ -1,0 +1,379 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createLogger } from "../src/logger.js";
+import GitHubPlatform from "../src/platforms/github/platform.js";
+import GitLabPlatform from "../src/platforms/gitlab/platform.js";
+import { GitLabTriggerLifecycle } from "../src/platforms/gitlab/trigger-lifecycle.js";
+import { NoOpPlatformTriggerLifecycle } from "../src/platforms/trigger-lifecycle.js";
+import type { ResolvedTenant } from "../src/platforms/IPlatform.js";
+import type {
+  InteractionJobRecord,
+  PlatformConnectionRecord,
+  TenantRecord,
+} from "../src/storage/contract/index.js";
+import {
+  createGitLabConnectionRecord,
+  createGitLabTenantRecord,
+} from "./helpers/gitlab-tenant.js";
+
+const logger = createLogger("silent");
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("platform local review jobs", () => {
+  it("reconstructs GitLab comments with canonical dedupe and native lifecycle", async () => {
+    stubGitLabApi({ noteBody: "@review-bot review this" });
+    const platform = new GitLabPlatform(logger);
+    const resolvedTenant = createGitLabResolvedTenant();
+    const baseInput = {
+      resolvedTenant,
+      storage: {} as never,
+      selector: {
+        kind: "comment-url" as const,
+        url: "https://gitlab.example.com/group/project/-/merge_requests/7#note_91",
+      },
+      createdAt: "2026-07-12T10:00:00.000Z",
+    };
+
+    const first = await platform.createLocalInteractionJob({
+      ...baseInput,
+      forceNew: false,
+      requestId: "request-1",
+    });
+    const repeated = await platform.createLocalInteractionJob({
+      ...baseInput,
+      forceNew: false,
+      requestId: "request-2",
+    });
+    const forced = await platform.createLocalInteractionJob({
+      ...baseInput,
+      forceNew: true,
+      requestId: "request-3",
+    });
+
+    expect(repeated.dedupeKey).toBe(first.dedupeKey);
+    expect(forced.dedupeKey).not.toBe(first.dedupeKey);
+    expect(first).toMatchObject({
+      codeReviewId: 7,
+      commentId: 91,
+      headSha: "head-sha",
+    });
+    expect(JSON.parse(first.triggerJson)).toMatchObject({
+      kind: "gitlab-comment",
+    });
+    expect(
+      platform.createTriggerLifecycle({
+        resolvedTenant,
+        job: createJob(first),
+        logger,
+      }),
+    ).toBeInstanceOf(GitLabTriggerLifecycle);
+  });
+
+  it("rejects GitLab tenant mismatches and unrecognized comments clearly", async () => {
+    stubGitLabApi({ noteBody: "ordinary comment" });
+    const platform = new GitLabPlatform(logger);
+    const input = {
+      resolvedTenant: createGitLabResolvedTenant(),
+      storage: {} as never,
+      forceNew: false,
+      requestId: "request-1",
+      createdAt: "2026-07-12T10:00:00.000Z",
+    };
+
+    await expect(
+      platform.createLocalInteractionJob({
+        ...input,
+        selector: {
+          kind: "comment-url",
+          url: "https://other.example.com/group/project/-/merge_requests/7#note_91",
+        },
+      }),
+    ).rejects.toThrow("does not match the resolved tenant connection");
+    await expect(
+      platform.createLocalInteractionJob({
+        ...input,
+        selector: {
+          kind: "comment-id",
+          commentId: 91,
+          codeReviewId: 7,
+        },
+      }),
+    ).rejects.toThrow("not a recognized ReviewPhin review trigger");
+  });
+
+  it("creates fresh GitLab and GitHub text jobs with no-op lifecycle", async () => {
+    stubGitLabApi({ noteBody: "" });
+    const gitlab = new GitLabPlatform(logger);
+    const gitlabTenant = createGitLabResolvedTenant();
+    const gitlabFirst = await gitlab.createLocalInteractionJob({
+      resolvedTenant: gitlabTenant,
+      storage: {} as never,
+      selector: { kind: "text", text: "Review auth.", codeReviewId: 7 },
+      forceNew: false,
+      requestId: "request-1",
+      createdAt: "2026-07-12T10:00:00.000Z",
+    });
+    const gitlabSecond = await gitlab.createLocalInteractionJob({
+      resolvedTenant: gitlabTenant,
+      storage: {} as never,
+      selector: { kind: "text", text: "Review auth.", codeReviewId: 7 },
+      forceNew: false,
+      requestId: "request-2",
+      createdAt: "2026-07-12T10:00:01.000Z",
+    });
+    expect(gitlabSecond.dedupeKey).not.toBe(gitlabFirst.dedupeKey);
+    expect(gitlabFirst.triggerJson).toBe(gitlabFirst.payloadJson);
+    expect(
+      gitlab.createTriggerLifecycle({
+        resolvedTenant: gitlabTenant,
+        job: createJob(gitlabFirst),
+        logger,
+      }),
+    ).toBeInstanceOf(NoOpPlatformTriggerLifecycle);
+
+    const githubTenant = createGitHubResolvedTenant();
+    const github = createGitHubPlatform();
+    const githubFirst = await github.createLocalInteractionJob({
+      resolvedTenant: githubTenant,
+      storage: {} as never,
+      selector: { kind: "text", text: "Review auth.", codeReviewId: 42 },
+      forceNew: false,
+      requestId: "request-1",
+      createdAt: "2026-07-12T10:00:00.000Z",
+    });
+    const githubSecond = await github.createLocalInteractionJob({
+      resolvedTenant: githubTenant,
+      storage: {} as never,
+      selector: { kind: "text", text: "Review auth.", codeReviewId: 42 },
+      forceNew: true,
+      requestId: "request-2",
+      createdAt: "2026-07-12T10:00:01.000Z",
+    });
+    expect(githubSecond.dedupeKey).not.toBe(githubFirst.dedupeKey);
+    expect(githubFirst.triggerJson).toBe(githubFirst.payloadJson);
+    expect(
+      github.createTriggerLifecycle({
+        resolvedTenant: githubTenant,
+        job: createJob(githubFirst),
+      }),
+    ).toBeInstanceOf(NoOpPlatformTriggerLifecycle);
+  });
+
+  it("rejects GitHub URL repository and explicit pull request mismatches", async () => {
+    const platform = createGitHubPlatform();
+    const input = {
+      resolvedTenant: createGitHubResolvedTenant(),
+      storage: {} as never,
+      forceNew: false,
+      requestId: "request-1",
+      createdAt: "2026-07-12T10:00:00.000Z",
+    };
+
+    await expect(
+      platform.createLocalInteractionJob({
+        ...input,
+        selector: {
+          kind: "comment-url",
+          url: "https://github.com/other/repository/pull/42#issuecomment-91",
+        },
+      }),
+    ).rejects.toThrow("repository does not match the resolved tenant");
+    await expect(
+      platform.createLocalInteractionJob({
+        ...input,
+        selector: {
+          kind: "comment-url",
+          url: "https://github.com/octo-org/reviewphin/pull/42#issuecomment-91",
+          codeReviewId: 43,
+        },
+      }),
+    ).rejects.toThrow("does not match GitHub comment URL pull request 42");
+  });
+});
+
+function stubGitLabApi(options: { noteBody: string }): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (request: string | URL | Request) => {
+      const url = new URL(
+        typeof request === "string"
+          ? request
+          : request instanceof URL
+            ? request.toString()
+            : request.url,
+      );
+      if (url.pathname.endsWith("/projects/123")) {
+        return jsonResponse({
+          id: 123,
+          web_url: "https://gitlab.example.com/group/project",
+          path_with_namespace: "group/project",
+          http_url_to_repo: "https://gitlab.example.com/group/project.git",
+        });
+      }
+      if (url.pathname.endsWith("/merge_requests/7")) {
+        return jsonResponse({
+          id: 700,
+          iid: 7,
+          project_id: 123,
+          title: "Local review",
+          description: "",
+          web_url:
+            "https://gitlab.example.com/group/project/-/merge_requests/7",
+          source_branch: "feature",
+          target_branch: "main",
+          author: { id: 1, username: "developer", name: "Developer" },
+          diff_refs: {
+            base_sha: "base-sha",
+            start_sha: "start-sha",
+            head_sha: "head-sha",
+          },
+        });
+      }
+      if (url.pathname.endsWith("/merge_requests/7/versions")) {
+        return jsonResponse([]);
+      }
+      if (url.pathname.endsWith("/merge_requests/7/notes")) {
+        return jsonResponse([
+          {
+            id: 91,
+            body: options.noteBody,
+            author: { id: 1, username: "developer", name: "Developer" },
+            created_at: "2026-07-12T09:00:00.000Z",
+            updated_at: "2026-07-12T09:00:00.000Z",
+            system: false,
+          },
+        ]);
+      }
+      if (url.pathname.endsWith("/merge_requests/7/discussions")) {
+        return jsonResponse([]);
+      }
+      return new Response("not found", { status: 404 });
+    }),
+  );
+}
+
+function createGitLabResolvedTenant(): ResolvedTenant {
+  return {
+    tenant: createGitLabTenantRecord(),
+    connection: createGitLabConnectionRecord(),
+  };
+}
+
+function createGitHubPlatform(): GitHubPlatform {
+  const request = vi.fn(async (route: string) => {
+    if (route === "GET /repos/{owner}/{repo}/pulls/{pull_number}") {
+      return {
+        data: {
+          number: 42,
+          title: "Local review",
+          body: "",
+          html_url: "https://github.com/octo-org/reviewphin/pull/42",
+          user: { login: "developer" },
+          head: { sha: "head-sha", ref: "feature" },
+          base: { sha: "base-sha", ref: "main" },
+        },
+      };
+    }
+    throw new Error(`Unexpected GitHub route: ${route}`);
+  });
+  return new GitHubPlatform({
+    logger,
+    publicUrl: "https://review.example.com",
+    createApp: () => ({
+      octokit: { request: vi.fn() },
+      getInstallationOctokit: vi.fn(async () => ({ request })),
+    }),
+  });
+}
+
+function createGitHubResolvedTenant(): ResolvedTenant {
+  const tenant: TenantRecord = {
+    id: "tenant-github",
+    key: "https://api.github.com::987",
+    platform: "github",
+    platformConnectionId: "connection-github",
+    platformConfigJson: JSON.stringify({
+      repositoryId: 987,
+      repositoryFullName: "octo-org/reviewphin",
+    }),
+    modelProfileName: null,
+    createdAt: "2026-07-12T00:00:00.000Z",
+    updatedAt: "2026-07-12T00:00:00.000Z",
+  };
+  const connection: PlatformConnectionRecord = {
+    id: "connection-github",
+    name: "github",
+    platform: "github",
+    status: "ready",
+    platformConnectionConfigJson: JSON.stringify({
+      owner: "octo-org",
+      apiUrl: "https://api.github.com",
+      appId: 123,
+      appSlug: "reviewphin-octo-org",
+      appName: "ReviewPhin",
+      clientId: "Iv1.client",
+      clientSecret: "secret",
+      webhookSecret: "secret",
+      privateKey: "private-key",
+      ownerLogin: "octo-org",
+      ownerId: 456,
+      ownerType: "Organization",
+      permissions: {
+        checks: "write",
+        contents: "read",
+        metadata: "read",
+        pull_requests: "write",
+      },
+      events: ["check_run", "pull_request"],
+      installationId: 789,
+      installationAccountLogin: "octo-org",
+      installationAccountId: 456,
+      installationAccountType: "Organization",
+      repositorySelection: "selected",
+      accessibleRepositoryCount: 1,
+    }),
+    createdAt: "2026-07-12T00:00:00.000Z",
+    updatedAt: "2026-07-12T00:00:00.000Z",
+  };
+  return { tenant, connection };
+}
+
+function createJob(input: {
+  dedupeKey: string;
+  codeReviewId: number;
+  commentId: number | null;
+  triggerJson: string;
+  headSha: string;
+  payloadJson: string;
+}): InteractionJobRecord {
+  return {
+    id: "job-1",
+    tenantId: "tenant-1",
+    ...input,
+    status: "queued",
+    retryCount: 0,
+    lastError: null,
+    enqueuedAt: "2026-07-12T10:00:00.000Z",
+    availableAt: "2026-07-12T10:00:00.000Z",
+    startedAt: null,
+    finishedAt: null,
+    claimToken: null,
+    claimedBy: null,
+    claimExpiresAt: null,
+    latestInteractionRunId: null,
+  };
+}
+
+function jsonResponse(value: unknown): Response {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: {
+      "content-type": "application/json",
+      "x-next-page": "",
+    },
+  });
+}

--- a/test/mr-review-cli.test.ts
+++ b/test/mr-review-cli.test.ts
@@ -1,0 +1,120 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { runCli } from "../src/cli.js";
+import { parseLocalReviewTrigger } from "../src/review/local-trigger.js";
+import { listAll } from "../src/storage/storage-helpers.js";
+import { createGitLabTenantInput } from "./helpers/gitlab-tenant.js";
+import { openSqliteTestStorage } from "./helpers/storage.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("mr review CLI", () => {
+  it("submits a fresh text job without starting a worker and emits one JSON summary", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "mr-review-cli-"));
+    const databasePath = join(directory, "reviewphin.sqlite");
+    const storage = await openSqliteTestStorage(databasePath);
+    await storage.upsertTenant(createGitLabTenantInput());
+    await storage.close();
+    vi.stubEnv("LOG_LEVEL", "info");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (request: string | URL | Request) => {
+        const url = new URL(
+          typeof request === "string"
+            ? request
+            : request instanceof URL
+              ? request.toString()
+              : request.url,
+        );
+        if (url.pathname.endsWith("/projects/123")) {
+          return jsonResponse({
+            id: 123,
+            web_url: "https://gitlab.example.com/group/project",
+            path_with_namespace: "group/project",
+            http_url_to_repo: "https://gitlab.example.com/group/project.git",
+          });
+        }
+        if (url.pathname.endsWith("/merge_requests/7")) {
+          return jsonResponse({
+            id: 700,
+            iid: 7,
+            project_id: 123,
+            title: "Review local changes",
+            description: "",
+            web_url:
+              "https://gitlab.example.com/group/project/-/merge_requests/7",
+            source_branch: "feature",
+            target_branch: "main",
+            author: { id: 1, username: "developer", name: "Developer" },
+            diff_refs: {
+              base_sha: "base",
+              start_sha: "start",
+              head_sha: "head",
+            },
+          });
+        }
+        if (url.pathname.endsWith("/merge_requests/7/versions")) {
+          return jsonResponse([]);
+        }
+        return new Response("not found", { status: 404 });
+      }),
+    );
+    const output = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+
+    await expect(
+      runCli([
+        "mr",
+        "review",
+        "--key",
+        "https://gitlab.example.com::123",
+        "--trigger-text",
+        "Focus on authorization boundaries.",
+        "--code-review-id",
+        "7",
+        "--no-watch",
+        "--json",
+        "--sqlite-database-path",
+        databasePath,
+      ]),
+    ).resolves.toBe(0);
+
+    const stdout = output.mock.calls.join("");
+    expect(stdout.trim().split("\n")).toHaveLength(1);
+    expect(JSON.parse(stdout)).toEqual(
+      expect.objectContaining({
+        created: true,
+        jobStatus: "queued",
+        runId: null,
+        findingCount: 0,
+        liveLogsAvailable: false,
+      }),
+    );
+    const persisted = await openSqliteTestStorage(databasePath);
+    const jobs = await listAll(persisted.stores.interactionJobs);
+    await persisted.close();
+    expect(jobs).toHaveLength(1);
+    expect(parseLocalReviewTrigger(JSON.parse(jobs[0]!.triggerJson))).toEqual(
+      expect.objectContaining({
+        codeReviewId: 7,
+        instruction: "Focus on authorization boundaries.",
+      }),
+    );
+  });
+});
+
+function jsonResponse(value: unknown): Response {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: {
+      "content-type": "application/json",
+      "x-next-page": "",
+    },
+  });
+}

--- a/test/review-prompt.test.ts
+++ b/test/review-prompt.test.ts
@@ -20,6 +20,7 @@ describe("buildReviewPrompt", () => {
         kind: "manual-review",
         provider: "github",
         source: "check-run-requested-action",
+        instruction: null,
         metadata: {
           checkRunId: 1357,
           actionIdentifier: "run_review",
@@ -33,6 +34,32 @@ describe("buildReviewPrompt", () => {
     expect(prompt).toContain('"kind": "manual-review"');
     expect(prompt).toContain('"checkRunId": 1357');
     expect(compact.reviewTrigger).not.toHaveProperty("commentId");
+  });
+
+  it("includes local manual instructions in the compact review trigger", () => {
+    const context: ReviewContext = {
+      ...createContext(),
+      trigger: {
+        kind: "manual-review",
+        provider: "gitlab",
+        source: "cli",
+        instruction: "Focus on authorization boundary regressions.",
+        metadata: {
+          requestId: "local-review_1",
+          codeReviewId: 7,
+          createdAt: "2026-07-12T09:00:00.000Z",
+        },
+      },
+    };
+
+    const compact = buildCompactReviewContext(context, 5_000);
+
+    expect(compact.reviewTrigger).toEqual(
+      expect.objectContaining({
+        source: "cli",
+        instruction: "Focus on authorization boundary regressions.",
+      }),
+    );
   });
 
   it("includes project memory in the serialized prompt context", () => {

--- a/test/review-scope.test.ts
+++ b/test/review-scope.test.ts
@@ -28,6 +28,7 @@ describe("buildScopedReviewContext", () => {
         kind: "manual-review",
         provider: "github",
         source: "check-run-requested-action",
+        instruction: null,
         metadata: {
           checkRunId: 1357,
           actionIdentifier: "run_review",
@@ -43,6 +44,35 @@ describe("buildScopedReviewContext", () => {
         kind: "manual-review",
         provider: "github",
       }),
+    );
+  });
+
+  it("includes a local manual instruction in first-pass scope text", () => {
+    const scoped = buildScopedReviewContext({
+      workspacePath: repoPath(),
+      codeReview,
+      changes: [
+        createChange("src/manual.ts", "@@ -1 +1 @@\n-old\n+new"),
+      ],
+      comments: [],
+      discussions: [],
+      trigger: {
+        kind: "manual-review",
+        provider: "gitlab",
+        source: "cli",
+        instruction: "Focus on authorization boundary regressions.",
+        metadata: {
+          requestId: "local-review_1",
+          codeReviewId: 7,
+          createdAt: "2026-07-12T09:00:00.000Z",
+        },
+      },
+      priorDiscussions: [],
+      previousReview: null,
+    });
+
+    expect(scoped.scope.scopeSummary).toContain(
+      "Focus on authorization boundary regressions.",
     );
   });
 

--- a/test/review-watch.test.ts
+++ b/test/review-watch.test.ts
@@ -1,0 +1,313 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  ReviewWatchAbortedError,
+  buildReviewWatchSummary,
+  selectReviewAttempt,
+  watchReviewJob,
+} from "../src/cli/review-watch.js";
+import type {
+  InteractionJobRecord,
+  InteractionRunRecord,
+} from "../src/storage/contract/index.js";
+
+describe("review job watcher", () => {
+  it("selects attempts by active claim and latest run while queued", () => {
+    const first = createRun("run_1", "claim_1", "2026-07-12T08:00:00.000Z");
+    const second = createRun("run_2", "claim_2", "2026-07-12T09:00:00.000Z");
+
+    expect(
+      selectReviewAttempt(
+        createJob({
+          status: "in_progress",
+          claimToken: "claim_2",
+          latestInteractionRunId: "run_1",
+        }),
+        [first, second],
+      )?.id,
+    ).toBe("run_2");
+    expect(
+      selectReviewAttempt(
+        createJob({
+          status: "queued",
+          claimToken: null,
+          latestInteractionRunId: "run_1",
+        }),
+        [first, second],
+      )?.id,
+    ).toBe("run_1");
+  });
+
+  it("observes external transitions, tails logs, and counts selected findings", async () => {
+    const root = await mkdtemp(join(tmpdir(), "review-watch-"));
+    const runDirectory = join(root, "run_2");
+    await mkdir(runDirectory);
+    await writeFile(
+      join(runDirectory, "app.ndjson"),
+      `${JSON.stringify({
+        timestamp: "2026-07-12T09:00:00.000Z",
+        level: "info",
+        message: "review started",
+        data: { attempt: 2 },
+      })}\nmalformed\n`,
+      "utf8",
+    );
+    let poll = 0;
+    let currentJob = createJob();
+    const run = createRun("run_2", "claim_2", "2026-07-12T09:00:00.000Z");
+    const output = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    const warnings = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+    const storage = {
+      stores: {
+        interactionJobs: {
+          get: async () => {
+            poll += 1;
+            currentJob =
+              poll === 1
+                ? createJob()
+                : poll === 2
+                  ? createJob({
+                      status: "in_progress",
+                      claimToken: "claim_2",
+                    })
+                  : createJob({
+                      status: "completed",
+                      claimToken: null,
+                      latestInteractionRunId: "run_2",
+                    });
+            return currentJob;
+          },
+        },
+        interactionRuns: {
+          list: async () =>
+            currentJob.status === "queued"
+              ? []
+              : [
+                  {
+                    ...run,
+                    status:
+                      currentJob.status === "completed"
+                        ? "completed"
+                        : "in_progress",
+                  },
+                ],
+        },
+        reviewFindings: {
+          list: async () => [{ id: "finding_1" }, { id: "finding_2" }],
+        },
+      },
+    };
+
+    const summary = await watchReviewJob({
+      storage: storage as never,
+      jobId: "job_1",
+      created: true,
+      runLogRoot: root,
+      pollIntervalMs: 1,
+      outputMode: "human",
+      signal: new AbortController().signal,
+    });
+
+    expect(summary).toEqual(
+      expect.objectContaining({
+        jobStatus: "completed",
+        runId: "run_2",
+        runStatus: "completed",
+        findingCount: 2,
+        liveLogsAvailable: true,
+      }),
+    );
+    expect(output.mock.calls.join("")).toContain(
+      "waiting for an external runner",
+    );
+    expect(output.mock.calls.join("")).toContain(
+      'INFO review started {"attempt":2}',
+    );
+    expect(warnings.mock.calls.join("")).toContain("malformed live log line");
+  });
+
+  it("waits for the selected run to settle after the job is terminal", async () => {
+    let runPoll = 0;
+    const job = createJob({
+      status: "completed",
+      latestInteractionRunId: "run_1",
+    });
+    const storage = {
+      stores: {
+        interactionJobs: { get: async () => job },
+        interactionRuns: {
+          list: async () => {
+            runPoll += 1;
+            return [
+              {
+                ...createRun("run_1", "claim_1", "2026-07-12T09:00:00.000Z"),
+                status: runPoll === 1 ? "in_progress" : "completed",
+              },
+            ];
+          },
+        },
+        reviewFindings: {
+          list: vi.fn(async (options) => {
+            expect(options.filters.interactionRunId.eq).toBe("run_1");
+            return [{ id: "finding_1" }];
+          }),
+        },
+      },
+    };
+
+    const summary = await watchReviewJob({
+      storage: storage as never,
+      jobId: "job_1",
+      created: false,
+      runLogRoot: "missing-run-logs",
+      pollIntervalMs: 1,
+      outputMode: "json",
+      signal: new AbortController().signal,
+    });
+
+    expect(runPoll).toBeGreaterThanOrEqual(2);
+    expect(summary).toMatchObject({
+      jobStatus: "completed",
+      runStatus: "completed",
+      findingCount: 1,
+      liveLogsAvailable: false,
+    });
+  });
+
+  it("summarizes expiration before a first run", async () => {
+    const storage = {
+      stores: {
+        interactionJobs: {
+          get: async () =>
+            createJob({
+              status: "expired",
+              lastError: "maximum queued age exceeded",
+            }),
+        },
+        interactionRuns: { list: async () => [] },
+        reviewFindings: { list: vi.fn() },
+      },
+    };
+
+    const summary = await buildReviewWatchSummary({
+      storage: storage as never,
+      jobId: "job_1",
+      created: true,
+      runLogRoot: "run-logs",
+    });
+
+    expect(summary).toMatchObject({
+      jobStatus: "expired",
+      runId: null,
+      runStatus: null,
+      runLogDirectory: null,
+      findingCount: 0,
+      error: "maximum queued age exceeded",
+      liveLogsAvailable: false,
+    });
+    expect(storage.stores.reviewFindings.list).not.toHaveBeenCalled();
+  });
+
+  it("fails on a missing referenced run and aborts polling without mutation", async () => {
+    const get = vi.fn(async () =>
+      createJob({
+        latestInteractionRunId: "missing-run",
+      }),
+    );
+    const storage = {
+      stores: {
+        interactionJobs: { get },
+        interactionRuns: { list: async () => [] },
+        reviewFindings: { list: vi.fn() },
+      },
+    };
+    await expect(
+      buildReviewWatchSummary({
+        storage: storage as never,
+        jobId: "job_1",
+        created: false,
+        runLogRoot: "run-logs",
+      }),
+    ).rejects.toThrow("references missing run missing-run");
+
+    const controller = new AbortController();
+    const queuedStorage = {
+      stores: {
+        interactionJobs: { get: async () => createJob() },
+        interactionRuns: { list: async () => [] },
+        reviewFindings: { list: vi.fn() },
+      },
+    };
+    const watching = watchReviewJob({
+      storage: queuedStorage as never,
+      jobId: "job_1",
+      created: true,
+      runLogRoot: "run-logs",
+      pollIntervalMs: 60_000,
+      outputMode: "json",
+      signal: controller.signal,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 1));
+    controller.abort();
+
+    await expect(watching).rejects.toBeInstanceOf(ReviewWatchAbortedError);
+    expect(queuedStorage.stores.reviewFindings.list).not.toHaveBeenCalled();
+  });
+});
+
+function createJob(
+  overrides: Partial<InteractionJobRecord> = {},
+): InteractionJobRecord {
+  return {
+    id: "job_1",
+    tenantId: "tenant_1",
+    dedupeKey: "dedupe",
+    codeReviewId: 7,
+    commentId: null,
+    triggerJson: "{}",
+    headSha: "abc",
+    status: "queued",
+    payloadJson: "{}",
+    retryCount: 0,
+    lastError: null,
+    enqueuedAt: "2026-07-12T08:00:00.000Z",
+    availableAt: "2026-07-12T08:00:00.000Z",
+    startedAt: null,
+    finishedAt: null,
+    claimToken: null,
+    claimedBy: null,
+    claimExpiresAt: null,
+    latestInteractionRunId: null,
+    ...overrides,
+  };
+}
+
+function createRun(
+  id: string,
+  interactionJobClaimToken: string,
+  startedAt: string,
+): InteractionRunRecord {
+  return {
+    id,
+    interactionJobId: "job_1",
+    interactionJobClaimToken,
+    tenantId: "tenant_1",
+    provider: "copilot",
+    model: null,
+    modelProfileName: null,
+    providerBaseUrl: null,
+    providerType: null,
+    textGenerationModel: null,
+    reviewReasoningEffort: null,
+    textGenerationReasoningEffort: null,
+    status: "in_progress",
+    resultJson: null,
+    error: null,
+    startedAt,
+    finishedAt: null,
+  };
+}


### PR DESCRIPTION
## Summary

- add `reviewphin mr review` for submitting persisted reviews without a webhook
- support GitLab and GitHub comment selectors plus fresh text instructions
- watch externally processed jobs, retries, live logs, findings, and terminal status
- document local submission, custom-provider support, and CLI behavior

## Validation

- `pnpm test` (439 tests passed)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm docs:build`
- `git diff --check`

<details><summary>Changelog: minor</summary>

### Added

- Operators can submit merge request and pull request reviews from the CLI without exposing a webhook.

</details>
