### PR TITLE
Fix GitHub review thread resolution authorization

### DIFF
--- a/src/platforms/github/review-publication-adapter.ts
+++ b/src/platforms/github/review-publication-adapter.ts
@@ -14,14 +14,15 @@ import {
   isReviewSummaryNoteBody,
 } from "../../review/summary.js";
 import type { ReviewAnchor, ReviewFinding } from "../../review/types.js";
-import type {
-  GitHubClient,
-  GitHubIssueComment,
-  GitHubPendingReviewComment,
-  GitHubPullRequestFile,
-  GitHubPullRequestReview,
-  GitHubReviewComment,
-  GitHubReviewThread,
+import {
+  GitHubApiError,
+  type GitHubClient,
+  type GitHubIssueComment,
+  type GitHubPendingReviewComment,
+  type GitHubPullRequestFile,
+  type GitHubPullRequestReview,
+  type GitHubReviewComment,
+  type GitHubReviewThread,
 } from "./client.js";
 
 const PUBLICATION_MARKER_PREFIX = "reviewphin-publication:";
@@ -153,10 +154,13 @@ export class GitHubReviewPublicationAdapter implements PlatformReviewPublication
           );
           return {};
         } catch (error) {
+          const skipReason = getPermanentGitHubResolutionFailure(error);
+          if (!skipReason) {
+            throw error;
+          }
           return {
             skipped: true,
-            skipReason:
-              error instanceof Error ? error.message : String(error),
+            skipReason,
           };
         }
       case "update-finding": {
@@ -602,6 +606,23 @@ export class GitHubReviewPublicationAdapter implements PlatformReviewPublication
     }
     return null;
   }
+}
+
+function getPermanentGitHubResolutionFailure(error: unknown): string | null {
+  if (!(error instanceof GitHubApiError)) {
+    return null;
+  }
+
+  let current: unknown = error;
+  const visited = new Set<unknown>();
+  while (current instanceof Error && !visited.has(current)) {
+    visited.add(current);
+    if (current.message.includes("Resource not accessible by integration")) {
+      return current.message;
+    }
+    current = current.cause;
+  }
+  return null;
 }
 
 export function renderGitHubFindingBody(

--- a/src/platforms/gitlab/review-publication-adapter.ts
+++ b/src/platforms/gitlab/review-publication-adapter.ts
@@ -115,13 +115,20 @@ export class GitLabReviewPublicationAdapter implements PlatformReviewPublication
     const projectId = getGitLabTenantConfig(this.tenant).projectId;
     switch (mutation.kind) {
       case "set-resolved":
-        await this.client.resolveDiscussion(
-          projectId,
-          this.context.mergeRequest.iid,
-          mutation.discussionId,
-          mutation.resolved,
-        );
-        return {};
+        try {
+          await this.client.resolveDiscussion(
+            projectId,
+            this.context.mergeRequest.iid,
+            mutation.discussionId,
+            mutation.resolved,
+          );
+          return {};
+        } catch (error) {
+          return {
+            skipped: true,
+            skipReason: error instanceof Error ? error.message : String(error),
+          };
+        }
       case "update-finding": {
         const position = this.findCommentPosition(
           mutation.discussionId,

--- a/src/platforms/gitlab/review-publication-adapter.ts
+++ b/src/platforms/gitlab/review-publication-adapter.ts
@@ -124,6 +124,9 @@ export class GitLabReviewPublicationAdapter implements PlatformReviewPublication
           );
           return {};
         } catch (error) {
+          if (!isPermanentGitLabResolutionFailure(error)) {
+            throw error;
+          }
           return {
             skipped: true,
             skipReason: error instanceof Error ? error.message : String(error),
@@ -473,6 +476,12 @@ export class GitLabReviewPublicationAdapter implements PlatformReviewPublication
       return createDraft(null);
     }
   }
+}
+
+function isPermanentGitLabResolutionFailure(
+  error: unknown,
+): error is GitLabApiError {
+  return error instanceof GitLabApiError && error.status === 403;
 }
 
 export function toPlatformReviewDiscussion(

--- a/src/reconcile/discussion-reconciler.ts
+++ b/src/reconcile/discussion-reconciler.ts
@@ -65,10 +65,14 @@ export interface ReconcileSummary {
   replied: number;
   resolved: number;
   skippedResolution: number;
+  skippedResolutionReasons?: string[];
   kept: number;
   summaryCommentAction: "created" | "updated" | null;
   links: PlatformPublicationLink[];
 }
+
+const MANUAL_RESOLUTION_NOTICE_MARKER =
+  "<!-- reviewphin-manual-resolution-notice:v1 -->";
 
 interface DiscussionReconcilerOptions {
   storage: StorageHelpers;
@@ -94,9 +98,7 @@ export interface ReconcileClaimGuard {
  * lost mid-reconcile the wrapper throws before issuing (or after completing) an
  * adapter mutation, preventing a stale attempt from publishing platform changes.
  */
-export class ClaimGuardedReviewPublicationAdapter
-  implements PlatformReviewPublicationAdapter
-{
+export class ClaimGuardedReviewPublicationAdapter implements PlatformReviewPublicationAdapter {
   public constructor(
     private readonly delegate: PlatformReviewPublicationAdapter,
     private readonly guard: ReconcileClaimGuard,
@@ -142,11 +144,7 @@ export class ClaimGuardedReviewPublicationAdapter
 }
 
 type DiscussionReconcileAction =
-  | "created"
-  | "updated"
-  | "replied"
-  | "resolved"
-  | "kept";
+  "created" | "updated" | "replied" | "resolved" | "kept";
 
 export class DiscussionReconciler {
   private readonly storage: StorageHelpers;
@@ -222,6 +220,7 @@ export class DiscussionReconciler {
       replied: 0,
       resolved: 0,
       skippedResolution: 0,
+      skippedResolutionReasons: [],
       kept: 0,
       summaryCommentAction: null,
       links: [],
@@ -299,6 +298,7 @@ export class DiscussionReconciler {
 
       if (disposition.action === "resolve") {
         let platformResolved = knownDiscussion.resolved;
+        let skippedResolutionReason: string | null = null;
         if (!knownDiscussion.resolved) {
           if (knownDiscussion.resolvable) {
             const mutation = await input.publicationAdapter.mutateDiscussion({
@@ -307,18 +307,22 @@ export class DiscussionReconciler {
               resolved: true,
             });
             if (mutation.skipped) {
+              skippedResolutionReason =
+                mutation.skipReason ?? "platform skipped resolution";
               this.logSkippedDiscussionResolutionMutation({
                 tenant: input.tenant,
                 codeReviewId: input.context.codeReview.id,
                 interactionRunId: input.interactionRunId,
                 knownDiscussion,
-                reason: mutation.skipReason ?? "platform skipped resolution",
+                reason: skippedResolutionReason,
               });
               summary.skippedResolution += 1;
+              summary.skippedResolutionReasons?.push(skippedResolutionReason);
             } else {
               platformResolved = true;
             }
           } else {
+            skippedResolutionReason = `Discussion ${knownDiscussion.platformDiscussionId} is not resolvable by the platform`;
             this.logSkippedDiscussionResolutionChange({
               tenant: input.tenant,
               codeReviewId: input.context.codeReview.id,
@@ -327,6 +331,7 @@ export class DiscussionReconciler {
               resolved: true,
             });
             summary.skippedResolution += 1;
+            summary.skippedResolutionReasons?.push(skippedResolutionReason);
           }
         }
 
@@ -373,6 +378,20 @@ export class DiscussionReconciler {
           discussionStatus: platformResolved ? "resolved" : "open",
           findingStatus: disposition.resolution ?? "resolved",
         });
+        if (skippedResolutionReason) {
+          const notified = await this.notifyManualDiscussionResolution({
+            tenant: input.tenant,
+            codeReviewId: input.context.codeReview.id,
+            interactionRunId: input.interactionRunId,
+            publicationAdapter: input.publicationAdapter,
+            knownDiscussion,
+            resolution: disposition.resolution ?? "resolved",
+            reason: skippedResolutionReason,
+          });
+          if (notified) {
+            summary.replied += 1;
+          }
+        }
         if (platformResolved) {
           summary.resolved += 1;
         }
@@ -509,11 +528,12 @@ export class DiscussionReconciler {
       let discussionStatus: "open" | "resolved" = "open";
       if (input.knownDiscussion.resolved) {
         if (input.knownDiscussion.resolvable) {
-          const reopenMutation = await input.publicationAdapter.mutateDiscussion({
-            kind: "set-resolved",
-            discussionId: input.knownDiscussion.platformDiscussionId,
-            resolved: false,
-          });
+          const reopenMutation =
+            await input.publicationAdapter.mutateDiscussion({
+              kind: "set-resolved",
+              discussionId: input.knownDiscussion.platformDiscussionId,
+              resolved: false,
+            });
           if (reopenMutation.skipped) {
             discussionStatus = "resolved";
             this.logSkippedDiscussionResolutionMutation({
@@ -851,6 +871,70 @@ export class DiscussionReconciler {
     );
   }
 
+  private async notifyManualDiscussionResolution(input: {
+    tenant: TenantRecord;
+    codeReviewId: number;
+    interactionRunId: string;
+    publicationAdapter: PlatformReviewPublicationAdapter;
+    knownDiscussion: KnownDiscussion;
+    resolution: "resolved" | "dismissed";
+    reason: string;
+  }): Promise<boolean> {
+    const discussions = await input.publicationAdapter.loadDiscussions({
+      fresh: true,
+    });
+    const discussion = discussions.find(
+      (entry) => entry.id === input.knownDiscussion.platformDiscussionId,
+    );
+    if (!discussion) {
+      throw new Error(
+        `Cannot notify missing platform discussion ${input.knownDiscussion.platformDiscussionId} about skipped resolution`,
+      );
+    }
+    if (
+      discussion.comments.some((comment) =>
+        comment.body.includes(MANUAL_RESOLUTION_NOTICE_MARKER),
+      )
+    ) {
+      this.logger.debug(
+        {
+          tenantId: input.tenant.id,
+          codeReviewId: input.codeReviewId,
+          interactionRunId: input.interactionRunId,
+          discussionId: input.knownDiscussion.discussionId,
+          platformDiscussionId: input.knownDiscussion.platformDiscussionId,
+        },
+        "manual discussion resolution notice already exists",
+      );
+      return false;
+    }
+
+    const body = buildManualResolutionNotice(input.resolution);
+    const mutation = await input.publicationAdapter.mutateDiscussion({
+      kind: "reply-text",
+      discussionId: input.knownDiscussion.platformDiscussionId,
+      body,
+    });
+    if (!mutation.comment) {
+      throw new Error(
+        `Platform did not return a manual resolution notice reply for discussion ${input.knownDiscussion.platformDiscussionId}`,
+      );
+    }
+    this.logger.warn(
+      {
+        tenantId: input.tenant.id,
+        codeReviewId: input.codeReviewId,
+        interactionRunId: input.interactionRunId,
+        discussionId: input.knownDiscussion.discussionId,
+        platformDiscussionId: input.knownDiscussion.platformDiscussionId,
+        resolution: input.resolution,
+        reason: input.reason,
+      },
+      "notified discussion that internal resolution requires manual platform resolution",
+    );
+    return true;
+  }
+
   private async syncSummaryNote(input: {
     platform: IPlatform;
     tenant: TenantRecord;
@@ -996,6 +1080,16 @@ export class DiscussionReconciler {
 
     return [...activeFindings.values()];
   }
+}
+
+function buildManualResolutionNotice(
+  resolution: "resolved" | "dismissed",
+): string {
+  const disposition =
+    resolution === "dismissed"
+      ? "dismissed this finding as no longer applicable"
+      : "considers this finding fixed";
+  return `${MANUAL_RESOLUTION_NOTICE_MARKER}\nReviewPhin's latest review ${disposition}. No further code change is requested for it, but this discussion could not be resolved automatically. Please review and resolve this thread manually when satisfied.`;
 }
 
 type SummaryFinding = Pick<

--- a/test/discussion-reconciler.test.ts
+++ b/test/discussion-reconciler.test.ts
@@ -148,7 +148,12 @@ describe("Discussion reconciler", () => {
   it("reports GitLab resolution failures as skipped mutations", async () => {
     const context = createHydratedContext();
     const resolveDiscussion = vi.fn(async () => {
-      throw new Error("GitLab token cannot resolve this discussion");
+      throw new GitLabApiError(
+        "GitLab token cannot resolve this discussion",
+        403,
+        '{"message":"403 Forbidden"}',
+        "https://gitlab.example.com/api/v4/projects/123/merge_requests/7/discussions/disc_1",
+      );
     });
 
     const result = await createDiscussionAdapter(context, {
@@ -164,6 +169,43 @@ describe("Discussion reconciler", () => {
       skipReason: "GitLab token cannot resolve this discussion",
     });
     expect(resolveDiscussion).toHaveBeenCalledWith(123, 7, "disc_1", true);
+  });
+
+  it.each([
+    [
+      "rate limit",
+      new GitLabApiError(
+        "GitLab rate limit reached",
+        429,
+        '{"message":"429 Too Many Requests"}',
+        "https://gitlab.example.com/api/v4/projects/123/merge_requests/7/discussions/disc_1",
+      ),
+    ],
+    [
+      "server failure",
+      new GitLabApiError(
+        "GitLab request failed",
+        500,
+        '{"message":"500 Internal Server Error"}',
+        "https://gitlab.example.com/api/v4/projects/123/merge_requests/7/discussions/disc_1",
+      ),
+    ],
+    ["network failure", new TypeError("fetch failed")],
+  ])("propagates transient GitLab %s errors", async (_label, error) => {
+    const context = createHydratedContext();
+    const resolveDiscussion = vi.fn(async () => {
+      throw error;
+    });
+
+    await expect(
+      createDiscussionAdapter(context, {
+        resolveDiscussion,
+      }).mutateDiscussion({
+        kind: "set-resolved",
+        discussionId: "disc_1",
+        resolved: true,
+      }),
+    ).rejects.toBe(error);
   });
 
   it("updates a bot-owned thread when the model revises the finding after a human reply", async () => {

--- a/test/discussion-reconciler.test.ts
+++ b/test/discussion-reconciler.test.ts
@@ -145,6 +145,27 @@ describe("Discussion reconciler", () => {
     );
   });
 
+  it("reports GitLab resolution failures as skipped mutations", async () => {
+    const context = createHydratedContext();
+    const resolveDiscussion = vi.fn(async () => {
+      throw new Error("GitLab token cannot resolve this discussion");
+    });
+
+    const result = await createDiscussionAdapter(context, {
+      resolveDiscussion,
+    }).mutateDiscussion({
+      kind: "set-resolved",
+      discussionId: "disc_1",
+      resolved: true,
+    });
+
+    expect(result).toEqual({
+      skipped: true,
+      skipReason: "GitLab token cannot resolve this discussion",
+    });
+    expect(resolveDiscussion).toHaveBeenCalledWith(123, 7, "disc_1", true);
+  });
+
   it("updates a bot-owned thread when the model revises the finding after a human reply", async () => {
     const storage = {
       upsertDiscussionMapping: vi.fn(async (input) => ({
@@ -985,7 +1006,6 @@ describe("Discussion reconciler", () => {
         },
       ],
     });
-
     const summary = await reconciler.reconcile({
       platform,
       tenant,
@@ -1080,65 +1100,103 @@ describe("Discussion reconciler", () => {
         },
       ],
     });
+    const liveDiscussions = structuredClone(context.discussions);
+    const listCodeReviewDiscussions = vi.fn(async () => liveDiscussions);
+    const replyToDiscussion = vi.fn(
+      async (
+        _projectId: number,
+        _codeReviewId: number,
+        _discussionId: string,
+        body: string,
+      ) => {
+        const note = {
+          id: 12,
+          body,
+          author: { id: 999, username: "review-bot", name: "Review Bot" },
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+          system: false,
+          resolvable: false,
+          resolved: false,
+        };
+        liveDiscussions[0]!.notes.push(note);
+        return note;
+      },
+    );
 
-    const summary = await reconciler.reconcile({
-      platform,
-      tenant,
-      context,
-      mappings: [
-        {
-          id: "map_1",
-          tenantId: tenant.id,
-          codeReviewId: 7,
-          identityKey: "identity",
-          findingFingerprint: "old",
-          title: "Old finding",
-          severity: "medium",
-          category: "bug",
-          body: "**Old finding**\n\nOld body",
-          platformDiscussionId: "disc_1",
-          platformCommentId: 10,
-          anchorJson: null,
-          positionJson: null,
-          botDiscussion: true,
-          botComment: true,
-          commentAuthorId: 999,
-          commentAuthorUsername: "review-bot",
-          status: "open" as const,
-          lastInteractionRunId: "run_old",
-          createdAt: new Date().toISOString(),
-          updatedAt: new Date().toISOString(),
-        },
-      ],
-      interactionRunId: "run_1",
-      interactionJobId: "job-publication",
-      reviewResult: {
-        overview: {
-          summary: "Handled follow-up",
-          overallSeverity: "low",
-        },
-        findings: [],
-        priorDispositions: [
+    const reconcile = () =>
+      reconciler.reconcile({
+        platform,
+        tenant,
+        context,
+        mappings: [
           {
-            discussionId: "map_1",
-            action: "resolve",
-            resolution: "dismissed",
+            id: "map_1",
+            tenantId: tenant.id,
+            codeReviewId: 7,
+            identityKey: "identity",
+            findingFingerprint: "old",
+            title: "Old finding",
+            severity: "medium",
+            category: "bug",
+            body: "**Old finding**\n\nOld body",
+            platformDiscussionId: "disc_1",
+            platformCommentId: 10,
+            anchorJson: null,
+            positionJson: null,
+            botDiscussion: true,
+            botComment: true,
+            commentAuthorId: 999,
+            commentAuthorUsername: "review-bot",
+            status: "open" as const,
+            lastInteractionRunId: "run_old",
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
           },
         ],
-      },
-      publicationAdapter: createDiscussionAdapter(context, {
-        createCodeReviewComment,
-        updateCodeReviewComment: vi.fn(),
-        replyToDiscussion: vi.fn(),
-        updateDiscussionNote: vi.fn(),
-        createCodeReviewDiscussion: vi.fn(),
-        resolveDiscussion,
-      }),
-    });
+        interactionRunId: "run_1",
+        interactionJobId: "job-publication",
+        reviewResult: {
+          overview: {
+            summary: "Handled follow-up",
+            overallSeverity: "low",
+          },
+          findings: [],
+          priorDispositions: [
+            {
+              discussionId: "map_1",
+              action: "resolve",
+              resolution: "dismissed",
+            },
+          ],
+        },
+        publicationAdapter: createDiscussionAdapter(context, {
+          createCodeReviewComment,
+          updateCodeReviewComment: vi.fn(),
+          replyToDiscussion,
+          updateDiscussionNote: vi.fn(),
+          createCodeReviewDiscussion: vi.fn(),
+          listCodeReviewDiscussions,
+          resolveDiscussion,
+        }),
+      });
+    const summary = await reconcile();
+    await reconcile();
 
     expect(summary.resolved).toBe(0);
     expect(summary.skippedResolution).toBe(1);
+    expect(summary.skippedResolutionReasons).toEqual([
+      "Discussion disc_1 is not resolvable by the platform",
+    ]);
+    expect(summary.replied).toBe(1);
     expect(resolveDiscussion).not.toHaveBeenCalled();
+    expect(replyToDiscussion).toHaveBeenCalledTimes(1);
+    expect(replyToDiscussion.mock.calls[0]?.[3]).toContain(
+      "<!-- reviewphin-manual-resolution-notice:v1 -->",
+    );
+    expect(replyToDiscussion.mock.calls[0]?.[3]).toContain(
+      "dismissed this finding as no longer applicable",
+    );
     expect(storage.upsertDiscussionMapping).toHaveBeenCalledWith(
       expect.objectContaining({ status: "open" }),
     );
@@ -1163,10 +1221,30 @@ describe("Discussion reconciler", () => {
       storage: storage as never,
       logger,
     });
-    const mutateDiscussion = vi.fn(async () => ({
-      skipped: true,
-      skipReason: "Resource not accessible by integration",
-    }));
+    const mutateDiscussion = vi.fn(async (mutation) => {
+      if (mutation.kind === "set-resolved") {
+        return {
+          skipped: true,
+          skipReason: "Resource not accessible by integration",
+        };
+      }
+      return {
+        comment: {
+          id: "11",
+          body: mutation.body,
+          authorId: "999",
+          authorUsername: "review-bot",
+          isBot: true,
+          resolvable: true,
+          resolved: false,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          anchor: null,
+          positionJson: null,
+          url: null,
+        },
+      };
+    });
 
     const summary = await reconciler.reconcile({
       platform,
@@ -1260,6 +1338,17 @@ describe("Discussion reconciler", () => {
     });
     expect(summary.resolved).toBe(0);
     expect(summary.skippedResolution).toBe(1);
+    expect(summary.skippedResolutionReasons).toEqual([
+      "Resource not accessible by integration",
+    ]);
+    expect(summary.replied).toBe(1);
+    expect(mutateDiscussion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "reply-text",
+        discussionId: "PRRT_1",
+        body: expect.stringContaining("considers this finding fixed"),
+      }),
+    );
     expect(storage.upsertDiscussionMapping).toHaveBeenCalledWith(
       expect.objectContaining({ status: "open" }),
     );

--- a/test/github-review-publication-adapter.test.ts
+++ b/test/github-review-publication-adapter.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 
-import type {
-  GitHubPendingReviewComment,
-  GitHubIssueComment,
-  GitHubPullRequestReview,
-  GitHubReviewComment,
-  GitHubReviewThread,
+import {
+  GitHubApiError,
+  type GitHubPendingReviewComment,
+  type GitHubIssueComment,
+  type GitHubPullRequestReview,
+  type GitHubReviewComment,
+  type GitHubReviewThread,
 } from "../src/platforms/github/client.js";
 import { GitHubReviewPublicationAdapter } from "../src/platforms/github/review-publication-adapter.js";
 
@@ -694,7 +695,9 @@ describe("GitHubReviewPublicationAdapter", () => {
       ],
     });
     state.client.setReviewThreadResolved.mockRejectedValueOnce(
-      new Error("Resource not accessible by integration"),
+      new GitHubApiError("GitHub review thread PRRT_600 request failed", null, {
+        cause: new Error("Resource not accessible by integration"),
+      }),
     );
 
     await expect(
@@ -711,6 +714,64 @@ describe("GitHubReviewPublicationAdapter", () => {
       "PRRT_600",
       true,
     );
+  });
+
+  it.each([
+    [
+      "rate limit",
+      new GitHubApiError(
+        "GitHub review thread PRRT_600 request failed with status 429",
+        429,
+      ),
+    ],
+    [
+      "server failure",
+      new GitHubApiError(
+        "GitHub review thread PRRT_600 request failed with status 500",
+        500,
+      ),
+    ],
+    [
+      "network failure",
+      new GitHubApiError("GitHub review thread PRRT_600 request failed", null, {
+        cause: new TypeError("fetch failed"),
+      }),
+    ],
+  ])("propagates transient GitHub %s errors", async (_label, error) => {
+    const state = createState();
+    const adapter = createAdapter(state);
+    await adapter.publishFindings({
+      publicationKey: "job-transient-resolution",
+      existingDiscussionIds: new Set(),
+      findings: [
+        {
+          identityKey: "inline",
+          fingerprint: "inline-fingerprint",
+          marker: "github:job-transient-resolution:inline",
+          finding: {
+            title: "Return the computed value",
+            body: "The current branch drops the result.",
+            severity: "high",
+            category: "bug",
+            anchor: {
+              path: "src/index.ts",
+              startLine: 2,
+              endLine: 2,
+              side: "new",
+            },
+          },
+        },
+      ],
+    });
+    state.client.setReviewThreadResolved.mockRejectedValueOnce(error);
+
+    await expect(
+      adapter.mutateDiscussion({
+        kind: "set-resolved",
+        discussionId: "PRRT_600",
+        resolved: true,
+      }),
+    ).rejects.toBe(error);
   });
 
   it("creates then updates the marked summary issue comment", async () => {


### PR DESCRIPTION
## Summary

- Resolve and reopen GitHub review threads with a maintainer's GitHub App user authorization instead of the installation token.
- Add authorization and status commands for upgrading existing connections, while including the authorization step in new GitHub App setup.
- Refresh expiring user tokens and persist replacements without interrupting an existing working authorization.
- Document the ReviewPhin 1.2 administrator upgrade path and a safe local test procedure using a copied production database.

## Upgrade notes

Existing GitHub connections remain usable for reviews, but administrators must add the printed callback URL to the existing GitHub App and run `reviewphin platform connection authorize --connection <name-or-id>` before ReviewPhin can resolve GitHub review threads. No storage-contract or database-schema migration is required.

## Validation

- `pnpm test` — 445 tests passed.
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm docs:build`
- Storage-contract verification completed with no contract revision required.

<details><summary>Changelog: minor</summary>

### Added

- Administrators can authorize a GitHub maintainer for new or existing GitHub connections through the setup flow or CLI.
- Administrators can check whether a GitHub connection is ready to resolve review threads.

### Fixed

- ReviewPhin now closes resolved GitHub review conversations on the pull request instead of updating only its internal review summary.

### Changed

- Existing GitHub Apps must add the ReviewPhin user authorization callback URL and complete a one-time maintainer authorization after upgrading.

</details>
