### PR TITLE
Improve OSS repository health

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [rgembalik]

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,54 @@
+name: Bug report
+description: Report a reproducible, non-security problem.
+title: "[Bug]: "
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        For vulnerabilities, follow [SECURITY.md](https://github.com/cdwv/ReviewPhin/blob/main/SECURITY.md) instead.
+        Never include credentials, private code, or sensitive logs in a public issue.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+      description: Describe the problem and its impact.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: How can we reproduce it?
+      description: Provide the smallest safe sequence of commands or events that triggers the problem.
+      placeholder: Do not include tokens, secrets, private repository contents, or sensitive logs.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect?
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - GitLab
+        - GitHub
+        - Storage
+        - Model provider
+        - CLI or deployment
+        - Documentation
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: ReviewPhin version
+      placeholder: For example, 1.4.0 or a commit SHA
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add only public, redacted details that help explain the issue.

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: >-
-        For vulnerabilities, follow [SECURITY.md](https://github.com/cdwv/ReviewPhin/blob/main/SECURITY.md) instead.
+        For vulnerabilities, follow [SECURITY.md](SECURITY.md) instead.
         Never include credentials, private code, or sensitive logs in a public issue.
   - type: textarea
     id: problem

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/cdwv/ReviewPhin/blob/main/SECURITY.md
+    about: Follow the private reporting instructions in SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,42 @@
+name: Feature request
+description: Suggest an improvement or new capability.
+title: "[Feature]: "
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        For vulnerabilities, follow [SECURITY.md](https://github.com/cdwv/ReviewPhin/blob/main/SECURITY.md) instead.
+        Never include credentials, private code, or sensitive logs in a public issue.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: Explain the user or operator need.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would you like to happen?
+      description: Describe the smallest useful outcome.
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - GitLab
+        - GitHub
+        - Storage
+        - Model provider
+        - CLI or deployment
+        - Documentation
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Optional; include any workaround you use today.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: >-
-        For vulnerabilities, follow [SECURITY.md](https://github.com/cdwv/ReviewPhin/blob/main/SECURITY.md) instead.
+        For vulnerabilities, follow [SECURITY.md](SECURITY.md) instead.
         Never include credentials, private code, or sensitive logs in a public issue.
   - type: textarea
     id: problem

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+## Summary
+
+<!-- What changed, and why? -->
+
+## Validation
+
+<!-- List the commands or manual checks you ran. -->
+
+- [ ] `pnpm lint`
+- [ ] `pnpm typecheck`
+- [ ] `pnpm test`
+- [ ] `pnpm docs:build` when docs or public behavior changed
+- [ ] Tests cover new or changed behavior
+- [ ] Documentation reflects user-facing changes
+- [ ] The change contains no credentials, private code, or sensitive logs
+
+## Changelog
+
+<!-- Replace patch|minor|major with one level. Use Added, Changed, Deprecated, Removed, Fixed, or Security headings. -->
+
+<details><summary>Changelog: patch|minor|major</summary>
+
+### Changed
+
+- Describe the user-visible change.
+
+</details>

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ A developer starts a review from a GitLab merge request or GitHub pull request. 
 
 Findings are published through the platform's native review tools as bot-owned discussions, inline comments, suggestions, and a summary. Later reviews can focus on new changes, while replies inside existing findings continue the conversation without starting over.
 
-The ReviewPhin worker runs on infrastructure you control, but review context is sent to the model provider you configure. Review state and project memory are also sent to a hosted storage provider when you select one instead of local SQLite. Review AI-generated findings before acting on or merging them.
+The ReviewPhin worker runs on infrastructure you control, but review context is sent to the model provider you configure. When you select a hosted storage provider instead of local SQLite, persisted review state goes to that provider. Project memory follows the platform: GitHub uses the configured storage provider, while GitLab uses the project wiki when enabled and configured storage otherwise. Review AI-generated findings before acting on or merging them.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Run on your own infrastructure. Bring your own model. Use your own agent subscri
 
 [![Docker Image](https://img.shields.io/badge/docker-cdwv%2Freviewphin-blue?logo=docker)](https://hub.docker.com/r/cdwv/reviewphin)
 [![License: MPL 2.0](https://img.shields.io/badge/License-MPL_2.0-brightgreen.svg)](LICENSE)
+[![Quality Gates](https://github.com/cdwv/ReviewPhin/actions/workflows/quality-gates.yml/badge.svg)](https://github.com/cdwv/ReviewPhin/actions/workflows/quality-gates.yml)
+
+[Security policy](SECURITY.md)
 
 </div>
 
@@ -32,7 +35,6 @@ _Created by [@rgembalik](https://github.com/rgembalik) with support from [CodeWa
 - [Using ReviewPhin](#using-reviewphin)
 - [How it works](#how-it-works)
 - [Review pipeline](#review-pipeline)
-- [Technologies](#technologies)
 - [Environment variables](#environment-variables)
 - [Inspiration & motivation](#inspiration--motivation)
 - [CLI reference](https://reviewphin.com/docs/management/cli-reference/)
@@ -71,6 +73,8 @@ docker compose up -d
 ```
 
 The compose file mounts `./data` to `/app/data` (SQLite database + run logs) and `./tmp` to `/app/tmp` (hydrated workspaces). Both directories are created automatically.
+
+> **Using GitHub?** Continue with the canonical [GitHub App setup instructions](https://reviewphin.com/docs/management/platform-connections/#github). The walkthrough below remains GitLab-first.
 
 ### 3. Expose the worker to GitLab
 
@@ -318,64 +322,48 @@ This selects a named model profile for every review run on that code review. To 
 
 ## How it works
 
-1. A developer triggers a review from GitLab comments, GitHub pull request comments, or the GitHub **Run Review** Check Run action.
-2. ReviewPhin receives the platform webhook, validates the signature, resolves the tenant, and queues a job.
-3. The **Router** hydrates the code review: it checks out the exact commit, fetches diffs, notes, and any project instruction files.
-4. The **Reviewer** (a two-agent pipeline) analyses the changes and produces structured findings with severity, category, optional line anchors, and inline code suggestions.
-5. The **Chatter** handles follow-up replies, conversational questions, and durable project memory updates.
-6. Findings are reconciled back through the platform provider as bot-owned review output. Obsolete threads are resolved where the platform supports it; the summary comment is updated.
+A developer starts a review from a GitLab merge request or GitHub pull request. ReviewPhin resolves the configured project, checks out the requested revision, gathers the change and its surrounding context, and sends that context to the selected model.
 
-All code and data stay on your infrastructure. The worker calls the configured model API and the connected code review platform API; nothing else leaves the network.
+Findings are published through the platform's native review tools as bot-owned discussions, inline comments, suggestions, and a summary. Later reviews can focus on new changes, while replies inside existing findings continue the conversation without starting over.
+
+The ReviewPhin worker runs on infrastructure you control, but review context is sent to the model provider you configure. Review state and project memory are also sent to a hosted storage provider when you select one instead of local SQLite. Review AI-generated findings before acting on or merging them.
 
 ---
 
 ## Review pipeline
 
-ReviewPhin uses three logical components for each triggered review:
+ReviewPhin uses three logical roles across a review: the **Router** accepts and classifies work, the **Reviewer** analyses the code, and **Chatter** handles conversations and project memory.
 
-### Router
+### 1. Receive and queue
 
-The webhook handler validates the platform signature, classifies the trigger (direct mention, Check Run action, follow-up reply, or summary note reply), deduplicates concurrent jobs, and enqueues a review task. No model calls happen here.
+The Router validates the incoming platform event, resolves it to a configured tenant, and decides whether it starts a review, continues a conversation, or updates existing review state. Review jobs are persisted and deduplicated before a worker claims them. No model calls happen at this stage.
 
-### Reviewer
+### 2. Hydrate the code review
 
-The main agent runs as two sequential subagents inside a single model session:
+The worker checks out the exact commit under review and gathers the diff, relevant discussions, repository context, and project instruction files. This creates an isolated workspace for the model session.
 
-1. **context-analyst** - explores the hydrated workspace using `glob`, `ripgrep`, and file-read tools to gather the context most relevant to the changed files.
-2. **review-author** - produces structured findings: severity, category, body text, optional diff anchor, and optional inline code suggestion.
+### 3. Review
 
-The reviewer selects one of three modes based on trigger context:
+The Reviewer runs two sequential agents inside one model session:
 
-- **first-pass-full** - first review of the MR, or an explicit full rescan
-- **incremental-rereview** - focused on files changed since the last review
-- **follow-up-discussion** - scoped to one existing discussion
+1. **context-analyst** — finds the repository context most relevant to the changed files.
+2. **review-author** — produces structured findings with severity, category, an optional diff anchor, and an optional inline suggestion.
 
-### Chatter
+The Reviewer selects a mode from the trigger context:
 
-A lightweight agent that runs after the reviewer (when applicable). It handles:
+- **first-pass-full** — reviews the complete change on the first run or after an explicit full rescan.
+- **incremental-rereview** — focuses on files changed since the previous review.
+- **follow-up-discussion** — limits the pass to one existing discussion.
 
-- conversational replies to questions or wording requests
-- project memory decisions (`add_memory_entry` tool writes to the selected memory backend)
-- reply text for explicit follow-up targets
+### 4. Publish
 
-Chatter uses the `textGenerationModel` from the active profile (falling back to the review model when unset), keeping lighter interactions cheaper.
+The platform provider reconciles the structured findings with ReviewPhin's existing output. It creates or updates bot-owned discussions and the review summary, and resolves obsolete findings where the platform supports it.
 
----
+### 5. Continue conversations
 
-## Technologies
+Chatter answers replies inside ReviewPhin-owned discussions and decides whether durable project conventions should be added to memory. It uses the active profile's text-generation model, falling back to the review model when none is configured.
 
-| Layer              | Technology                                                        |
-| ------------------ | ----------------------------------------------------------------- |
-| Runtime            | Node.js 22.12+ source runtime, Node.js 26 Docker image, TypeScript 6 |
-| HTTP server        | Fastify 5                                                         |
-| AI runtime         | `@github/copilot-sdk` (Copilot CLI wrapper)                       |
-| Model APIs         | native Copilot, vLLM, Azure OpenAI, Anthropic                     |
-| Storage (default)  | SQLite via Node.js `node:sqlite`                                  |
-| Storage (optional) | Flotiq headless CMS                                               |
-| Logging            | pino (structured JSON)                                            |
-| Validation         | zod                                                               |
-| Packaging          | Docker, multi-stage build                                         |
-| Orchestration      | Helm (Kubernetes)                                                 |
+See the [technical review flow](https://reviewphin.com/docs/development/review-flow/) for queue, retry, lease, and publication details.
 
 ---
 
@@ -401,7 +389,7 @@ All variables are optional unless noted. For local Docker from source, put them 
 | `REVIEWPHIN_JOB_POLL_INTERVAL_MS`                    | `2000`                           | How often the runner polls storage for a claimable job (positive integer)          |
 | `REVIEWPHIN_MAX_QUEUED_JOB_AGE_MS`                   | `21600000`                       | Max age from original enqueue before a queued job is expired (positive integer)    |
 | `REVIEWPHIN_JOB_LEASE_MS`                            | `120000`                         | Claim lease; heartbeat renews at one third of it (minimum `1000`)                  |
-| `REVIEWPHIN_JOB_RUNNER_ENABLED`                      | `true`                           | Set `false` for HTTP-only replicas that never claim or execute jobs                 |
+| `REVIEWPHIN_JOB_RUNNER_ENABLED`                      | `true`                           | Set `false` for HTTP-only replicas that never claim or execute jobs                |
 | `COPILOT_TIMEOUT_MS`                                 | `180000`                         | Model session timeout in milliseconds                                              |
 | `COPILOT_SDK_LOG_LEVEL`                              | _(none)_                         | SDK log verbosity: `none` \| `error` \| `warning` \| `info` \| `debug` \| `all`    |
 | `COPILOT_CLI_PATH`                                   | `/usr/local/bin/copilot` (image) | Path to the Copilot CLI binary                                                     |
@@ -412,18 +400,6 @@ All variables are optional unless noted. For local Docker from source, put them 
 For model profile setup (BYOK providers, Azure OpenAI, etc.) see [Model providers](https://reviewphin.com/docs/management/model-profiles/).
 For custom storage adapters see [Storage providers](https://reviewphin.com/docs/deployment/storage/).
 For custom code review platform providers see [Code review platform providers](https://reviewphin.com/docs/development/providers/).
-
----
-
-## Routes
-
-| Method | Path                    | Description                                                                        |
-| ------ | ----------------------- | ---------------------------------------------------------------------------------- |
-| `GET`  | `/healthz`              | Liveness probe, returns `{"status":"ok"}`                                          |
-| `POST` | `/webhooks/<platform>`  | Platform webhook receiver. Built-ins use `/webhooks/gitlab` and `/webhooks/github` |
-| `*`    | `/setup/<platform>`     | Optional platform setup handler when the provider exposes one                      |
-| `GET`  | `/github/setup/samples` | Dev-server-only GitHub setup template previews with example data                   |
-| `POST` | `/webhooks/gitlab/note` | Deprecated GitLab compatibility alias                                              |
 
 ---
 
@@ -441,4 +417,4 @@ The motivation, then, is the intersection of three constraints those tools did n
 2. **Bring-your-own model, including private ones.** I wanted to point the reviewer at models hosted inside our own infrastructure - e.g. a Qwen 3 27B running on internal GPUs - to push the cost down further and keep code inside the network. ReviewPhin's harness/profile system exists primarily to make that possible.
 3. **GitLab first.** ReviewPhin starts from self-hosted GitLab in mind. Why? Because I use it as daily driver for most of my development work. (see [Code review platform providers](https://reviewphin.com/docs/development/providers/)).
 
-So: **everything is yours.** Storage, model, subscription, hosting. You know what you pay for because it's all yours - and if any of the projects above fits your team and budget better, please use them. They are great.
+So: **the deployment choices are yours.** You choose the storage, model provider, subscription, and hosting, including self-hosted options where they fit. If any of the projects above fits your team and budget better, please use it. They are great.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security policy
+
+## Report a vulnerability
+
+Please report suspected vulnerabilities through [GitHub private vulnerability reporting](https://github.com/cdwv/ReviewPhin/security/advisories/new). Do not open a public issue or discussion for a vulnerability.
+
+Include the affected component, the conditions needed to reproduce the issue, its likely impact, and a minimal reproduction when practical. Remove tokens, credentials, private repository contents, and other sensitive data before submitting the report.
+
+The maintainers will review the report and coordinate any fix and disclosure with the reporter through the private advisory. Please allow time for that process before publishing details.
+
+For setup help, feature requests, and non-sensitive bugs, use the repository's public issue tracker instead.

--- a/public/todo.html
+++ b/public/todo.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>ReviewPhin OSS launch todo</title>
+    <title>ReviewPhin open-source readiness audit</title>
     <link rel="icon" href="./favicon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -77,14 +77,14 @@
               <p class="font-data text-[11px] uppercase tracking-[0.24em] text-white/55">
                 ReviewPhin
               </p>
-              <h1 class="mt-1 text-2xl font-black tracking-tight">OSS launch board</h1>
+              <h1 class="mt-1 text-2xl font-black tracking-tight">OSS readiness board</h1>
             </div>
           </div>
 
           <div class="mt-8 border-l border-white/15 pl-4">
             <p class="max-w-[22rem] text-sm leading-6 text-white/72">
-              Public release work grouped by launch gate. Each item includes a comparison
-              project or public practice to calibrate quality.
+              A repository-specific audit, checked against the code and docs. Completed and
+              deliberately rejected ideas stay visible so the list does not regress into a generic OSS checklist.
             </p>
           </div>
 
@@ -133,8 +133,7 @@
                   Public release readiness
                 </p>
                 <h2 class="mt-2 max-w-4xl text-3xl font-black tracking-tight sm:text-4xl">
-                  Categorized todo list for making ReviewPhin understandable,
-                  trustworthy, and usable as open source.
+                  What ReviewPhin still needs, what is already in place, and what is not worth doing yet.
                 </h2>
               </div>
               <div class="grid grid-cols-3 gap-2 text-center font-data text-xs" id="miniStats"></div>
@@ -175,6 +174,7 @@
                 <select id="statusFilter" class="mt-1 h-10 w-full border border-rule bg-white px-3 text-sm">
                   <option value="open">Open</option>
                   <option value="done">Done</option>
+                  <option value="not-planned">Not planned</option>
                   <option value="all">All</option>
                 </select>
               </label>
@@ -194,7 +194,7 @@
                   Reset
                 </button>
                 <button id="resetProgress" class="h-10 border border-rule bg-white px-3 text-sm font-semibold text-ink">
-                  Clear done
+                  Reset checks
                 </button>
               </div>
             </div>
@@ -253,15 +253,15 @@
                 <div class="mt-4 space-y-3 text-sm leading-6">
                   <div class="border-l-4 border-danger bg-white px-3 py-2">
                     <strong>High</strong>
-                    <span class="block text-muted">Needed before a public GitHub launch.</span>
+                    <span class="block text-muted">A real trust, safety, or contribution blocker.</span>
                   </div>
                   <div class="border-l-4 border-warn bg-white px-3 py-2">
                     <strong>Medium</strong>
-                    <span class="block text-muted">Best first steps once people can find the project.</span>
+                    <span class="block text-muted">Important follow-up, but not a reason to delay opening the repository.</span>
                   </div>
                   <div class="border-l-4 border-mint bg-white px-3 py-2">
                     <strong>Low</strong>
-                    <span class="block text-muted">Useful polish, optional distribution, or community extras.</span>
+                    <span class="block text-muted">Only worth doing when usage creates a clear need.</span>
                   </div>
                 </div>
 
@@ -286,7 +286,8 @@
           area: "GitHub migration",
           effort: "M",
           title: "Replace GitLab CI with GitHub Actions CI",
-          reason: "A GitHub project needs visible, reproducible checks for pull requests and tags.",
+          reason: "Implemented in .github/workflows/quality-gates.yml, including lint, typecheck, builds, tests, coverage, CodeQL, and dependency review.",
+          status: "done",
           example: "Fastify and Vitest expose GitHub Actions as the normal contributor feedback loop.",
           links: [
             ["Fastify", "https://github.com/fastify/fastify"],
@@ -298,8 +299,8 @@
           priority: "High",
           area: "GitHub migration",
           effort: "M",
-          title: "Add required GitHub branch protection rules",
-          reason: "Public PRs should not merge without test, lint, and typecheck status checks.",
+          title: "Configure the documented GitHub branch protection rules",
+          reason: "The required checks are documented, but repository rulesets live in GitHub settings and cannot be verified from this checkout.",
           example: "Kubernetes uses protected branches and explicit contributor policy around merges.",
           links: [["Kubernetes", "https://github.com/kubernetes/kubernetes"]],
         },
@@ -309,7 +310,8 @@
           area: "Release and distribution",
           effort: "L",
           title: "Build tag-based release automation",
-          reason: "A public project needs repeatable GitHub Releases, Docker image publishing, and chart publishing.",
+          reason: "Implemented in .github/workflows/release.yml for tagged releases, Docker Hub images, the GHCR Helm chart, docs, and release artifacts.",
+          status: "done",
           example: "Renovate and Fastify make releases discoverable through GitHub releases and automation.",
           links: [
             ["Renovate", "https://github.com/renovatebot/renovate"],
@@ -332,8 +334,9 @@
           priority: "High",
           area: "Repository hygiene",
           effort: "S",
-          title: "Decide whether npm publishing is supported",
-          reason: "The package is currently private; either publish the CLI properly or document Docker-first distribution.",
+          title: "Document Docker-first distribution instead of npm publishing",
+          reason: "Done: the package remains private and the CLI reference explicitly says there is no separate global host installation.",
+          status: "done",
           example: "Docusaurus publishes npm packages and also documents the supported distribution path clearly.",
           links: [["Docusaurus", "https://github.com/facebook/docusaurus"]],
         },
@@ -354,7 +357,8 @@
           area: "Community health",
           effort: "S",
           title: "Add SECURITY.md",
-          reason: "This project handles tokens, webhooks, repositories, and model calls; reporters need a private path.",
+          reason: "Done: SECURITY.md routes sensitive reports to GitHub private vulnerability reporting, which is enabled for the repository.",
+          status: "done",
           example: "Fastify and Kubernetes both publish explicit security reporting policies.",
           links: [
             ["Fastify", "https://github.com/fastify/fastify/security"],
@@ -363,21 +367,22 @@
         },
         {
           id: "H08",
-          priority: "High",
+          priority: "Medium",
           area: "Community health",
           effort: "S",
-          title: "Add SUPPORT.md",
-          reason: "Users need to know where to ask setup questions and where security issues do not belong.",
+          title: "Add a concise support and version policy",
+          reason: "Explain where setup questions belong, which releases receive fixes, and where security reports must go. This can be one SUPPORT.md rather than several policy files.",
           example: "Docker docs routes feedback and support separately from security-sensitive reports.",
           links: [["Docker docs", "https://github.com/docker/docs"]],
         },
         {
           id: "H09",
-          priority: "High",
+          priority: "Medium",
           area: "Community health",
           effort: "M",
           title: "Add issue forms and a pull request template",
-          reason: "Structured reports reduce maintainer back-and-forth for installation, platform, and model-provider issues.",
+          reason: "Done: concise bug and feature forms gather safe reproduction context, security reports route to SECURITY.md, and the pull request template mirrors project validation and changelog requirements.",
+          status: "done",
           example: "Vitest and Docusaurus use templates to route bugs, features, and docs work.",
           links: [
             ["Vitest", "https://github.com/vitest-dev/vitest/tree/main/.github"],
@@ -401,7 +406,8 @@
           area: "Security",
           effort: "M",
           title: "Run secret scanning across the full history",
-          reason: "The repository has local config patterns and internal CI history; public launch should not expose old tokens.",
+          reason: "Done: checksum-verified Gitleaks scanned all refs across the full 400-commit history with redaction and found no secrets.",
+          status: "done",
           example: "Gitleaks and TruffleHog are common pre-publication checks for repos that handled credentials.",
           links: [
             ["Gitleaks", "https://github.com/gitleaks/gitleaks"],
@@ -410,11 +416,11 @@
         },
         {
           id: "H12",
-          priority: "High",
+          priority: "Medium",
           area: "Repository hygiene",
           effort: "S",
           title: "Audit tracked workspace metadata",
-          reason: "Decide whether .agents, .vscode, and skills-lock.json are intentional public project files.",
+          reason: "The repository tracks agent plans and skills, editor settings, and skills-lock.json. Keep them only if they help outside contributors and contain no private operational context.",
           example: "Docker docs keeps contributor tooling public only when it helps contributors reproduce work.",
           links: [["Docker docs", "https://github.com/docker/docs"]],
         },
@@ -424,7 +430,8 @@
           area: "Documentation",
           effort: "S",
           title: "Fix README technical inconsistencies",
-          reason: "The README storage implementation and Dockerfile SQLite environment variable were corrected during docs consolidation.",
+          reason: "Done: the storage and Docker inconsistencies identified by the earlier audit were corrected during docs consolidation.",
+          status: "done",
           example: "Vitest documentation keeps runtime and package assumptions explicit for contributors.",
           links: [["Vitest", "https://github.com/vitest-dev/vitest"]],
         },
@@ -468,8 +475,8 @@
           priority: "High",
           area: "Security",
           effort: "M",
-          title: "Harden the Docker runtime image",
-          reason: "Run as a non-root user, add OCI labels, document supported architectures, and keep only runtime files.",
+          title: "Run the Docker runtime as a non-root user",
+          reason: "The multi-stage image is already minimal, release builds add OCI labels, and amd64/arm64 are published. The remaining material hardening gap is that the runtime still runs as root.",
           example: "OpenTelemetry images publish clear container metadata and security expectations.",
           links: [["OpenTelemetry JS", "https://github.com/open-telemetry/opentelemetry-js"]],
         },
@@ -479,27 +486,30 @@
           area: "Security",
           effort: "S",
           title: "Add Dependabot or Renovate for dependency updates",
-          reason: "Public users expect dependency vulnerabilities to be visible and maintained.",
+          reason: "Implemented in .github/dependabot.yml for npm, GitHub Actions, and Docker dependencies.",
+          status: "done",
           example: "Renovate is itself a strong reference for automated dependency maintenance.",
           links: [["Renovate", "https://github.com/renovatebot/renovate"]],
         },
         {
           id: "H19",
-          priority: "High",
+          priority: "Medium",
           area: "Documentation",
-          effort: "M",
-          title: "Write a GitHub-first quickstart",
-          reason: "The launch target is GitHub, so the first path should cover GitHub App setup before GitLab.",
-          example: "Docusaurus optimizes its first-run path around the default user journey.",
-          links: [["Docusaurus docs", "https://docusaurus.io/docs"]],
+          effort: "S",
+          title: "Add a visible GitHub setup handoff to the GitLab-first README path",
+          reason: "Done: the GitLab-first quickstart now hands GitHub users to the canonical App setup instructions before the platform-specific walkthrough begins.",
+          status: "done",
+          example: "The ReviewPhin docs already give GitHub its own setup section while keeping GitLab first.",
+          links: [["Platform setup", "https://reviewphin.com/docs/management/platform-connections/"]],
         },
         {
           id: "H20",
           priority: "High",
           area: "Documentation",
           effort: "M",
-          title: "Add data handling and AI review caveats",
-          reason: "Users should understand what leaves their network, model quality limitations, and human review expectations.",
+          title: "Correct the data-flow claim and add AI review caveats",
+          reason: "Done: the README states that review context goes to the configured model provider, hosted storage receives persisted data when selected, and AI findings need human review.",
+          status: "done",
           example: "GitHub Copilot docs describe code review boundaries and user responsibility.",
           links: [["GitHub Copilot docs", "https://docs.github.com/en/copilot"]],
         },
@@ -516,11 +526,12 @@
         },
         {
           id: "H22",
-          priority: "High",
+          priority: "Medium",
           area: "Release and distribution",
           effort: "M",
-          title: "Add public badges and canonical project links",
-          reason: "README badges should point to GitHub Actions, release artifacts, license, security policy, and Docker/GHCR image.",
+          title: "Add a CI badge and canonical security link",
+          reason: "Done: the README adds one Quality Gates badge and a visible SECURITY.md link alongside the existing Docker and license badges.",
+          status: "done",
           example: "Fastify uses badges and top-level links to make project status obvious.",
           links: [["Fastify", "https://github.com/fastify/fastify"]],
         },
@@ -554,7 +565,7 @@
         },
         {
           id: "M03",
-          priority: "Medium",
+          priority: "High",
           area: "Documentation",
           effort: "M",
           title: "Add a troubleshooting guide",
@@ -580,8 +591,8 @@
           priority: "Medium",
           area: "Operations",
           effort: "M",
-          title: "Document backup, restore, upgrade, and rollback",
-          reason: "ReviewPhin stores tenants, model profiles, project memory, run logs, and publication mappings.",
+          title: "Complete restore and rollback guidance",
+          reason: "SQLite backup and storage migration are documented. Add a tested restore procedure and explain how to roll back the app when a storage contract migration has run.",
           example: "Kubernetes and database-backed OSS projects publish operational upgrade procedures.",
           links: [["Kubernetes docs", "https://kubernetes.io/docs/tasks/administer-cluster/"]],
         },
@@ -591,7 +602,8 @@
           area: "Documentation",
           effort: "S",
           title: "Add a compatibility matrix",
-          reason: "Users need a compact view of supported Node versions, platforms, storage providers, and model providers.",
+          reason: "Not planned: Node, platform, storage, and model support already have canonical pages. A second matrix would duplicate them and drift.",
+          status: "not-planned",
           example: "Vitest and Fastify document runtime support clearly around Node compatibility.",
           links: [
             ["Vitest", "https://vitest.dev/"],
@@ -604,7 +616,8 @@
           area: "Documentation",
           effort: "S",
           title: "Add a limitations page",
-          reason: "GitHub comment threading, file-level comments, auto triggers, and AI accuracy should be explicit.",
+          reason: "Not planned as a separate page. Fold material product limitations and AI caveats into the relevant workflow pages and the high-priority data-handling task.",
+          status: "not-planned",
           example: "GitHub docs often call out product limitations directly in feature docs.",
           links: [["GitHub docs", "https://docs.github.com/"]],
         },
@@ -614,7 +627,8 @@
           area: "Architecture",
           effort: "M",
           title: "Add architecture diagrams",
-          reason: "A webhook-to-worker-to-platform flow diagram will make the adapter and storage model easier to understand.",
+          reason: "Done: the review-flow docs include a webhook/CLI-to-worker-to-model-to-publication diagram and explain provider and storage behavior.",
+          status: "done",
           example: "OpenTelemetry docs rely on architecture diagrams for multi-component systems.",
           links: [["OpenTelemetry docs", "https://opentelemetry.io/docs/"]],
         },
@@ -624,7 +638,8 @@
           area: "Usability",
           effort: "L",
           title: "Create a public demo repository or mocked playground",
-          reason: "Potential users should see review output without wiring production credentials first.",
+          reason: "Not planned for launch: a maintained demo needs credentials, moderation, and representative fixtures. Screenshots provide the evaluation path with much less operational cost.",
+          status: "not-planned",
           example: "Docusaurus and many CLI projects provide templates or demos to lower evaluation cost.",
           links: [["Docusaurus examples", "https://github.com/facebook/docusaurus/tree/main/examples"]],
         },
@@ -634,7 +649,8 @@
           area: "Community health",
           effort: "S",
           title: "Enable GitHub Discussions with clear categories",
-          reason: "Questions, ideas, announcements, and setup help should not all become issues.",
+          reason: "Not planned until community volume justifies another inbox. Issues plus a clear support policy are sufficient for an early project.",
+          status: "not-planned",
           example: "Fastify uses Discussions for community support separate from bug tracking.",
           links: [["Fastify Discussions", "https://github.com/fastify/fastify/discussions"]],
         },
@@ -644,7 +660,8 @@
           area: "Community health",
           effort: "S",
           title: "Create a public label taxonomy",
-          reason: "Labels like good first issue, docs, platform:github, platform:gitlab, storage, and model-provider make work discoverable.",
+          reason: "Done: the existing contributor labels are joined by restrained platform:gitlab, platform:github, storage, and model-provider labels.",
+          status: "done",
           example: "Kubernetes uses rich labels to route issue ownership and contributor entry points.",
           links: [["Kubernetes issues", "https://github.com/kubernetes/kubernetes/issues"]],
         },
@@ -654,7 +671,8 @@
           area: "Community health",
           effort: "S",
           title: "Publish a roadmap",
-          reason: "Users should see what is planned, what is deliberately out of scope, and where help is useful.",
+          reason: "Not planned as a separate document. Public issues and milestones are easier to keep current; add a roadmap only when there is a stable multi-release plan.",
+          status: "not-planned",
           example: "Kubernetes and OpenTelemetry maintain public planning surfaces for future work.",
           links: [
             ["Kubernetes", "https://github.com/kubernetes/enhancements"],
@@ -666,8 +684,9 @@
           priority: "Medium",
           area: "Community health",
           effort: "S",
-          title: "Add release and support policy",
-          reason: "Users need to know semver expectations, supported versions, and migration commitments.",
+          title: "Add semver and migration promises to SUPPORT.md",
+          reason: "Keep this with the support/version task rather than creating another standalone policy document.",
+          status: "not-planned",
           example: "Fastify publishes long-term support and release expectations.",
           links: [["Fastify", "https://github.com/fastify/fastify"]],
         },
@@ -677,7 +696,8 @@
           area: "Community health",
           effort: "M",
           title: "Add governance and maintainer policy",
-          reason: "Even a small OSS project benefits from clear merge, release, and maintainer rules.",
+          reason: "Not planned while the project has one maintainer. CONTRIBUTING.md and CODEOWNERS cover the current workflow; formal governance should follow shared ownership.",
+          status: "not-planned",
           example: "Fastify and Kubernetes both publish governance models appropriate to their scale.",
           links: [
             ["Fastify governance", "https://github.com/fastify/fastify/blob/main/GOVERNANCE.md"],
@@ -690,7 +710,8 @@
           area: "Security",
           effort: "M",
           title: "Add CodeQL, dependency review, and OpenSSF Scorecard",
-          reason: "These checks build trust and catch common repository and code security issues.",
+          reason: "Implemented in the pull-request quality gates and scheduled security workflow.",
+          status: "done",
           example: "OpenSSF Scorecard is built specifically to measure open source security posture.",
           links: [
             ["Scorecard", "https://github.com/ossf/scorecard"],
@@ -699,7 +720,7 @@
         },
         {
           id: "M16",
-          priority: "Medium",
+          priority: "Low",
           area: "Security",
           effort: "L",
           title: "Publish SBOMs and artifact attestations",
@@ -716,7 +737,8 @@
           area: "Release and distribution",
           effort: "M",
           title: "Publish multi-architecture container images",
-          reason: "Users running ARM servers, Apple Silicon, and Kubernetes nodes should not build their own image.",
+          reason: "Implemented: release.yml publishes linux/amd64 and linux/arm64 images.",
+          status: "done",
           example: "Docker official images commonly publish linux/amd64 and linux/arm64 variants.",
           links: [["Docker buildx", "https://docs.docker.com/build/building/multi-platform/"]],
         },
@@ -737,7 +759,8 @@
           area: "Extensibility",
           effort: "L",
           title: "Add a PostgreSQL storage adapter",
-          reason: "SQLite is good for a start, but production operators often standardize on Postgres.",
+          reason: "Not planned in core: the documented storage contract already supports third-party PostgreSQL adapters, while SQLite and Flotiq cover the maintained built-ins.",
+          status: "not-planned",
           example: "Many self-hosted OSS apps support SQLite for simple installs and Postgres for production.",
           links: [["Django", "https://github.com/django/django"]],
         },
@@ -747,7 +770,8 @@
           area: "Developer experience",
           effort: "M",
           title: "Add Dev Container or Codespaces setup",
-          reason: "Contributors can run tests and preview setup screens without manually preparing Node and pnpm.",
+          reason: "Not planned: local setup is already Node plus Corepack/pnpm, and maintaining another development image is not justified yet.",
+          status: "not-planned",
           example: "GitHub Codespaces examples and many docs projects make browser-based contribution possible.",
           links: [["Codespaces docs", "https://docs.github.com/en/codespaces"]],
         },
@@ -777,7 +801,8 @@
           area: "Documentation",
           effort: "M",
           title: "Add reverse proxy examples",
-          reason: "Caddy, nginx, Cloudflare Tunnel, and ngrok examples would reduce setup friction.",
+          reason: "Not planned as copied configuration: the docs already cover tunnels, TLS proxies, Ingress, and Gateway API. Vendor-specific snippets would become another security-sensitive maintenance surface.",
+          status: "not-planned",
           example: "Docker docs commonly include compose and proxy snippets for deployment paths.",
           links: [["Docker docs", "https://docs.docker.com/"]],
         },
@@ -787,7 +812,8 @@
           area: "Extensibility",
           effort: "M",
           title: "Add adapter starter templates",
-          reason: "Platform and storage provider interfaces are documented, but examples make contribution practical.",
+          reason: "Not planned yet: custom-provider docs and maintained built-in adapters are better references. Extract templates only after an external adapter exposes repeated friction.",
+          status: "not-planned",
           example: "Fastify plugin examples show how template code accelerates ecosystem contributions.",
           links: [["Fastify plugins", "https://github.com/fastify/fastify-plugin"]],
         },
@@ -797,7 +823,8 @@
           area: "Testing and quality",
           effort: "M",
           title: "Add release smoke tests",
-          reason: "CI should verify the built Docker image starts, serves /healthz, and exposes the CLI.",
+          reason: "Implemented in release.yml: the built image must start, answer /healthz, and run reviewphin --help before publishing.",
+          status: "done",
           example: "Docker-based OSS projects commonly smoke-test images before publishing.",
           links: [["Docker docs", "https://docs.docker.com/build/ci/"]],
         },
@@ -807,7 +834,8 @@
           area: "Testing and quality",
           effort: "M",
           title: "Publish coverage trend or coverage artifact",
-          reason: "The project has a broad test suite; public signal helps contributors understand expectations.",
+          reason: "Implemented: pull requests and releases upload the Vitest coverage report as a workflow artifact.",
+          status: "done",
           example: "Vitest and many JS projects publish coverage artifacts or badges.",
           links: [["Vitest", "https://github.com/vitest-dev/vitest"]],
         },
@@ -826,10 +854,14 @@
           priority: "Low",
           area: "Community growth",
           effort: "S",
-          title: "Add FUNDING.yml",
-          reason: "Funding links are useful if sponsorship or paid support becomes part of the project.",
-          example: "Fastify exposes sponsorship options without making them part of basic setup.",
-          links: [["Fastify sponsors", "https://github.com/sponsors/fastify"]],
+          title: "Add FUNDING.yml for the maintainer's GitHub Sponsors profile",
+          reason: "Done: .github/FUNDING.yml points GitHub's sponsor button to @rgembalik.",
+          status: "done",
+          example: "GitHub surfaces FUNDING.yml links without requiring funding copy throughout the README or docs.",
+          links: [
+            ["Sponsor @rgembalik", "https://github.com/sponsors/rgembalik"],
+            ["GitHub docs", "https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository"],
+          ],
         },
         {
           id: "L02",
@@ -850,7 +882,8 @@
           area: "Documentation",
           effort: "M",
           title: "Record a short setup video",
-          reason: "Video helps evaluation, but text docs should carry the project first.",
+          reason: "Not planned: setup behavior is still evolving, and searchable text plus screenshots are cheaper to keep accurate.",
+          status: "not-planned",
           example: "Many developer tools use videos as secondary onboarding material after docs.",
           links: [["Docker docs", "https://docs.docker.com/"]],
         },
@@ -860,7 +893,8 @@
           area: "Documentation",
           effort: "M",
           title: "Add docs style guide",
-          reason: "A style guide is useful once external contributors regularly edit docs.",
+          reason: "Done at the appropriate depth: the contributing-to-docs page defines the docs workflow, ordering, voice, links, and verification expectations.",
+          status: "done",
           example: "Docker docs maintains contribution and writing guidance for docs quality.",
           links: [["Docker docs", "https://github.com/docker/docs"]],
         },
@@ -891,7 +925,8 @@
           area: "Documentation",
           effort: "XL",
           title: "Localize documentation",
-          reason: "Translation can wait until there is stable English documentation and active demand.",
+          reason: "Not planned until the English docs stabilize and contributors volunteer to own translations.",
+          status: "not-planned",
           example: "Kubernetes localizes docs after the core documentation structure is mature.",
           links: [["Kubernetes docs", "https://kubernetes.io/docs/"]],
         },
@@ -901,7 +936,8 @@
           area: "Community growth",
           effort: "S",
           title: "Add all-contributors or contributor credits automation",
-          reason: "Useful for community recognition once external contributions start.",
+          reason: "Not planned: Git history and release notes provide credit without adding a bot and generated metadata. Reassess if contributors ask for broader recognition.",
+          status: "not-planned",
           example: "The all-contributors bot is common in community-oriented OSS projects.",
           links: [["All Contributors", "https://allcontributors.org/"]],
         },
@@ -911,7 +947,8 @@
           area: "Community growth",
           effort: "S",
           title: "Avoid or delay stale bot automation",
-          reason: "Stale bots can harm small communities if issues are closed before maintainers have capacity.",
+          reason: "Not a todo. The decision is simply to avoid stale automation while issue volume is low.",
+          status: "not-planned",
           example: "Large repos use automation selectively; small projects often do better with manual triage first.",
           links: [["Kubernetes issues", "https://github.com/kubernetes/kubernetes/issues"]],
         },
@@ -921,7 +958,8 @@
           area: "Release and distribution",
           effort: "M",
           title: "Package the CLI for Homebrew or Scoop",
-          reason: "Useful if the CLI becomes a common local operator workflow; unnecessary for Docker-first use.",
+          reason: "Not planned because Docker is the supported distribution. Reconsider only if a standalone host CLI becomes a supported product path.",
+          status: "not-planned",
           example: "Many mature CLIs add package-manager distribution after demand exists.",
           links: [["Homebrew", "https://brew.sh/"]],
         },
@@ -931,7 +969,8 @@
           area: "Operations",
           effort: "L",
           title: "Add Terraform modules",
-          reason: "Infrastructure modules are helpful only after the recommended production topology stabilizes.",
+          reason: "Not planned in core. ReviewPhin ships a Helm chart; cloud-specific infrastructure should be demand-led and can live in separate repositories.",
+          status: "not-planned",
           example: "Kubernetes ecosystem projects often add Terraform later through community demand.",
           links: [["Terraform Registry", "https://registry.terraform.io/"]],
         },
@@ -941,7 +980,8 @@
           area: "Documentation",
           effort: "M",
           title: "Create public case studies or adopter notes",
-          reason: "Real usage stories help trust, but they require users and consent.",
+          reason: "Not planned until adopters volunteer real, consented stories. This is outreach, not repository readiness.",
+          status: "not-planned",
           example: "Kubernetes and OpenTelemetry publish user stories once adoption is broad.",
           links: [
             ["Kubernetes case studies", "https://kubernetes.io/case-studies/"],
@@ -954,7 +994,8 @@
           area: "Testing and quality",
           effort: "M",
           title: "Add benchmark documentation",
-          reason: "Benchmarks are only valuable once workloads and deployment recommendations are stable.",
+          reason: "Not planned because ReviewPhin makes no performance claim and model latency dominates most runs. A benchmark would currently create a misleading comparison.",
+          status: "not-planned",
           example: "Fastify publishes benchmarks because performance is a core product claim.",
           links: [["Fastify benchmarks", "https://github.com/fastify/benchmarks"]],
         },
@@ -964,7 +1005,8 @@
           area: "Documentation",
           effort: "M",
           title: "Publish changelog as a docs page",
-          reason: "GitHub releases and CHANGELOG.md are enough at launch; a searchable page helps later.",
+          reason: "Not planned: the docs already link to the canonical CHANGELOG.md, avoiding a duplicated release-history surface.",
+          status: "not-planned",
           example: "Docusaurus projects commonly expose versioned release notes in docs.",
           links: [["Docusaurus", "https://docusaurus.io/"]],
         },
@@ -974,7 +1016,8 @@
           area: "Extensibility",
           effort: "M",
           title: "Add OpenAPI documentation for HTTP routes",
-          reason: "The public API is mostly webhooks and setup routes, so OpenAPI can wait unless external integrations grow.",
+          reason: "Not planned: these are provider-owned webhook and setup endpoints, not a supported third-party REST API.",
+          status: "not-planned",
           example: "API-heavy projects publish OpenAPI specs when third-party clients are expected.",
           links: [["OpenAPI", "https://www.openapis.org/"]],
         },
@@ -984,7 +1027,8 @@
           area: "Branding",
           effort: "M",
           title: "Polish a lightweight public website",
-          reason: "A website can help discovery, but the working docs and README matter more first.",
+          reason: "Done: the Astro/Starlight build includes a public homepage and documentation site at reviewphin.com.",
+          status: "done",
           example: "Fastify and Docusaurus have public sites once the project identity is stable.",
           links: [
             ["Fastify site", "https://fastify.dev/"],
@@ -1005,8 +1049,7 @@
 
       const priorityRank = { High: 0, Medium: 1, Low: 2 };
       const effortRank = { XS: 0, S: 1, M: 2, L: 3, XL: 4 };
-      const progressKey = "reviewphin-oss-launch-board-v1";
-      localStorage.removeItem(progressKey);
+      const initialTaskStatus = new Map(tasks.map((task) => [task.id, task.status ?? "open"]));
       const state = {
         query: "",
         priority: "All",
@@ -1067,6 +1110,14 @@
         return task.status === "done";
       }
 
+      function isTaskNotPlanned(task) {
+        return task.status === "not-planned";
+      }
+
+      function isTaskOpen(task) {
+        return !isTaskDone(task) && !isTaskNotPlanned(task);
+      }
+
       function taskMatches(task) {
         const haystack = [
           task.id,
@@ -1082,7 +1133,8 @@
         const statusMatch =
           state.status === "all" ||
           (state.status === "done" && isTaskDone(task)) ||
-          (state.status === "open" && !isTaskDone(task));
+          (state.status === "not-planned" && isTaskNotPlanned(task)) ||
+          (state.status === "open" && isTaskOpen(task));
 
         return (
           (state.priority === "All" || task.priority === state.priority) &&
@@ -1125,17 +1177,22 @@
         els.rows.innerHTML = visible
           .map((task) => {
             const done = isTaskDone(task);
+            const notPlanned = isTaskNotPlanned(task);
             const classes = priorityClasses(task.priority);
             return `
-              <tr class="border-l-4 ${classes.rail} ${done ? "bg-[#f2f4ef] opacity-60" : "bg-white/85"} hover:bg-[#f9fbf5]">
+              <tr class="border-l-4 ${classes.rail} ${done || notPlanned ? "bg-[#f2f4ef] opacity-60" : "bg-white/85"} hover:bg-[#f9fbf5]">
                 <td class="align-top px-3 py-4">
-                  <input
-                    type="checkbox"
-                    class="h-4 w-4 accent-signal"
-                    data-task-id="${escapeHtml(task.id)}"
-                    ${done ? "checked" : ""}
-                    aria-label="Mark ${escapeHtml(task.title)} done"
-                  />
+                  ${
+                    notPlanned
+                      ? '<span class="font-data text-xs font-bold text-muted" title="Not planned">—</span>'
+                      : `<input
+                          type="checkbox"
+                          class="h-4 w-4 accent-signal"
+                          data-task-id="${escapeHtml(task.id)}"
+                          ${done ? "checked" : ""}
+                          aria-label="Mark ${escapeHtml(task.title)} done"
+                        />`
+                  }
                 </td>
                 <td class="align-top px-3 py-4">
                   <span class="inline-flex min-w-20 items-center justify-center border px-2 py-1 font-data text-[11px] font-semibold ${classes.badge}">
@@ -1147,7 +1204,7 @@
                   <span class="font-data text-xs font-semibold text-ink">${escapeHtml(task.area)}</span>
                 </td>
                 <td class="max-w-xl align-top px-3 py-4">
-                  <p class="font-semibold leading-5 ${done ? "line-through decoration-2 decoration-muted" : ""}">
+                  <p class="font-semibold leading-5 ${done || notPlanned ? "line-through decoration-2 decoration-muted" : ""}">
                     ${escapeHtml(task.title)}
                   </p>
                   <p class="mt-1 leading-6 text-muted">${escapeHtml(task.reason)}</p>
@@ -1172,10 +1229,11 @@
 
       function renderStats(visible) {
         const doneCount = tasks.filter(isTaskDone).length;
-        const allOpen = tasks.length - doneCount;
-        const highOpen = tasks.filter((task) => task.priority === "High" && !isTaskDone(task)).length;
-        const mediumOpen = tasks.filter((task) => task.priority === "Medium" && !isTaskDone(task)).length;
-        const lowOpen = tasks.filter((task) => task.priority === "Low" && !isTaskDone(task)).length;
+        const notPlannedCount = tasks.filter(isTaskNotPlanned).length;
+        const allOpen = tasks.filter(isTaskOpen).length;
+        const highOpen = tasks.filter((task) => task.priority === "High" && isTaskOpen(task)).length;
+        const mediumOpen = tasks.filter((task) => task.priority === "Medium" && isTaskOpen(task)).length;
+        const lowOpen = tasks.filter((task) => task.priority === "Low" && isTaskOpen(task)).length;
 
         els.prioritySummary.innerHTML = [
           ["High", highOpen, "Before launch"],
@@ -1198,9 +1256,9 @@
           .join("");
 
         els.miniStats.innerHTML = [
-          ["Total", tasks.length],
           ["Open", allOpen],
           ["Done", doneCount],
+          ["Skipped", notPlannedCount],
         ]
           .map(
             ([label, count]) => `
@@ -1213,10 +1271,11 @@
           .join("");
 
         const visibleDone = visible.filter(isTaskDone).length;
+        const visibleNotPlanned = visible.filter(isTaskNotPlanned).length;
         els.viewStats.innerHTML = [
           ["Showing", visible.length],
           ["Done here", visibleDone],
-          ["High open", highOpen],
+          ["Skipped here", visibleNotPlanned],
           ["All open", allOpen],
         ]
           .map(
@@ -1232,7 +1291,9 @@
         document.querySelectorAll(".quickPriority").forEach((button) => {
           button.addEventListener("click", () => {
             state.priority = button.dataset.priority;
+            state.status = "open";
             els.priority.value = state.priority;
+            els.status.value = state.status;
             renderRows();
           });
         });
@@ -1273,6 +1334,8 @@
               state.area = value;
               els.area.value = value;
             }
+            state.status = "open";
+            els.status.value = state.status;
             renderRows();
           });
         });
@@ -1314,6 +1377,9 @@
           renderRows();
         });
         els.resetProgress.addEventListener("click", () => {
+          tasks.forEach((task) => {
+            task.status = initialTaskStatus.get(task.id);
+          });
           renderRows();
         });
         els.rows.addEventListener("change", (event) => {

--- a/scripts/build-docker-readme.cjs
+++ b/scripts/build-docker-readme.cjs
@@ -2,6 +2,7 @@ const fs = require("node:fs");
 
 const CANONICAL_DOCS_URL = "https://reviewphin.com";
 const CANONICAL_REPOSITORY_URL = "https://github.com/cdwv/ReviewPhin";
+const DOCKERHUB_FULL_DESCRIPTION_MAX_CHARACTERS = 25_000;
 const DOCKER_IMAGE_BADGE_MARKDOWN =
   "[![Docker Image](https://img.shields.io/badge/docker-cdwv%2Freviewphin-blue?logo=docker)](https://hub.docker.com/r/cdwv/reviewphin)";
 
@@ -124,6 +125,13 @@ content = content.replace(/\[([^\]]*)\]\(([^)]+)\)/g, (match, text, href) => {
   }
   return match;
 });
+
+const characterCount = Array.from(content).length;
+if (characterCount > DOCKERHUB_FULL_DESCRIPTION_MAX_CHARACTERS) {
+  throw new Error(
+    `Docker Hub repository overview is ${characterCount} characters, exceeding the ${DOCKERHUB_FULL_DESCRIPTION_MAX_CHARACTERS}-character limit by ${characterCount - DOCKERHUB_FULL_DESCRIPTION_MAX_CHARACTERS}`,
+  );
+}
 
 fs.writeFileSync("DOCKERHUB_README.md", content, "utf8");
 console.log("DOCKERHUB_README.md generated successfully");

--- a/test/docker-readme.test.ts
+++ b/test/docker-readme.test.ts
@@ -99,6 +99,21 @@ describe("Docker Hub README generation", () => {
       "[License](https://github.example.test/acme/reviewphin/blob/v1.2.3/LICENSE)",
     );
   });
+
+  it("accepts a transformed README at Docker Hub's character limit", async () => {
+    const output = await generateDockerReadme("a".repeat(25_000));
+
+    expect(Array.from(output)).toHaveLength(25_000);
+  });
+
+  it("rejects a README that exceeds the limit only after transformation", async () => {
+    const readme = "[License](LICENSE)\n".repeat(400).trim();
+
+    expect(Array.from(readme).length).toBeLessThan(25_000);
+    await expect(generateDockerReadme(readme)).rejects.toThrow(
+      /Docker Hub repository overview is \d+ characters, exceeding the 25000-character limit by \d+/,
+    );
+  });
 });
 
 async function generateDockerReadme(


### PR DESCRIPTION
## Summary

- correct the README's model and storage data-flow boundary, add a human-review caveat, and preserve the GitLab-first setup path with an early GitHub App handoff
- add the security policy, private vulnerability-reporting route, funding configuration, issue forms, pull request template, Quality Gates badge, and security link
- keep the Docker Hub README within its 25,000-character limit and test the transformed output boundary
- update the public readiness audit only for completed work, add the missing repository labels, and enable GitHub private vulnerability reporting and secret scanning

## Validation

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm test` (473 tests)
- [x] `pnpm docs:build`
- [x] Inline `public/todo.html` script parsing
- [x] `git diff --check`
- [x] Checksum-verified Gitleaks scan across all refs and 400 commits (zero findings)
- [x] Tests cover the Docker Hub README boundary behavior
- [x] Documentation reflects the user-facing changes
- [x] The change contains no credentials, private code, or sensitive logs

## Changelog

<details><summary>Changelog: patch</summary>

### Added

- Contributors and security researchers now have structured public templates and a private vulnerability-reporting path.

### Changed

- The README now explains configured-provider data flows, human review responsibility, GitHub setup, CI status, and security guidance more clearly.

### Fixed

- Docker Hub README generation now rejects descriptions that exceed the platform's 25,000-character limit.

</details>
