### PR TITLE
fix(docker): restore v1.4.0 image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,5 @@
-FROM node:24-bookworm-slim@sha256:6f7b03f7c2c8e2e784dcf9295400527b9b1270fd37b7e9a7285cf83b6951452d AS base
+FROM node:26-bookworm-slim AS build
 
-ENV PNPM_HOME=/pnpm \
-  PATH=/pnpm/bin:/pnpm:$PATH \
-  COREPACK_HOME=/opt/corepack
-
-RUN corepack enable \
-  && corepack install --global pnpm@10.18.2
-
-FROM base AS build
 
 ARG REVIEWPHIN_BUILD_HOMEPAGE=false
 ARG REVIEWPHIN_POSTHOG_KEY=
@@ -15,6 +7,12 @@ ARG REVIEWPHIN_POSTHOG_HOST=
 ENV REVIEWPHIN_BUILD_HOMEPAGE=${REVIEWPHIN_BUILD_HOMEPAGE} \
   REVIEWPHIN_POSTHOG_KEY=${REVIEWPHIN_POSTHOG_KEY} \
   REVIEWPHIN_POSTHOG_HOST=${REVIEWPHIN_POSTHOG_HOST}
+
+ENV PNPM_HOME=/pnpm
+ENV PATH=$PNPM_HOME:$PATH
+
+RUN npm install --global corepack@latest \
+  && corepack enable
 
 WORKDIR /app
 
@@ -30,7 +28,9 @@ RUN pnpm install --frozen-lockfile \
   && pnpm docs:build:container \
   && pnpm prune --prod
 
-FROM base AS runtime
+FROM node:26-bookworm-slim AS runtime
+
+ARG COPILOT_CLI_VERSION=1.0.70
 
 ENV NODE_ENV=production \
   HOST=0.0.0.0 \
@@ -45,8 +45,7 @@ ENV NODE_ENV=production \
 
 RUN apt-get update \
   && apt-get install --yes --no-install-recommends ca-certificates git \
-  && pnpm add --global --global-bin-dir /pnpm @github/copilot@1.0.70 \
-  && ln -s /pnpm/copilot /usr/local/bin/copilot \
+  && npm install --global @github/copilot@${COPILOT_CLI_VERSION} \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/docs/src/content/docs/deployment/docker.md
+++ b/docs/src/content/docs/deployment/docker.md
@@ -59,10 +59,10 @@ A local Docker host is not reachable by your platform yet. For a quick trial, op
 
 The repository ships a multi-stage `Dockerfile`. The compose file builds it locally as `reviewphin:local`; `docker compose up --build` rebuilds after source changes.
 
-The runtime stage pins the bundled Copilot CLI version for reproducible images. Build it with:
+The runtime stage pins the bundled Copilot CLI to a fixed version for reproducible images. It defaults to `1.0.70` and can be overridden at build time:
 
 ```bash
-docker build --tag reviewphin:local .
+docker build --build-arg COPILOT_CLI_VERSION=1.0.70 -t reviewphin:local .
 ```
 
-The image installs `@github/copilot` `1.0.70` globally with pnpm and exposes it at `/usr/local/bin/copilot`. Update the pinned version in the `Dockerfile` when intentionally upgrading the CLI.
+The image installs `@github/copilot` at that version and points `COPILOT_CLI_PATH` at `/usr/local/bin/copilot`. CLI `1.0.70` is the dependency resolved for the bundled `@github/copilot-sdk` `1.0.6`.


### PR DESCRIPTION
## Summary

- restore the Docker image build used by ReviewPhin 1.4.0
- return to separate Node 26 build and runtime stages
- restore the global Corepack and Copilot CLI installation paths
- restore the documented `COPILOT_CLI_VERSION` build argument

## Validation

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm docs:build`
- [x] Dockerfile behavior matches `v1.4.0`
- [ ] local Docker build unavailable because Docker Desktop is not running

<details><summary>Changelog: patch</summary>

### Fixed

- Container images now use the working Docker configuration from ReviewPhin 1.4.0 again.

</details>
