### PR TITLE
fix: react to every trigger comment

### DIFF
--- a/.agents/plans/3.interaction-admission-grouping-and-revisions.html
+++ b/.agents/plans/3.interaction-admission-grouping-and-revisions.html
@@ -139,8 +139,8 @@
             </li>
             <li>Reply to every comment that needs a reply.</li>
             <li>
-              Give every triggering comment the correct queued, running,
-              success, or failure signal when its platform supports one.
+              Keep every unique triggering comment so ReviewPhin can show its
+              queued, running, success, or failure state.
             </li>
           </ul>
         </section>
@@ -223,8 +223,9 @@
             <li>
               <div>
                 <strong>Build and run the grouped work.</strong> Merge the
-                request types, keep all replies, and update the status of all
-                triggers.
+                request types, keep all replies, and preserve every unique
+                triggering comment so its visual feedback follows the grouped
+                job.
               </div>
             </li>
             <li>

--- a/.agents/plans/index.html
+++ b/.agents/plans/index.html
@@ -15,7 +15,7 @@
             ><span class="brand-mark">◉</span><span>ReviewPhin plans</span></a
           >
           <p class="rail-label">Checked</p>
-          <p class="rail-value">16 July 2026</p>
+          <p class="rail-value">19 July 2026</p>
           <p class="rail-label">Database format</p>
           <p class="rail-value">storage-v006</p>
           <nav class="toc" aria-label="On this page">
@@ -29,19 +29,19 @@
       <main id="content">
         <header class="hero">
           <p class="eyebrow">Work we want to do</p>
-          <h1>Six plans, in the order that matters most.</h1>
+          <h1>Five plans, in the order that matters most.</h1>
           <p class="lede">
             Start at the top. The first plans fix things that can confuse users
             or produce bad review results. The last plans improve the code and
             make ReviewPhin cheaper to run.
           </p>
           <div class="meta-grid">
-            <div class="meta-item"><span>Plans</span><strong>6</strong></div>
+            <div class="meta-item"><span>Plans</span><strong>5</strong></div>
             <div class="meta-item">
               <span>Most urgent</span><strong>Safe publication</strong>
             </div>
             <div class="meta-item">
-              <span>Plans needing new database data</span><strong>2</strong>
+              <span>Plans needing new database data</span><strong>1</strong>
             </div>
             <div class="meta-item">
               <span>First place to start</span><strong>Plan 2</strong>
@@ -163,14 +163,6 @@
                 <td>
                   No database change. This work changes API loading and code
                   types.
-                </td>
-              </tr>
-              <tr>
-                <td>7. Usage metrics</td>
-                <td>
-                  Replace one premium-request row per interaction with
-                  unit-aware records for every harness session. Migrate old rows
-                  without losing their counters or timestamps.
                 </td>
               </tr>
             </tbody>

--- a/docs/src/content/docs/using-reviewphin/comments-and-triggers.md
+++ b/docs/src/content/docs/using-reviewphin/comments-and-triggers.md
@@ -66,6 +66,22 @@ Selects a named [model profile](../../management/model-profiles/) for every run 
 
 </details>
 
+## See when ReviewPhin is working
+
+When ReviewPhin accepts a comment, it tries to add a reaction to that comment. The reaction gives you quick visual feedback while the review runs.
+
+| Status           | GitLab        | GitHub         |
+| ---------------- | ------------- | -------------- |
+| Looking at it    | 👀 Eyes       | 👀 Eyes        |
+| Finished         | ✅ Check mark | 🎉 Celebration |
+| Could not finish | 😖 Confounded | 😕 Confused    |
+
+The eyes reaction stays when ReviewPhin adds the final reaction. "Could not finish" also covers reviews that were cancelled or expired.
+
+Reactions are best-effort feedback. A reaction may be missing if the comment was deleted, permissions changed, or the platform rejected it. ReviewPhin may still process the review.
+
+This feedback applies only when there is a platform comment to react to. GitHub's **Run Review** action uses the check run status instead. A local trigger written as plain text also has no comment reaction.
+
 ## Platform notes
 
 | Command                      | GitLab                 | GitHub                                  |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -51,7 +51,7 @@ import {
   initializePlatformRegistry,
 } from "./platforms/platform-registry.js";
 import type { LocalReviewSelector } from "./platforms/IPlatform.js";
-import { syncPlatformTriggerLifecycle } from "./platforms/trigger-lifecycle.js";
+import { syncPlatformTriggerLifecycleForJob } from "./platforms/trigger-lifecycle.js";
 import { TenantRegistry } from "./tenants/tenant-registry.js";
 import {
   buildReviewWatchSummary,
@@ -1921,17 +1921,16 @@ async function runMergeRequestReviewCommand(
       ...interactionJob,
       tenantId: resolvedTenant.tenant.id,
     });
-    if (submitted.created) {
+    if (submitted.created || submitted.job.commentId !== null) {
       const lifecycle = platform.createTriggerLifecycle({
         resolvedTenant,
         job: submitted.job,
         logger,
       });
-      await syncPlatformTriggerLifecycle({
+      await syncPlatformTriggerLifecycleForJob({
         logger,
         job: submitted.job,
-        phase: "queued",
-        update: () => lifecycle.queued(),
+        lifecycle,
       });
     }
 

--- a/src/jobs/review-worker.ts
+++ b/src/jobs/review-worker.ts
@@ -9,7 +9,10 @@ import type {
   ResolvedTenant,
 } from "../platforms/IPlatform.js";
 import { getPlatformBySlug } from "../platforms/platform-registry.js";
-import { syncPlatformTriggerLifecycle } from "../platforms/trigger-lifecycle.js";
+import {
+  syncPlatformTriggerLifecycle,
+  syncPlatformTriggerLifecycleForJob,
+} from "../platforms/trigger-lifecycle.js";
 import type {
   DiscussionReconciler,
   ReconcileSummary,
@@ -149,21 +152,52 @@ export class ReviewWorker {
       payloadJson: interactionJob.payloadJson,
     });
 
-    if (createdJob.created) {
+    if (createdJob.created || createdJob.job.commentId !== null) {
       const lifecycle = platform.createTriggerLifecycle({
         resolvedTenant,
         job: createdJob.job,
         logger: this.logger,
       });
-      await syncPlatformTriggerLifecycle({
+      await syncPlatformTriggerLifecycleForJob({
         logger: this.logger,
         job: createdJob.job,
-        phase: "queued",
-        update: () => lifecycle.queued(),
+        lifecycle,
       });
     }
 
     return createdJob;
+  }
+
+  public async reconcileTriggerLifecycle(
+    job: InteractionJobRecord,
+  ): Promise<void> {
+    try {
+      const resolvedTenant = await this.tenantRegistry.getResolvedTenantById(
+        job.tenantId,
+      );
+      if (!resolvedTenant) {
+        return;
+      }
+      const platform = this.platformResolver(resolvedTenant.tenant.platform);
+      if (!platform) {
+        return;
+      }
+      const lifecycle = platform.createTriggerLifecycle({
+        resolvedTenant,
+        job,
+        logger: this.logger,
+      });
+      await syncPlatformTriggerLifecycleForJob({
+        logger: this.logger,
+        job,
+        lifecycle,
+      });
+    } catch (error) {
+      this.logger.warn(
+        { err: error, interactionJobId: job.id, status: job.status },
+        "failed to reconcile provider trigger lifecycle from job state",
+      );
+    }
   }
 
   public async classifyWebhookTrigger(

--- a/src/jobs/review-worker.ts
+++ b/src/jobs/review-worker.ts
@@ -152,18 +152,16 @@ export class ReviewWorker {
       payloadJson: interactionJob.payloadJson,
     });
 
-    if (createdJob.created || createdJob.job.commentId !== null) {
-      const lifecycle = platform.createTriggerLifecycle({
-        resolvedTenant,
-        job: createdJob.job,
-        logger: this.logger,
-      });
-      await syncPlatformTriggerLifecycleForJob({
-        logger: this.logger,
-        job: createdJob.job,
-        lifecycle,
-      });
-    }
+    const lifecycle = platform.createTriggerLifecycle({
+      resolvedTenant,
+      job: createdJob.job,
+      logger: this.logger,
+    });
+    await syncPlatformTriggerLifecycleForJob({
+      logger: this.logger,
+      job: createdJob.job,
+      lifecycle,
+    });
 
     return createdJob;
   }

--- a/src/jobs/storage-backed-job-runner.ts
+++ b/src/jobs/storage-backed-job-runner.ts
@@ -20,10 +20,12 @@ export interface StorageBackedJobRunnerOptions {
   workerId?: string | undefined;
   expireBatchLimit?: number | undefined;
   orphanReconcileLimit?: number | undefined;
+  triggerLifecycleShutdownGraceMs?: number | undefined;
 }
 
 const DEFAULT_EXPIRE_BATCH_LIMIT = 100;
 const DEFAULT_ORPHAN_RECONCILE_LIMIT = 100;
+const DEFAULT_TRIGGER_LIFECYCLE_SHUTDOWN_GRACE_MS = 5_000;
 
 /**
  * Polls the claim-aware interaction-job store and drives the {@link ReviewWorker}
@@ -44,6 +46,7 @@ export class StorageBackedJobRunner {
   private readonly maxJobRetries: number;
   private readonly expireBatchLimit: number;
   private readonly orphanReconcileLimit: number;
+  private readonly triggerLifecycleShutdownGraceMs: number;
 
   public readonly workerId: string;
 
@@ -52,6 +55,7 @@ export class StorageBackedJobRunner {
   private timer: NodeJS.Timeout | null = null;
   private inFlight: Promise<void> = Promise.resolve();
   private triggerLifecycleReconciliation: Promise<void> = Promise.resolve();
+  private triggerLifecycleReconciliationGeneration = 0;
 
   public constructor(options: StorageBackedJobRunnerOptions) {
     this.storage = options.storage;
@@ -66,6 +70,9 @@ export class StorageBackedJobRunner {
       options.expireBatchLimit ?? DEFAULT_EXPIRE_BATCH_LIMIT;
     this.orphanReconcileLimit =
       options.orphanReconcileLimit ?? DEFAULT_ORPHAN_RECONCILE_LIMIT;
+    this.triggerLifecycleShutdownGraceMs =
+      options.triggerLifecycleShutdownGraceMs ??
+      DEFAULT_TRIGGER_LIFECYCLE_SHUTDOWN_GRACE_MS;
     this.workerId = options.workerId ?? createId("worker");
   }
 
@@ -86,12 +93,13 @@ export class StorageBackedJobRunner {
    */
   public async stop(): Promise<void> {
     this.stopping = true;
+    this.triggerLifecycleReconciliationGeneration += 1;
     if (this.timer) {
       clearTimeout(this.timer);
       this.timer = null;
     }
     await this.inFlight.catch(() => undefined);
-    await this.triggerLifecycleReconciliation.catch(() => undefined);
+    await this.waitForTriggerLifecycleReconciliation();
     this.started = false;
   }
 
@@ -241,19 +249,48 @@ export class StorageBackedJobRunner {
   private queueTriggerLifecycleReconciliation(
     jobs: readonly InteractionJobRecord[],
   ): void {
-    this.triggerLifecycleReconciliation =
-      this.triggerLifecycleReconciliation
-        .then(async () => {
-          for (const job of jobs) {
-            await this.worker.reconcileTriggerLifecycle(job);
+    if (this.stopping) {
+      return;
+    }
+    const generation = this.triggerLifecycleReconciliationGeneration;
+    this.triggerLifecycleReconciliation = this.triggerLifecycleReconciliation
+      .then(async () => {
+        for (const job of jobs) {
+          if (generation !== this.triggerLifecycleReconciliationGeneration) {
+            return;
           }
-        })
-        .catch((error: unknown) => {
-          this.logger.warn(
-            { err: error },
-            "failed to reconcile expired job trigger lifecycle",
-          );
-        });
+          await this.worker.reconcileTriggerLifecycle(job);
+        }
+      })
+      .catch((error: unknown) => {
+        this.logger.warn(
+          { err: error },
+          "failed to reconcile expired job trigger lifecycle",
+        );
+      });
+  }
+
+  private async waitForTriggerLifecycleReconciliation(): Promise<void> {
+    let timeout: NodeJS.Timeout | null = null;
+    const completed = await Promise.race([
+      this.triggerLifecycleReconciliation.then(() => true),
+      new Promise<boolean>((resolve) => {
+        timeout = setTimeout(
+          () => resolve(false),
+          this.triggerLifecycleShutdownGraceMs,
+        );
+      }),
+    ]);
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+    if (!completed) {
+      this.logger.warn(
+        { graceMs: this.triggerLifecycleShutdownGraceMs },
+        "stopped waiting for best-effort trigger lifecycle reconciliation",
+      );
+      this.triggerLifecycleReconciliation = Promise.resolve();
+    }
   }
 
   private async processClaimed(

--- a/src/jobs/storage-backed-job-runner.ts
+++ b/src/jobs/storage-backed-job-runner.ts
@@ -51,6 +51,7 @@ export class StorageBackedJobRunner {
   private stopping = false;
   private timer: NodeJS.Timeout | null = null;
   private inFlight: Promise<void> = Promise.resolve();
+  private triggerLifecycleReconciliation: Promise<void> = Promise.resolve();
 
   public constructor(options: StorageBackedJobRunnerOptions) {
     this.storage = options.storage;
@@ -90,6 +91,7 @@ export class StorageBackedJobRunner {
       this.timer = null;
     }
     await this.inFlight.catch(() => undefined);
+    await this.triggerLifecycleReconciliation.catch(() => undefined);
     this.started = false;
   }
 
@@ -150,9 +152,7 @@ export class StorageBackedJobRunner {
         page: 1,
         pageSize: this.expireBatchLimit,
       });
-      for (const expiredJob of expiredJobs) {
-        await this.worker.reconcileTriggerLifecycle(expiredJob);
-      }
+      this.queueTriggerLifecycleReconciliation(expiredJobs);
     }
 
     await this.reconcileOrphans();
@@ -236,6 +236,24 @@ export class StorageBackedJobRunner {
     for (const run of runs) {
       await this.worker.reconcileOrphanLifecycle(run);
     }
+  }
+
+  private queueTriggerLifecycleReconciliation(
+    jobs: readonly InteractionJobRecord[],
+  ): void {
+    this.triggerLifecycleReconciliation =
+      this.triggerLifecycleReconciliation
+        .then(async () => {
+          for (const job of jobs) {
+            await this.worker.reconcileTriggerLifecycle(job);
+          }
+        })
+        .catch((error: unknown) => {
+          this.logger.warn(
+            { err: error },
+            "failed to reconcile expired job trigger lifecycle",
+          );
+        });
   }
 
   private async processClaimed(

--- a/src/jobs/storage-backed-job-runner.ts
+++ b/src/jobs/storage-backed-job-runner.ts
@@ -132,12 +132,28 @@ export class StorageBackedJobRunner {
       maintenanceNowMs - this.maxQueuedJobAgeMs,
     ).toISOString();
 
-    await this.storage.stores.interactionJobs.expireQueued({
-      now: maintenanceNow,
-      queuedBefore,
-      reason: `Queued job expired after exceeding the maximum age of ${this.maxQueuedJobAgeMs}ms.`,
-      limit: this.expireBatchLimit,
-    });
+    const expiredCount = await this.storage.stores.interactionJobs.expireQueued(
+      {
+        now: maintenanceNow,
+        queuedBefore,
+        reason: `Queued job expired after exceeding the maximum age of ${this.maxQueuedJobAgeMs}ms.`,
+        limit: this.expireBatchLimit,
+      },
+    );
+    if (expiredCount > 0) {
+      const expiredJobs = await this.storage.stores.interactionJobs.list({
+        filters: {
+          status: { eq: "expired" },
+          finishedAt: { eq: maintenanceNow },
+        },
+        order: [{ field: "id", direction: "asc" }],
+        page: 1,
+        pageSize: this.expireBatchLimit,
+      });
+      for (const expiredJob of expiredJobs) {
+        await this.worker.reconcileTriggerLifecycle(expiredJob);
+      }
+    }
 
     await this.reconcileOrphans();
 

--- a/src/platforms/github/client.ts
+++ b/src/platforms/github/client.ts
@@ -846,6 +846,40 @@ export class GitHubClient {
     );
   }
 
+  public async listPullRequestReviewCommentReactions(
+    repositoryFullName: string,
+    commentId: number,
+  ): Promise<GitHubReaction[]> {
+    return this.paginate(
+      repositoryFullName,
+      "GET /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions",
+      { comment_id: commentId },
+      reactionSchema,
+      `reactions for GitHub pull request review comment ${commentId}`,
+    );
+  }
+
+  public async createPullRequestReviewCommentReaction(input: {
+    repositoryFullName: string;
+    commentId: number;
+    content: GitHubReaction["content"];
+  }): Promise<GitHubReaction> {
+    const { owner, repository } = splitRepositoryFullName(
+      input.repositoryFullName,
+    );
+    return this.requestParsed(
+      "POST /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions",
+      {
+        owner,
+        repo: repository,
+        comment_id: input.commentId,
+        content: input.content,
+      },
+      reactionSchema,
+      `reaction for GitHub pull request review comment ${input.commentId}`,
+    );
+  }
+
   public async downloadRepositoryArchive(
     repositoryFullName: string,
     ref: string,

--- a/src/platforms/github/trigger-lifecycle.ts
+++ b/src/platforms/github/trigger-lifecycle.ts
@@ -150,14 +150,16 @@ export class GitHubCommentTriggerLifecycle implements PlatformTriggerLifecycle {
   private async ensureReaction(
     content: GitHubReaction["content"],
   ): Promise<void> {
-    if (this.trigger.eventName !== "issue_comment") {
-      return;
-    }
-
-    const existing = await this.client.listIssueCommentReactions(
-      this.tenant.repositoryFullName,
-      this.trigger.commentId,
-    );
+    const existing =
+      this.trigger.eventName === "pull_request_review_comment"
+        ? await this.client.listPullRequestReviewCommentReactions(
+            this.tenant.repositoryFullName,
+            this.trigger.commentId,
+          )
+        : await this.client.listIssueCommentReactions(
+            this.tenant.repositoryFullName,
+            this.trigger.commentId,
+          );
     if (
       existing.some(
         (reaction) =>
@@ -168,11 +170,16 @@ export class GitHubCommentTriggerLifecycle implements PlatformTriggerLifecycle {
       return;
     }
 
-    await this.client.createIssueCommentReaction({
+    const input = {
       repositoryFullName: this.tenant.repositoryFullName,
       commentId: this.trigger.commentId,
       content,
-    });
+    };
+    if (this.trigger.eventName === "pull_request_review_comment") {
+      await this.client.createPullRequestReviewCommentReaction(input);
+    } else {
+      await this.client.createIssueCommentReaction(input);
+    }
   }
 }
 

--- a/src/platforms/gitlab/trigger-lifecycle.ts
+++ b/src/platforms/gitlab/trigger-lifecycle.ts
@@ -87,10 +87,6 @@ export class GitLabTriggerLifecycle implements PlatformTriggerLifecycle {
 
   private async ensureReaction(reactionName: string): Promise<void> {
     const comment = await this.resolveComment();
-    if (comment.kind === "discussion-comment") {
-      return;
-    }
-
     const tenantConfig = getGitLabTenantConfig(this.resolvedTenant.tenant);
     const existing = await this.client.listTriggerNoteAwardEmojis(
       tenantConfig.projectId,

--- a/src/platforms/trigger-lifecycle.ts
+++ b/src/platforms/trigger-lifecycle.ts
@@ -37,3 +37,47 @@ export async function syncPlatformTriggerLifecycle(input: {
     );
   }
 }
+
+export async function syncPlatformTriggerLifecycleForJob(input: {
+  logger: Logger;
+  job: InteractionJobRecord;
+  lifecycle: PlatformTriggerLifecycle;
+}): Promise<void> {
+  const error =
+    input.job.lastError ?? "ReviewPhin could not complete the requested work.";
+  switch (input.job.status) {
+    case "queued":
+      await syncPlatformTriggerLifecycle({
+        logger: input.logger,
+        job: input.job,
+        phase: "queued",
+        update: () => input.lifecycle.queued(),
+      });
+      return;
+    case "in_progress":
+      await syncPlatformTriggerLifecycle({
+        logger: input.logger,
+        job: input.job,
+        phase: "in_progress",
+        update: () => input.lifecycle.inProgress(),
+      });
+      return;
+    case "completed":
+      await syncPlatformTriggerLifecycle({
+        logger: input.logger,
+        job: input.job,
+        phase: "completed",
+        update: () => input.lifecycle.completed(),
+      });
+      return;
+    case "failed":
+    case "cancelled":
+    case "expired":
+      await syncPlatformTriggerLifecycle({
+        logger: input.logger,
+        job: input.job,
+        phase: input.job.status,
+        update: () => input.lifecycle.failed(error),
+      });
+  }
+}

--- a/test/github-client.test.ts
+++ b/test/github-client.test.ts
@@ -296,6 +296,49 @@ describe("GitHubClient", () => {
     );
   });
 
+  it("lists and creates pull request review comment reactions", async () => {
+    const request = vi.fn(async (route: string) => {
+      if (route.startsWith("GET")) {
+        return { data: [createReaction("eyes")] };
+      }
+      return { data: createReaction("hooray") };
+    });
+    const client = createClientWithInstallationRequest(request);
+
+    await expect(
+      client.listPullRequestReviewCommentReactions("octo-org/reviewphin", 555),
+    ).resolves.toMatchObject([{ content: "eyes" }]);
+    await expect(
+      client.createPullRequestReviewCommentReaction({
+        repositoryFullName: "octo-org/reviewphin",
+        commentId: 555,
+        content: "hooray",
+      }),
+    ).resolves.toMatchObject({ content: "hooray" });
+
+    expect(request).toHaveBeenNthCalledWith(
+      1,
+      "GET /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions",
+      {
+        owner: "octo-org",
+        repo: "reviewphin",
+        comment_id: 555,
+        per_page: 100,
+        page: 1,
+      },
+    );
+    expect(request).toHaveBeenNthCalledWith(
+      2,
+      "POST /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions",
+      {
+        owner: "octo-org",
+        repo: "reviewphin",
+        comment_id: 555,
+        content: "hooray",
+      },
+    );
+  });
+
   it("downloads repository archives as buffers", async () => {
     const request = vi.fn(async () => ({
       data: Uint8Array.from([31, 139, 8, 0]),

--- a/test/github-trigger-lifecycle.test.ts
+++ b/test/github-trigger-lifecycle.test.ts
@@ -170,11 +170,23 @@ describe("GitHub comment trigger lifecycle", () => {
     );
   });
 
-  it("skips inline review comment reactions like GitLab discussion comments", async () => {
-    const listIssueCommentReactions = vi.fn();
-    const createIssueCommentReaction = vi.fn();
+  it("adds reactions to inline pull request review comments", async () => {
+    const listPullRequestReviewCommentReactions = vi
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    const createPullRequestReviewCommentReaction = vi.fn(async (input) => ({
+      id: 2,
+      content: input.content,
+      user: { id: 10, login: "reviewphin-octo[bot]", type: "Bot" },
+      created_at: "2026-06-11T00:00:00.000Z",
+    }));
     const lifecycle = new GitHubCommentTriggerLifecycle(
-      { listIssueCommentReactions, createIssueCommentReaction } as never,
+      {
+        listPullRequestReviewCommentReactions,
+        createPullRequestReviewCommentReaction,
+      } as never,
       {
         repositoryId: 2468,
         repositoryFullName: "octo-org/reviewphin",
@@ -187,8 +199,16 @@ describe("GitHub comment trigger lifecycle", () => {
     await lifecycle.completed();
     await lifecycle.failed();
 
-    expect(listIssueCommentReactions).not.toHaveBeenCalled();
-    expect(createIssueCommentReaction).not.toHaveBeenCalled();
+    expect(listPullRequestReviewCommentReactions).toHaveBeenCalledTimes(3);
+    expect(createPullRequestReviewCommentReaction).toHaveBeenCalledWith(
+      expect.objectContaining({ commentId: 555, content: "eyes" }),
+    );
+    expect(createPullRequestReviewCommentReaction).toHaveBeenCalledWith(
+      expect.objectContaining({ commentId: 555, content: "hooray" }),
+    );
+    expect(createPullRequestReviewCommentReaction).toHaveBeenCalledWith(
+      expect.objectContaining({ commentId: 555, content: "confused" }),
+    );
   });
 });
 

--- a/test/gitlab-reactions.test.ts
+++ b/test/gitlab-reactions.test.ts
@@ -543,7 +543,7 @@ describe("GitLab reactions", () => {
     );
   });
 
-  it("skips reactions for follow-up discussion notes", async () => {
+  it("adds reactions to follow-up discussion notes", async () => {
     const discussions = [
       {
         id: "disc_1",
@@ -571,6 +571,7 @@ describe("GitLab reactions", () => {
       },
     ] satisfies GitLabDiscussion[];
 
+    const deliveredReactions = new Set<string>();
     const fetchMock = vi.fn(
       async (input: URL | RequestInfo, init?: RequestInit) => {
         const url = String(input);
@@ -590,10 +591,32 @@ describe("GitLab reactions", () => {
           });
         }
 
+        if (init?.method === "GET" && url.includes("/award_emoji")) {
+          return new Response(
+            JSON.stringify(
+              [...deliveredReactions].map((name, index) => ({
+                id: index + 1,
+                name,
+                user: {
+                  id: 999,
+                  username: "review-bot",
+                  name: "Review Bot",
+                },
+                created_at: new Date().toISOString(),
+              })),
+            ),
+            {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            },
+          );
+        }
+
         const body = String(init?.body);
         const reactionName = body.includes("white_check_mark")
           ? "white_check_mark"
           : "eyes";
+        deliveredReactions.add(reactionName);
         return new Response(
           JSON.stringify({
             id: reactionName === "eyes" ? 1 : 2,
@@ -635,11 +658,18 @@ describe("GitLab reactions", () => {
     );
     await worker.processClaimedJob(job as never, createClaimContext(job.id));
 
-    const awardEmojiRequests = fetchMock.mock.calls.filter(([input]) =>
-      String(input).includes("/award_emoji"),
+    const awardEmojiPosts = fetchMock.mock.calls.filter(
+      ([input, init]) =>
+        init?.method === "POST" && String(input).includes("/award_emoji"),
     );
-
-    expect(awardEmojiRequests).toEqual([]);
+    expect(awardEmojiPosts.map(([input]) => String(input))).toEqual([
+      expect.stringContaining("/discussions/disc_1/notes/56/award_emoji"),
+      expect.stringContaining("/discussions/disc_1/notes/56/award_emoji"),
+    ]);
+    expect(awardEmojiPosts.map(([, init]) => String(init?.body))).toEqual([
+      expect.stringContaining("name=eyes"),
+      expect.stringContaining("name=white_check_mark"),
+    ]);
   });
 
   it("does not fail job creation when a lifecycle update fails", async () => {

--- a/test/review-worker-trigger-lifecycle.test.ts
+++ b/test/review-worker-trigger-lifecycle.test.ts
@@ -9,6 +9,80 @@ import type {
 import { createClaimContext } from "./helpers/claim.js";
 
 describe("ReviewWorker provider trigger lifecycle", () => {
+  it("reapplies the terminal reaction when a duplicate comment webhook finds a completed job", async () => {
+    const lifecycle: PlatformTriggerLifecycle = {
+      queued: vi.fn(async () => {}),
+      inProgress: vi.fn(async () => {}),
+      completed: vi.fn(async () => {}),
+      retry: vi.fn(async () => {}),
+      failed: vi.fn(async () => {}),
+    };
+    const job = {
+      id: "job-duplicate",
+      tenantId: "tenant-github",
+      dedupeKey: "dedupe-comment",
+      codeReviewId: 42,
+      commentId: 555,
+      triggerJson: '{"kind":"github-comment"}',
+      headSha: "abc123",
+      status: "completed" as const,
+      payloadJson: "{}",
+      retryCount: 0,
+      lastError: null,
+      enqueuedAt: "2026-06-11T00:00:00.000Z",
+      availableAt: "2026-06-11T00:00:00.000Z",
+      startedAt: "2026-06-11T00:00:01.000Z",
+      finishedAt: "2026-06-11T00:01:00.000Z",
+      claimToken: null,
+      claimedBy: null,
+      claimExpiresAt: null,
+      latestInteractionRunId: "run-1",
+    };
+    const platform = {
+      createInteractionJob: vi.fn(async () => ({
+        dedupeKey: job.dedupeKey,
+        codeReviewId: job.codeReviewId,
+        commentId: job.commentId,
+        triggerJson: job.triggerJson,
+        headSha: job.headSha,
+        payloadJson: job.payloadJson,
+      })),
+      createTriggerLifecycle: vi.fn(() => lifecycle),
+    } as unknown as IPlatform;
+    const worker = new ReviewWorker({
+      storage: {
+        createOrGetInteractionJob: vi.fn(async () => ({
+          job,
+          created: false,
+        })),
+      } as never,
+      tenantRegistry: {} as never,
+      reviewProviderFactory: {} as never,
+      chatterRunnerFactory: {} as never,
+      reconciler: {} as never,
+      logger: createLogger("silent"),
+      runLogDir: "tmp/test-trigger-lifecycle",
+      maxJobRetries: 3,
+      retryBackoffMs: 1000,
+      platformResolver: () => platform,
+    });
+
+    await worker.createInteractionJobFromWebhook(
+      {},
+      {
+        tenant: { id: job.tenantId, platform: "github" } as never,
+        connection: { id: "connection-github" } as never,
+      },
+      {
+        kind: "direct-mention",
+        comment: { kind: "code-review-comment", commentId: job.commentId },
+      },
+    );
+
+    expect(lifecycle.completed).toHaveBeenCalledTimes(1);
+    expect(lifecycle.queued).not.toHaveBeenCalled();
+  });
+
   it("processes commentless jobs and keeps lifecycle failures out of job retry logic", async () => {
     const lifecycle: PlatformTriggerLifecycle = {
       queued: vi.fn(async () => {}),

--- a/test/review-worker-trigger-lifecycle.test.ts
+++ b/test/review-worker-trigger-lifecycle.test.ts
@@ -6,82 +6,116 @@ import type {
   IPlatform,
   PlatformTriggerLifecycle,
 } from "../src/platforms/IPlatform.js";
+import type { WebhookReviewTrigger } from "../src/review/types.js";
 import { createClaimContext } from "./helpers/claim.js";
 
 describe("ReviewWorker provider trigger lifecycle", () => {
-  it("reapplies the terminal reaction when a duplicate comment webhook finds a completed job", async () => {
-    const lifecycle: PlatformTriggerLifecycle = {
-      queued: vi.fn(async () => {}),
-      inProgress: vi.fn(async () => {}),
-      completed: vi.fn(async () => {}),
-      retry: vi.fn(async () => {}),
-      failed: vi.fn(async () => {}),
-    };
-    const job = {
-      id: "job-duplicate",
-      tenantId: "tenant-github",
-      dedupeKey: "dedupe-comment",
-      codeReviewId: 42,
+  const duplicateWebhookCases: Array<{
+    source: string;
+    commentId: number | null;
+    triggerJson: string;
+    trigger: WebhookReviewTrigger;
+  }> = [
+    {
+      source: "comment",
       commentId: 555,
       triggerJson: '{"kind":"github-comment"}',
-      headSha: "abc123",
-      status: "completed" as const,
-      payloadJson: "{}",
-      retryCount: 0,
-      lastError: null,
-      enqueuedAt: "2026-06-11T00:00:00.000Z",
-      availableAt: "2026-06-11T00:00:00.000Z",
-      startedAt: "2026-06-11T00:00:01.000Z",
-      finishedAt: "2026-06-11T00:01:00.000Z",
-      claimToken: null,
-      claimedBy: null,
-      claimExpiresAt: null,
-      latestInteractionRunId: "run-1",
-    };
-    const platform = {
-      createInteractionJob: vi.fn(async () => ({
-        dedupeKey: job.dedupeKey,
-        codeReviewId: job.codeReviewId,
-        commentId: job.commentId,
-        triggerJson: job.triggerJson,
-        headSha: job.headSha,
-        payloadJson: job.payloadJson,
-      })),
-      createTriggerLifecycle: vi.fn(() => lifecycle),
-    } as unknown as IPlatform;
-    const worker = new ReviewWorker({
-      storage: {
-        createOrGetInteractionJob: vi.fn(async () => ({
-          job,
-          created: false,
-        })),
-      } as never,
-      tenantRegistry: {} as never,
-      reviewProviderFactory: {} as never,
-      chatterRunnerFactory: {} as never,
-      reconciler: {} as never,
-      logger: createLogger("silent"),
-      runLogDir: "tmp/test-trigger-lifecycle",
-      maxJobRetries: 3,
-      retryBackoffMs: 1000,
-      platformResolver: () => platform,
-    });
-
-    await worker.createInteractionJobFromWebhook(
-      {},
-      {
-        tenant: { id: job.tenantId, platform: "github" } as never,
-        connection: { id: "connection-github" } as never,
-      },
-      {
+      trigger: {
         kind: "direct-mention",
-        comment: { kind: "code-review-comment", commentId: job.commentId },
+        comment: { kind: "code-review-comment", commentId: 555 },
       },
-    );
+    },
+    {
+      source: "check run",
+      commentId: null,
+      triggerJson: JSON.stringify({
+        kind: "github-check-run",
+        deliveryId: "delivery-1",
+        checkRunId: 1357,
+        actionIdentifier: "run_review",
+        repositoryId: 2468,
+      }),
+      trigger: {
+        kind: "check-run-requested-action",
+        checkRunId: 1357,
+        actionIdentifier: "run_review",
+      },
+    },
+  ];
 
-    expect(lifecycle.completed).toHaveBeenCalledTimes(1);
-    expect(lifecycle.queued).not.toHaveBeenCalled();
-  });
+  it.each(duplicateWebhookCases)(
+    "reapplies the terminal lifecycle when a duplicate $source webhook finds a completed job",
+    async ({ commentId, triggerJson, trigger }) => {
+      const lifecycle: PlatformTriggerLifecycle = {
+        queued: vi.fn(async () => {}),
+        inProgress: vi.fn(async () => {}),
+        completed: vi.fn(async () => {}),
+        retry: vi.fn(async () => {}),
+        failed: vi.fn(async () => {}),
+      };
+      const job = {
+        id: "job-duplicate",
+        tenantId: "tenant-github",
+        dedupeKey: "dedupe-comment",
+        codeReviewId: 42,
+        commentId,
+        triggerJson,
+        headSha: "abc123",
+        status: "completed" as const,
+        payloadJson: "{}",
+        retryCount: 0,
+        lastError: null,
+        enqueuedAt: "2026-06-11T00:00:00.000Z",
+        availableAt: "2026-06-11T00:00:00.000Z",
+        startedAt: "2026-06-11T00:00:01.000Z",
+        finishedAt: "2026-06-11T00:01:00.000Z",
+        claimToken: null,
+        claimedBy: null,
+        claimExpiresAt: null,
+        latestInteractionRunId: "run-1",
+      };
+      const platform = {
+        createInteractionJob: vi.fn(async () => ({
+          dedupeKey: job.dedupeKey,
+          codeReviewId: job.codeReviewId,
+          commentId: job.commentId,
+          triggerJson: job.triggerJson,
+          headSha: job.headSha,
+          payloadJson: job.payloadJson,
+        })),
+        createTriggerLifecycle: vi.fn(() => lifecycle),
+      } as unknown as IPlatform;
+      const worker = new ReviewWorker({
+        storage: {
+          createOrGetInteractionJob: vi.fn(async () => ({
+            job,
+            created: false,
+          })),
+        } as never,
+        tenantRegistry: {} as never,
+        reviewProviderFactory: {} as never,
+        chatterRunnerFactory: {} as never,
+        reconciler: {} as never,
+        logger: createLogger("silent"),
+        runLogDir: "tmp/test-trigger-lifecycle",
+        maxJobRetries: 3,
+        retryBackoffMs: 1000,
+        platformResolver: () => platform,
+      });
+
+      await worker.createInteractionJobFromWebhook(
+        {},
+        {
+          tenant: { id: job.tenantId, platform: "github" } as never,
+          connection: { id: "connection-github" } as never,
+        },
+        trigger,
+      );
+
+      expect(lifecycle.completed).toHaveBeenCalledTimes(1);
+      expect(lifecycle.queued).not.toHaveBeenCalled();
+    },
+  );
 
   it("processes commentless jobs and keeps lifecycle failures out of job retry logic", async () => {
     const lifecycle: PlatformTriggerLifecycle = {

--- a/test/storage-backed-job-runner.test.ts
+++ b/test/storage-backed-job-runner.test.ts
@@ -338,6 +338,49 @@ describe("StorageBackedJobRunner heartbeat and lifecycle", () => {
     expect(claimNext).toHaveBeenCalledTimes(1);
   });
 
+  it("bounds shutdown while expired trigger feedback is pending", async () => {
+    vi.useFakeTimers();
+    try {
+      const expiredJob = { id: "job-expired", status: "expired" };
+      const store = fakeStore({
+        expireQueued: vi.fn(async () => 1),
+        list: vi.fn(async () => [expiredJob]),
+      });
+      const worker = {
+        processClaimedJob: vi.fn(),
+        reconcileOrphanLifecycle: vi.fn(),
+        reconcileTriggerLifecycle: vi.fn(
+          () => new Promise<void>(() => {}),
+        ),
+      };
+      const runner = new StorageBackedJobRunner({
+        storage: { stores: { interactionJobs: store } } as never,
+        worker: worker as never,
+        logger,
+        pollIntervalMs: 2_000,
+        maxQueuedJobAgeMs: 21_600_000,
+        leaseMs: 120_000,
+        maxJobRetries: 3,
+        triggerLifecycleShutdownGraceMs: 50,
+      });
+
+      await runner.runOnce();
+      const stopPromise = runner.stop();
+      await vi.advanceTimersByTimeAsync(49);
+      let stopped = false;
+      void stopPromise.then(() => {
+        stopped = true;
+      });
+      expect(stopped).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await stopPromise;
+      expect(stopped).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("aborts a hung renewal at the local lease deadline without overlapping renewals", async () => {
     vi.useFakeTimers();
     try {

--- a/test/storage-backed-job-runner.test.ts
+++ b/test/storage-backed-job-runner.test.ts
@@ -102,6 +102,7 @@ describe("StorageBackedJobRunner (sqlite)", () => {
         },
       ),
       reconcileOrphanLifecycle: vi.fn(async () => {}),
+      reconcileTriggerLifecycle: vi.fn(async () => {}),
     };
   }
 
@@ -163,7 +164,8 @@ describe("StorageBackedJobRunner (sqlite)", () => {
       }),
     );
     const processed: InteractionJobRecord[] = [];
-    const runner = createRunner(completingWorker(processed));
+    const worker = completingWorker(processed);
+    const runner = createRunner(worker);
 
     await runner.runOnce();
 
@@ -171,6 +173,9 @@ describe("StorageBackedJobRunner (sqlite)", () => {
     const job = await harness.storage.stores.interactionJobs.get("job-old");
     expect(job?.status).toBe("expired");
     expect(job?.lastError).toContain("maximum age");
+    expect(worker.reconcileTriggerLifecycle).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "job-old", status: "expired" }),
+    );
   });
 
   it("reconciles orphaned runs even when no new job can be claimed", async () => {

--- a/test/storage-backed-job-runner.test.ts
+++ b/test/storage-backed-job-runner.test.ts
@@ -307,6 +307,37 @@ describe("StorageBackedJobRunner heartbeat and lifecycle", () => {
     expect(processClaimedJob).toHaveBeenCalledTimes(1);
   });
 
+  it("does not delay job claiming while expired trigger feedback is pending", async () => {
+    const expiredJob = { id: "job-expired", status: "expired" };
+    const claimNext = vi.fn(async () => null);
+    const store = fakeStore({
+      expireQueued: vi.fn(async () => 1),
+      list: vi.fn(async () => [expiredJob]),
+      claimNext,
+    });
+    const worker = {
+      processClaimedJob: vi.fn(),
+      reconcileOrphanLifecycle: vi.fn(),
+      reconcileTriggerLifecycle: vi.fn(
+        () => new Promise<void>(() => {}),
+      ),
+    };
+    const runner = new StorageBackedJobRunner({
+      storage: { stores: { interactionJobs: store } } as never,
+      worker: worker as never,
+      logger,
+      pollIntervalMs: 2_000,
+      maxQueuedJobAgeMs: 21_600_000,
+      leaseMs: 120_000,
+      maxJobRetries: 3,
+    });
+
+    await runner.runOnce();
+
+    expect(worker.reconcileTriggerLifecycle).toHaveBeenCalledWith(expiredJob);
+    expect(claimNext).toHaveBeenCalledTimes(1);
+  });
+
   it("aborts a hung renewal at the local lease deadline without overlapping renewals", async () => {
     vi.useFakeTimers();
     try {


### PR DESCRIPTION
## Summary

- Apply prompt eyes and terminal reactions to GitHub issue comments, GitHub inline review comments, GitLab merge-request notes, and GitLab discussion replies.
- Reconcile visual feedback from duplicate webhook or local comment submissions and newly expired jobs without adding durable delivery state.
- Restore stale GitHub check-run status when a duplicate **Run Review** delivery arrives.
- Keep expiry feedback off the queue claim path and bound its shutdown grace period so provider delays cannot block graceful shutdown.
- Document the reaction states and their best-effort behavior.
- Remove completed implementation-plan entries and retain grouped-trigger feedback requirements.

## Validation

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 489 tests passed
- [x] `pnpm build`
- [x] `pnpm docs:build`
- [x] Tests cover new or changed behavior
- [x] Documentation reflects user-facing changes
- [x] The change contains no credentials, private code, or sensitive logs

## Review findings

ReviewPhin reported two medium findings. Both were verified against the current code and fixed:

- Duplicate GitHub check-run deliveries now reapply the stored job's lifecycle state.
- Best-effort expiry feedback receives a bounded shutdown grace period, and queued feedback stops when shutdown begins.

## Changelog

<details><summary>Changelog: patch</summary>

### Fixed

- ReviewPhin now shows visual feedback for inline and follow-up comment requests and safely retries it when duplicate events arrive.

</details>
