### PR TITLE
Keep review summaries focused on overall PR state

### DIFF
--- a/prompts/review/main.md
+++ b/prompts/review/main.md
@@ -12,7 +12,9 @@ For standalone unused-code cleanup findings, follow instruction precedence from 
 
 `reviewTrigger` is the latest explicit user request. Follow its instruction when it is compatible with the code and review evidence.
 
-Use `overview` to summarize the code review overall, assess merge readiness with a confidence level, and optionally include a few concise highlights that would help a human reviewer scan the result quickly.
+Use `overview` to describe the current overall state of the entire code review, regardless of this pass's inspection scope. It must stand alone, not summarize only the latest pass.
+
+When `reviewScope.previousReview.overviewSummary` is present, treat it as a draft: preserve what remains true, revise it with the latest evidence and prior-finding state, and remove what is stale. Return one rewritten summary, not an appended update or review history.
 
 When continuing an existing bot-owned discussion, set `priorDiscussionId` on the finding instead of creating a duplicate discussion.
 

--- a/prompts/review/main.md
+++ b/prompts/review/main.md
@@ -12,7 +12,7 @@ For standalone unused-code cleanup findings, follow instruction precedence from 
 
 `reviewTrigger` is the latest explicit user request. Follow its instruction when it is compatible with the code and review evidence.
 
-Use `overview` to describe the current overall state of the entire code review, regardless of this pass's inspection scope. It must stand alone, not summarize only the latest pass.
+Use `overview` to describe the current overall state of the entire code review, assess merge readiness with confidence, and include concise highlights when useful. It must stand alone, regardless of this pass's inspection scope, and not summarize only the latest pass.
 
 When `reviewScope.previousReview.overviewSummary` is present, treat it as a draft: preserve what remains true, revise it with the latest evidence and prior-finding state, and remove what is stale. Return one rewritten summary, not an appended update or review history.
 

--- a/test/review-prompt.test.ts
+++ b/test/review-prompt.test.ts
@@ -167,6 +167,48 @@ describe("buildReviewPrompt", () => {
     );
   });
 
+  it.each([
+    "first-pass-full",
+    "incremental-rereview",
+    "follow-up-discussion",
+  ] as const)(
+    "requires %s overviews to summarize the entire code review",
+    (mode) => {
+      const context = createContext(
+        null,
+        mode === "follow-up-discussion"
+          ? "follow-up-comment"
+          : "direct-mention",
+        mode,
+      );
+      context.scope.previousReview = {
+        reviewRunId: "run_previous",
+        reviewedAt: "2026-07-13T09:00:00.000Z",
+        headSha: "previous-head",
+        overviewSummary: "Adds tenant-scoped review synchronization.",
+        mergeReadiness: null,
+      };
+
+      const prompt = buildReviewPrompt(context);
+
+      expect(prompt).toContain(
+        "current overall state of the entire code review",
+      );
+      expect(prompt).toContain(
+        "It must stand alone, not summarize only the latest pass.",
+      );
+      expect(prompt).toContain(
+        "treat it as a draft: preserve what remains true",
+      );
+      expect(prompt).toContain(
+        "Return one rewritten summary, not an appended update or review history.",
+      );
+      expect(prompt).toContain(
+        '"overviewSummary": "Adds tenant-scoped review synchronization."',
+      );
+    },
+  );
+
   it("includes prior finding history with status and resolve resolution schema", () => {
     const prompt = buildReviewPrompt(
       createContext(null, "direct-mention", "incremental-rereview"),

--- a/test/review-prompt.test.ts
+++ b/test/review-prompt.test.ts
@@ -194,8 +194,10 @@ describe("buildReviewPrompt", () => {
       expect(prompt).toContain(
         "current overall state of the entire code review",
       );
+      expect(prompt).toContain("assess merge readiness with confidence");
+      expect(prompt).toContain("include concise highlights when useful");
       expect(prompt).toContain(
-        "It must stand alone, not summarize only the latest pass.",
+        "It must stand alone, regardless of this pass's inspection scope",
       );
       expect(prompt).toContain(
         "treat it as a draft: preserve what remains true",


### PR DESCRIPTION
## Summary

- Make review overviews describe the current overall state of the entire pull or merge request, even when the latest review pass is incremental or focused.
- Carry the previous overview forward as a draft, preserving valid context while replacing stale conclusions.
- Retain merge-readiness confidence and concise highlights in the reviewer contract.

## Validation

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm test` (492 tests)
- [x] `pnpm docs:build`
- [x] Tests cover the changed prompt behavior across full, incremental, and focused review modes
- [x] The change contains no credentials, private code, or sensitive logs

Documentation changes are not required because this adjusts generated review wording without changing setup, configuration, or the documented review workflow.

## Changelog

<details><summary>Changelog: patch</summary>

### Fixed

- Review summaries now describe the current overall state of the pull or merge request after incremental and focused reviews.

</details>
