### PR TITLE
Add local no-publish CLI review reports

### DIFF
--- a/.agents/plans/9.no-publish-cli-reviews.html
+++ b/.agents/plans/9.no-publish-cli-reviews.html
@@ -28,13 +28,15 @@
       </aside>
       <main id="content">
         <header class="hero">
-          <p class="eyebrow">Plan 09 · local CLI</p>
+          <p class="eyebrow">Plan 09 · local CLI test</p>
           <h1>Review a remote change without writing back to its platform.</h1>
           <p class="lede">
             The CLI can submit a review of an existing merge request or pull
             request, but a successful run follows the normal publication path.
             Operators need a mode that reads remote context, runs the model, and
-            shows the result locally while guaranteeing zero remote mutations.
+            acts as a local test: it delivers the result locally while
+            guaranteeing zero platform mutations and retaining the result in
+            ReviewPhin storage.
           </p>
           <div class="meta-grid">
             <div class="meta-item">
@@ -47,14 +49,19 @@
               <span>Main area</span><strong>Review CLI and worker</strong>
             </div>
             <div class="meta-item">
-              <span>Stored data</span><strong>Local job and run records</strong>
+              <span>Stored data</span
+              ><strong>Job, run, result, and diagnostic records</strong>
             </div>
           </div>
           <div class="outcome">
             <strong>Finished result:</strong>
-            <code>mr review --no-publish</code> reads an existing remote review,
-            performs the full analysis, saves local diagnostics, and prints a
-            readable report without creating or updating anything on GitLab or
+            <code>mr review --no-publish</code> and its exact alias
+            <code>--no-comment</code> read an existing remote review, perform
+            the full analysis, and save the checked result to storage. By
+            default, the CLI prints a readable report; with
+            <code>--report/-r &lt;path&gt;</code>, the invoking CLI writes a
+            Markdown report to its own filesystem, replacing the file if it
+            already exists. The run creates or updates nothing on GitLab or
             GitHub.
           </div>
         </header>
@@ -72,62 +79,79 @@
               <h3>The result is hidden behind job status</h3>
               <p>
                 The watch view reports progress and counts. It does not present
-                the completed review as a useful local report.
+                the completed review as useful formatted console text or a
+                Markdown file.
               </p>
             </article>
             <article class="card">
               <h3>“Dry run” would be misleading</h3>
               <p>
                 The operation still reads the remote platform, calls a model
-                that may incur cost, and writes local database and run-log
+                that may incur cost, and writes configured storage and run-log
                 records.
               </p>
             </article>
             <article class="card">
-              <h3>Pretty output needs Markdown semantics</h3>
+              <h3>There is no report artifact option</h3>
               <p>
-                Finding bodies contain headings, lists, code, and suggestions.
-                Printing raw markers produces a poor terminal experience.
+                The existing <code>--output</code> option selects console data
+                format, not a destination. A separate
+                <code>--report/-r</code> option must write the final review to a
+                file, and the CLI must learn to parse that short option.
               </p>
             </article>
           </div>
         </section>
         <section id="goal">
           <h2>What do we want instead?</h2>
-          <div class="flow" aria-label="No-publish review flow">
+          <div class="flow" aria-label="CLI and runner responsibilities">
             <div>
-              <strong>1. Read remotely</strong
+              <strong>1. CLI queues and watches</strong
               ><span
-                >Load the selected merge request or pull request and hydrate its
-                workspace.</span
+                >Submit the local-test job with its publication choice, then
+                watch the stored job and run state.</span
               >
             </div>
             <div>
-              <strong>2. Analyze locally</strong
+              <strong>2. Runner analyzes and stores</strong
               ><span
-                >Run the normal reviewer and save its checked result and
-                diagnostics.</span
+                >Run the normal review, save the checked result, and omit every
+                platform publication step.</span
               >
             </div>
             <div>
-              <strong>3. Render locally</strong
+              <strong>3. CLI collects and delivers</strong
               ><span
-                >Skip all publication and print the report in the requested CLI
-                format.</span
+                >Load the completed result from storage, then print formatted
+                text or write the Markdown report.</span
               >
             </div>
           </div>
           <ul class="checklist">
             <li>The default command keeps its current publication behavior.</li>
             <li>
-              <code>--no-publish</code> means zero remote writes, not zero
-              remote reads.
+              <code>--no-publish</code> and <code>--no-comment</code> are exact
+              aliases with the same help text and behavior.
             </li>
-            <li>Pretty output renders Markdown for a terminal.</li>
             <li>
-              Plain output is valid Markdown suitable for redirection to a file.
+              Either alias means zero platform writes, not zero platform reads.
             </li>
-            <li>JSON output returns stable structured review data.</li>
+            <li>A no-publish run is explicitly a local test.</li>
+            <li>The checked review result is saved to configured storage.</li>
+            <li>
+              With no file destination, the final review is printed as readable,
+              well-formatted console text.
+            </li>
+            <li>
+              With <code>--report/-r &lt;path&gt;</code>, the final review is
+              written by the invoking CLI as valid Markdown to that path instead
+              of being printed as the console report. An existing destination
+              file is overwritten with the new complete report.
+            </li>
+            <li>
+              Combining <code>--no-watch</code> with
+              <code>--report/-r</code> fails before a review job is submitted.
+            </li>
           </ul>
         </section>
         <section id="fix">
@@ -143,36 +167,78 @@
               <tr>
                 <td>Command option</td>
                 <td>
-                  Add <code>--no-publish</code>. Do not call it a dry run
-                  because model and local persistence work still happen.
+                  Add <code>--no-publish</code> and the easier-to-remember
+                  <code>--no-comment</code> alias. Treat them as one publication
+                  choice. Do not call this a dry run because model work and
+                  storage writes still happen.
                 </td>
               </tr>
               <tr>
-                <td>Queued execution</td>
+                <td>Output destination</td>
                 <td>
-                  Store the publication choice with the submitted local request
-                  so another runner process sees it.
+                  Print a polished text report to the console by default. When
+                  <code>--report/-r &lt;path&gt;</code> is supplied, the
+                  invoking CLI—not the runner—writes the same review as valid
+                  UTF-8 Markdown to the requested file, replacing rather than
+                  appending to an existing file. Continue to use the existing
+                  <code>--output</code> option only for the format of progress,
+                  diagnostics, and other CLI data.
+                </td>
+              </tr>
+              <tr>
+                <td>Invalid option combination</td>
+                <td>
+                  Reject <code>--no-watch</code> together with
+                  <code>--report</code> or <code>-r</code> with the error
+                  “Cannot combine <code>--no-watch</code> with
+                  <code>--report</code> or <code>-r</code>.” Validate this
+                  before any job is queued.
+                </td>
+              </tr>
+              <tr>
+                <td>CLI responsibility</td>
+                <td>
+                  Queue the job, watch it to completion, load and validate the
+                  stored checked result, build the report, and either print it
+                  or write it to the caller-local file. Keep the report path and
+                  presentation choices in the CLI process.
+                </td>
+              </tr>
+              <tr>
+                <td>Runner responsibility</td>
+                <td>
+                  Read the publication choice from the queued request. Otherwise
+                  perform the normal review and storage work, but bypass every
+                  platform publication path. The runner does not format output,
+                  write the report file, or receive its path.
                 </td>
               </tr>
               <tr>
                 <td>Remote safety</td>
                 <td>
-                  Skip discussion reconciliation, summaries, replies, reactions,
-                  check updates, and any project-memory write.
+                  Skip every platform mutation, including emojis or reactions,
+                  inline and summary comments, responses or replies, discussion
+                  reconciliation, GitHub review submissions and statuses, check
+                  statuses, trigger-status updates, cleanup, and platform-hosted
+                  project memory writes.
                 </td>
               </tr>
               <tr>
-                <td>Local persistence</td>
+                <td>ReviewPhin storage</td>
                 <td>
-                  Complete the interaction run with the checked review result
-                  and retain normal logs and metrics.
+                  Complete the interaction run with the checked review result in
+                  the configured storage provider. Retain normal job and run
+                  records, diagnostics, artifacts, logs, and metrics even though
+                  nothing is published to the code-review platform.
                 </td>
               </tr>
               <tr>
                 <td>CLI report</td>
                 <td>
-                  Build one canonical Markdown report, then render it for pretty
-                  mode or emit it directly for plain mode.
+                  Build one canonical Markdown report. Render its headings,
+                  lists, code, suggestions, severity, and file anchors cleanly
+                  for a terminal, or write the Markdown source to the selected
+                  file.
                 </td>
               </tr>
             </tbody>
@@ -180,7 +246,39 @@
           <div class="callout warning">
             <strong>Zero remote writes is a contract:</strong> tests must fail
             if any GitLab or GitHub mutation endpoint is called, even for
-            progress feedback, cleanup, memory, or an error path.
+            progress feedback, an emoji, a comment or response, a GitHub review
+            or status, cleanup, platform memory, or an error path.
+          </div>
+          <div class="callout">
+            <strong>Keep format and destination separate:</strong>
+            <code>--output</code> continues to choose pretty, plain, or JSON CLI
+            data. <code>--report/-r</code> only redirects the final review
+            artifact to a Markdown file; it does not change the global output
+            format.
+          </div>
+          <div class="callout warning">
+            <strong>Local-test report contract:</strong>
+            <code>--report/-r</code> belongs to a watched no-publish run. The
+            CLI process that submitted and watched the test writes the file
+            after loading the checked result from storage. Combining it with
+            <code>--no-watch</code> is an error and queues nothing. Progress and
+            diagnostics may still use the console; only the final review
+            artifact has one destination.
+          </div>
+          <div class="callout">
+            <strong>The runner integration stays narrow:</strong> the queued
+            publication choice is the only new input the runner needs. It does
+            not receive the report destination or CLI output settings. Its only
+            changed behavior is to skip platform publication while preserving
+            normal analysis, result storage, diagnostics, metrics, artifacts,
+            and cleanup.
+          </div>
+          <div class="callout">
+            <strong>Overwrite is intentional:</strong> once the watched run has
+            a checked result, <code>--report/-r</code> replaces any file already
+            at the selected path with one complete Markdown report. It never
+            appends. A run that fails before producing a checked result does not
+            start the write, so an existing file remains unchanged.
           </div>
         </section>
         <section id="steps">
@@ -188,45 +286,56 @@
           <ol class="sequence">
             <li>
               <div>
-                <strong>Persist the publication choice.</strong> Extend the
-                local review request with a backward-compatible publication mode
-                and expose <code>--no-publish</code> in help.
+                <strong>Add a report destination.</strong> Add
+                <code>--report &lt;path&gt;</code> and its <code>-r</code> alias
+                without changing the global output-format option. Add
+                short-option parsing and reject <code>--no-watch</code> together
+                with either report spelling before platform setup, storage
+                access, or job submission. Replace an existing destination only
+                after the completed report has been built in memory.
               </div>
             </li>
             <li>
               <div>
-                <strong>Fence remote mutations.</strong> Decide publication once
-                in the worker and bypass every mutation path while retaining
-                remote reads and workspace hydration.
+                <strong>Persist one publication choice.</strong> Extend the
+                local review request with a backward-compatible publication
+                mode. Map <code>--no-publish</code> and
+                <code>--no-comment</code> to that same value and expose both in
+                help. Do not queue the report path or presentation settings.
               </div>
             </li>
             <li>
               <div>
-                <strong>Keep local results useful.</strong> Save the completed
-                result and make the watcher load it after terminal job
-                completion.
+                <strong>Fence only platform publication in the runner.</strong>
+                Read the queued publication choice once and bypass every
+                mutation path while retaining platform reads, workspace
+                hydration, analysis, storage, diagnostics, metrics, artifacts,
+                and cleanup.
+              </div>
+            </li>
+            <li>
+              <div>
+                <strong>Collect the result in the CLI.</strong> After the
+                watcher observes terminal completion, make the CLI load and
+                validate the checked result from configured storage. Do not add
+                report rendering or file-writing responsibilities to the runner.
               </div>
             </li>
             <li>
               <div>
                 <strong>Create one report formatter.</strong> Convert overview,
                 readiness, findings, anchors, explanations, and suggestions into
-                canonical Markdown.
-              </div>
-            </li>
-            <li>
-              <div>
-                <strong>Render by output mode.</strong> Use terminal styling and
-                width-aware wrapping for pretty mode, raw Markdown for plain
-                mode, and structured data for JSON mode. Respect color settings
-                and non-terminal output.
+                canonical Markdown. Render it with terminal styling and
+                width-aware wrapping for console delivery, or write it without
+                terminal escapes to the chosen Markdown file.
               </div>
             </li>
             <li>
               <div>
                 <strong>Prove the safety boundary.</strong> Run successful,
                 failed, retried, GitLab, and GitHub no-publish jobs against
-                clients that reject every mutation call.
+                clients that reject every mutation call. Exercise both aliases,
+                console delivery, file delivery, and stored-result retrieval.
               </div>
             </li>
           </ol>
@@ -242,6 +351,17 @@
                 triggers must continue to mean normal publication.
               </li>
               <li>
+                Global output parsing is implemented by
+                <a href="../../src/cli/output.ts"
+                  ><code>resolveOutputMode</code></a
+                >, and
+                <a href="../../src/cli.ts"><code>parseCliArgs</code></a>
+                currently recognizes only long options. Keep
+                <code>--report</code> out of <code>resolveOutputMode</code>, and
+                extend argument parsing narrowly enough that <code>-r</code>
+                cannot consume a command name or another option by accident.
+              </li>
+              <li>
                 The CLI submission and wait path lives in
                 <a href="../../src/cli.ts"
                   ><code>runMergeRequestReviewCommand</code></a
@@ -252,6 +372,20 @@
                 >.
               </li>
               <li>
+                <a href="../../src/cli/review-watch.ts"
+                  ><code>watchReviewJob</code></a
+                >
+                currently returns <code>ReviewWatchSummary</code>, which has a
+                run ID and counts but not the stored review payload. After a
+                successful watch, keep result collection in
+                <a href="../../src/cli.ts"
+                  ><code>runMergeRequestReviewCommand</code></a
+                >: load that interaction run, parse its
+                <code>resultJson</code> with <code>reviewResultSchema</code>,
+                then render or write the report. Do not add file-output
+                arguments to the watcher or worker.
+              </li>
+              <li>
                 The main mutation boundary is
                 <a href="../../src/jobs/review-worker.ts">the review worker</a>,
                 especially discussion reconciliation and chatter publication.
@@ -259,6 +393,13 @@
                 <a href="../../src/platforms/trigger-lifecycle.ts"
                   ><code>NoOpPlatformTriggerLifecycle</code></a
                 >.
+              </li>
+              <li>
+                In the worker, the publication mode should only guard platform
+                mutation calls such as discussion reconciliation, chatter reply
+                publication, and lifecycle updates. Keep the normal reviewer,
+                finding persistence, <code>completeInteractionRun</code>,
+                metrics, run artifacts, and workspace cleanup paths unchanged.
               </li>
               <li>
                 Parse the stored result with
@@ -271,6 +412,29 @@
                 Add any Markdown parser/renderer as a direct production
                 dependency. Do not rely on documentation-tool transitive
                 dependencies.
+              </li>
+              <li>
+                A caller-side output file requires a watched terminal result.
+                Reject <code>--report/-r</code> with
+                <code>--no-watch</code> during input validation, before
+                <code>initializePlatformRegistry</code>,
+                <code>withStorage</code>, or
+                <code>createOrGetInteractionJob</code>. Cover both report
+                spellings with the same human-readable validation error.
+              </li>
+              <li>
+                Keep the report path out of
+                <a href="../../src/review/local-trigger.ts"
+                  ><code>localReviewTriggerSchema</code></a
+                >. The runner may be on another machine. After
+                <a href="../../src/cli/review-watch.ts"
+                  ><code>watchReviewJob</code></a
+                >
+                returns a completed result, the invoking CLI resolves the
+                caller-local path and writes the Markdown file. Build the full
+                report before opening the destination, then replace its contents
+                rather than appending. A filesystem write error must fail the
+                command.
               </li>
               <li>
                 No new storage column is expected because the trigger JSON and
@@ -288,29 +452,65 @@
             </li>
             <li>
               A no-publish run makes remote read calls but no remote mutation
-              calls in success, retry, or failure paths.
+              calls in success, retry, or failure paths. This includes emojis,
+              comments, responses, GitHub reviews, and GitHub check statuses.
             </li>
             <li>
-              Pretty output has readable headings, lists, code blocks, severity,
-              and file anchors at narrow and wide terminal widths.
+              <code>--no-publish</code> and <code>--no-comment</code> produce
+              the same queued publication mode and the same observable behavior.
             </li>
             <li>
-              Plain output can be redirected to a file and remains valid
-              Markdown without ANSI escapes.
+              The queued request contains the publication choice but never the
+              report path or console-format settings.
             </li>
             <li>
-              JSON output contains the checked review result and job identity
-              without mixed progress text.
+              The runner stores the same checked result shape as a publishing
+              run; its only no-publish difference is that no platform mutation
+              path is called.
             </li>
             <li>
-              The run result, metrics, and diagnostic artifacts remain available
-              locally.
+              After completion, the CLI uses the watched run identity to load
+              and validate the stored result before it prints or writes the
+              report.
+            </li>
+            <li>
+              Default console output has readable headings, lists, code blocks,
+              severity, and file anchors at narrow and wide terminal widths.
+            </li>
+            <li>
+              <code>--report</code> and <code>-r</code> write the same valid
+              Markdown file without terminal escape codes, and do not also print
+              the final console report.
+            </li>
+            <li>
+              When the report path already exists, its previous contents are
+              replaced by exactly one complete new report; no old content is
+              retained or appended.
+            </li>
+            <li>
+              A review failure before report generation leaves an existing
+              destination unchanged, while a filesystem write failure returns a
+              non-zero exit code.
+            </li>
+            <li>
+              <code>--no-watch --report &lt;path&gt;</code> and
+              <code>--no-watch -r &lt;path&gt;</code> both fail with a clear
+              incompatibility error before platform setup, storage access, or
+              job creation; neither creates or changes the report file.
+            </li>
+            <li>
+              The checked review result, job and run records, metrics, logs, and
+              diagnostic artifacts remain available through the configured
+              storage provider.
             </li>
           </ul>
           <p>
             <strong>Checks to run:</strong> merge-request review CLI tests,
             review-watch tests, worker orchestration and lifecycle tests, GitLab
-            and GitHub runtime tests, CLI output snapshot tests,
+            and GitHub runtime tests, CLI argument and help tests, console and
+            Markdown-file output snapshot tests, report overwrite and
+            write-error tests, queued-payload boundary tests, runner publication
+            fence tests, storage-provider contract tests,
             <code>pnpm test</code>, <code>pnpm typecheck</code>, and
             <code>pnpm build</code>.
           </p>

--- a/docs/src/content/docs/development/custom-platforms.md
+++ b/docs/src/content/docs/development/custom-platforms.md
@@ -43,7 +43,9 @@ createLocalInteractionJob(input: {
 
 The selector is one canonical comment URL, a comment ID plus code review ID, or local instruction text plus code review ID. The provider owns platform API access, tenant and URL verification, comment classification, head-SHA resolution, trigger construction, and canonical deduplication. For comment selectors, return the same trigger and dedupe identity as the equivalent webhook. For text selectors, include the request ID so each submission is fresh.
 
-The CLI adds the resolved tenant ID, persists the job, and synchronizes its queued lifecycle. Return a no-op lifecycle for provider-neutral local text triggers; keep native lifecycle behavior for reconstructed comments.
+The CLI adds the resolved tenant ID and persists the job. For publishing reviews, it also synchronizes the queued lifecycle. Return a no-op lifecycle for provider-neutral local text triggers; keep native lifecycle behavior for reconstructed comments.
+
+Local tests submitted with `--no-publish` or `--no-comment` deliberately skip trigger-lifecycle synchronization and every other platform mutation. The provider still resolves the selected review and constructs the persisted job, but it is not asked to publish lifecycle state or review output. See the [`mr review` CLI reference](../../management/cli-reference/#mr-review) for the complete local-test behavior.
 
 Providers that omit this hook continue to load normally. `mr review` reports that local submission is unsupported for those providers.
 

--- a/docs/src/content/docs/development/review-flow.md
+++ b/docs/src/content/docs/development/review-flow.md
@@ -13,7 +13,8 @@ CLI request    -> mr review             -> resolve + construct trigger
   -> review worker              runner claims a leased job
   -> model harness              Reviewer (context-analyst -> review-author)
   -> finding reconciliation     Chatter: replies + memory
-  -> platform publication       create/update/resolve/reply
+  -> platform publication       publishing reviews: create/update/resolve/reply
+                                local tests: skipped
 ```
 
 ## 1. Receive
@@ -26,9 +27,9 @@ The tenant registry maps the platform event to a configured tenant.
 
 ## Interaction jobs and the runner
 
-Webhooks, provider-owned actions, and `mr review` write persisted interaction jobs; they never enqueue process-local work. The persisted queue is the source of truth. The CLI uses the configured platform connection to verify a selected comment and preserves that platform's normal trigger lifecycle.
+Webhooks, provider-owned actions, and `mr review` write persisted interaction jobs; they never enqueue process-local work. The persisted queue is the source of truth. The CLI uses the configured platform connection to verify a selected comment. Publishing reviews preserve that platform's normal trigger lifecycle; local tests submitted with `--no-publish` or `--no-comment` deliberately skip lifecycle synchronization and all other platform mutations. See the [`mr review` CLI reference](../../management/cli-reference/#mr-review) for local-test output and storage behavior.
 
-A CLI text selector creates a local manual-review trigger instead of a synthetic comment. Its instruction is included in review scope and prompt context. It always requests review work, never requests a trigger-comment reply, and still publishes normal findings and a summary.
+A CLI text selector creates a local manual-review trigger instead of a synthetic comment. Its instruction is included in review scope and prompt context. It always requests review work and never requests a trigger-comment reply. By default, it publishes normal findings and a summary; in no-publish mode, it stores the completed result without publishing either.
 
 Each enabled runner process polls for work, while storage permits only one active review:
 
@@ -71,6 +72,6 @@ It selects one of three modes from the trigger context:
 
 ## 5. Publish
 
-Chatter handles conversational replies and project memory decisions, using the profile's text-generation model to keep light interactions cheap. The publication adapter then creates, updates, resolves, reopens, or replies to bot-owned discussions and summaries. Retries recover bot-owned publications by stable markers instead of duplicating comments.
+Chatter handles conversational replies and project memory decisions, using the profile's text-generation model to keep light interactions cheap. For publishing reviews, the publication adapter then creates, updates, resolves, reopens, or replies to bot-owned discussions and summaries. Retries recover bot-owned publications by stable markers instead of duplicating comments. Local tests still run the review and store its result, but they bypass the publication adapter and platform-backed memory writes.
 
 ReviewPhin calls the configured model API, the connected platform API, and any configured external storage provider such as Flotiq. SQLite keeps persisted review data on the ReviewPhin host; hosted adapters store it with that provider.

--- a/docs/src/content/docs/management/cli-reference.md
+++ b/docs/src/content/docs/management/cli-reference.md
@@ -426,6 +426,9 @@ Exactly one tenant selector and one trigger selector are required.
 | `--trigger-text-file`       | Yes\*\*   | UTF-8 instruction file, resolved from the current directory. Requires `--code-review-id`.                   |
 | `--code-review-id`          | Sometimes | Positive merge request IID or pull request number. A comment URL supplies it; an explicit value must match. |
 | `--force-new`               | No        | Create a distinct job for a comment that would otherwise reuse its canonical job.                           |
+| `--no-publish`              | No        | Run a local test: store the review result without publishing anything to the code-hosting platform.         |
+| `--no-comment`              | No        | Exact alias for `--no-publish`.                                                                             |
+| `--report`, `-r`            | No        | Write the completed local-test result as Markdown to this path, replacing an existing file.                 |
 | `--watch`                   | No        | Watch persisted job and run state. This is the default.                                                     |
 | `--no-watch`                | No        | Return after persistence without waiting.                                                                   |
 | `--sqlite-database-path`    | No        | Override the SQLite path.                                                                                   |
@@ -448,9 +451,13 @@ ReviewPhin verifies the URL against the resolved tenant and fetches the comment 
 
 Comment submissions use the same deduplication identity as webhook submissions. Repeating one reuses the existing job, including a terminal job; `--force-new` derives a distinct identity. Text instructions always include a new local request ID and therefore always create a fresh job.
 
+`--no-publish` (or its exact alias, `--no-comment`) marks the review as a local test. The runner still reads the platform context, performs the review, and stores the completed result, but it does not mutate the platform: no reactions, comments, replies, review/check statuses, or platform-backed memory writes are published. A local test has a separate deduplication identity from an otherwise identical published review, so it cannot accidentally reuse a result that was already published.
+
+After a local test completes, the CLI loads the stored result. Without `--report`, it prints a formatted report to the terminal. With `--report <path>` or `-r <path>`, it writes the same result as UTF-8 Markdown and replaces the file if it already exists. The report path is local to the CLI and is never sent to the runner. `--report` requires `--no-publish` or `--no-comment`; it cannot be combined with `--no-watch`, because the CLI must wait for the stored result before writing the file. These combinations are validated before the job is queued.
+
 Watch mode reports persisted status changes and follows the selected attempt through retries. In pretty mode on an interactive terminal, it keeps a dashboard in place with separate status, identity, and latest-activity sections. The dashboard uses the available terminal width and wraps recent activity messages onto aligned continuation lines. Plain output and redirected pretty output remain append-only. The watcher tails live logs only when the configured run-log directory is locally accessible or shared with the runner. Missing live logs do not affect persisted status or findings. Leaving watch mode with `SIGINT` or `SIGTERM` does not cancel the job.
 
-With `--output json`, watch mode emits JSONL events: `review_submitted`, `job_status`, `run_status`, `activity`, and a final `review_completed`. Activity events retain a safe projection of up to four scalar log-data fields; nested values are omitted and credential-like fields are redacted. Human-readable activity details use the same projection. `--no-watch --output json` is not a stream and returns exactly one summary object.
+With `--output json`, watch mode emits JSONL events: `review_submitted`, `job_status`, `run_status`, `activity`, and a final `review_completed`. A successful local test without `--report` then emits a `review_result` event containing the stored result. Activity events retain a safe projection of up to four scalar log-data fields; nested values are omitted and credential-like fields are redacted. Human-readable activity details use the same projection. `--no-watch --output json` is not a stream and returns exactly one summary object.
 
 The final summary contains `jobId`, `created`, `jobStatus`, `runId`, `runStatus`, `runLogDirectory`, `findingCount`, `error`, and `liveLogsAvailable`. Exit code `0` means a no-watch submission succeeded or a watched job completed. Validation and operational errors, or watched jobs ending as failed, cancelled, or expired, return `1`; interrupted watches return `130` for `SIGINT` and `143` for `SIGTERM`.
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "@github/copilot-sdk": "^1.0.6",
     "fastify": "^5.9.0",
     "glob": "^13.0.6",
+    "marked": "^15.0.12",
+    "marked-terminal": "^7.3.0",
     "octokit": "^5.0.5",
     "pino": "^10.3.1",
     "sharp": "0.35.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,12 @@ importers:
       glob:
         specifier: ^13.0.6
         version: 13.0.6
+      marked:
+        specifier: ^15.0.12
+        version: 15.0.12
+      marked-terminal:
+        specifier: ^7.3.0
+        version: 7.3.0(marked@15.0.12)
       octokit:
         specifier: ^5.0.5
         version: 5.0.5
@@ -259,6 +265,10 @@ packages:
   '@clack/prompts@1.7.0':
     resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
     engines: {node: '>= 20.12.0'}
+
+  '@colors/colors@1.5.0':
+    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
+    engines: {node: '>=0.1.90'}
 
   '@ctrl/tinycolor@4.2.0':
     resolution: {integrity: sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A==}
@@ -1175,6 +1185,10 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@sindresorhus/is@4.6.0':
+    resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
+    engines: {node: '>=10'}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -1372,13 +1386,24 @@ packages:
     resolution: {integrity: sha512-MxT4XZL7pzLHpuvhDKdMaQHMGGkJDLluKBLsbstn+8wv9sWcFT6h+0ve9qkml95amVTZtZV83gQe2hY+ojgHLg==}
     hasBin: true
 
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
@@ -1467,6 +1492,18 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  char-regex@1.0.2:
+    resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
+    engines: {node: '>=10'}
+
   character-entities-html4@2.1.0:
     resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
 
@@ -1490,6 +1527,18 @@ packages:
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
+
+  cli-highlight@2.1.11:
+    resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
+    engines: {node: '>=8.0.0', npm: '>=5.0.0'}
+    hasBin: true
+
+  cli-table3@0.6.5:
+    resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
+    engines: {node: 10.* || >= 12.*}
+
+  cliui@7.0.4:
+    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -1647,6 +1696,9 @@ packages:
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
+  emojilib@2.4.0:
+    resolution: {integrity: sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==}
+
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
@@ -1654,6 +1706,10 @@ packages:
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
+
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
 
   es-module-lexer@2.3.0:
     resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
@@ -1936,6 +1992,9 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
+  highlight.js@10.7.3:
+    resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -2193,6 +2252,17 @@ packages:
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
+  marked-terminal@7.3.0:
+    resolution: {integrity: sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      marked: '>=1 <16'
+
+  marked@15.0.12:
+    resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
+    engines: {node: '>= 18'}
+    hasBin: true
+
   mdast-util-definitions@6.0.0:
     resolution: {integrity: sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==}
 
@@ -2385,6 +2455,9 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
   nanoid@3.3.15:
     resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -2400,6 +2473,10 @@ packages:
   nlcst-to-string@4.0.0:
     resolution: {integrity: sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==}
 
+  node-emoji@2.2.0:
+    resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
+    engines: {node: '>=18'}
+
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
 
@@ -2412,6 +2489,10 @@ packages:
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
 
   obug@2.1.3:
     resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
@@ -2473,6 +2554,15 @@ packages:
 
   parse-latin@7.0.0:
     resolution: {integrity: sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==}
+
+  parse5-htmlparser2-tree-adapter@6.0.1:
+    resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
+
+  parse5@5.1.1:
+    resolution: {integrity: sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==}
+
+  parse5@6.0.1:
+    resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
@@ -2748,6 +2838,10 @@ packages:
     engines: {node: '>=20.19.5', npm: '>=10.8.2'}
     hasBin: true
 
+  skin-tone@2.0.0:
+    resolution: {integrity: sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==}
+    engines: {node: '>=8'}
+
   smol-toml@1.7.0:
     resolution: {integrity: sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==}
     engines: {node: '>= 18'}
@@ -2804,6 +2898,10 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  supports-hyperlinks@3.2.0:
+    resolution: {integrity: sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==}
+    engines: {node: '>=14.18'}
+
   svgo@4.0.1:
     resolution: {integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==}
     engines: {node: '>=16'}
@@ -2812,6 +2910,13 @@ packages:
   tar@7.5.19:
     resolution: {integrity: sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==}
     engines: {node: '>=18'}
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
   thread-stream@4.2.0:
     resolution: {integrity: sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ==}
@@ -2901,6 +3006,10 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  unicode-emoji-modifier-base@1.0.0:
+    resolution: {integrity: sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==}
+    engines: {node: '>=4'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -3157,6 +3266,10 @@ packages:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
 
+  yargs-parser@20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
+    engines: {node: '>=10'}
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -3164,6 +3277,10 @@ packages:
   yargs-parser@22.0.0:
     resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  yargs@16.2.2:
+    resolution: {integrity: sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==}
+    engines: {node: '>=10'}
 
   yargs@17.7.3:
     resolution: {integrity: sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==}
@@ -3418,6 +3535,9 @@ snapshots:
       fast-string-width: 3.0.2
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
+
+  '@colors/colors@1.5.0':
+    optional: true
 
   '@ctrl/tinycolor@4.2.0': {}
 
@@ -4203,6 +4323,8 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@sindresorhus/is@4.6.0': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@tybys/wasm-util@0.10.3':
@@ -4448,13 +4570,19 @@ snapshots:
     dependencies:
       process-ancestry: 0.1.0
 
-  ansi-regex@5.0.1:
-    optional: true
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
 
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
-    optional: true
+
+  any-promise@1.3.0: {}
 
   anymatch@3.1.3:
     dependencies:
@@ -4613,6 +4741,15 @@ snapshots:
 
   chai@6.2.2: {}
 
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  chalk@5.6.2: {}
+
+  char-regex@1.0.2: {}
+
   character-entities-html4@2.1.0: {}
 
   character-entities-legacy@3.0.0: {}
@@ -4629,6 +4766,27 @@ snapshots:
 
   ci-info@4.4.0: {}
 
+  cli-highlight@2.1.11:
+    dependencies:
+      chalk: 4.1.2
+      highlight.js: 10.7.3
+      mz: 2.7.0
+      parse5: 5.1.1
+      parse5-htmlparser2-tree-adapter: 6.0.1
+      yargs: 16.2.2
+
+  cli-table3@0.6.5:
+    dependencies:
+      string-width: 4.2.3
+    optionalDependencies:
+      '@colors/colors': 1.5.0
+
+  cliui@7.0.4:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
   cliui@8.0.1:
     dependencies:
       string-width: 4.2.3
@@ -4643,10 +4801,8 @@ snapshots:
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
-    optional: true
 
-  color-name@1.1.4:
-    optional: true
+  color-name@1.1.4: {}
 
   comma-separated-tokens@2.0.3: {}
 
@@ -4760,12 +4916,15 @@ snapshots:
 
   dset@3.1.4: {}
 
-  emoji-regex@8.0.0:
-    optional: true
+  emoji-regex@8.0.0: {}
+
+  emojilib@2.4.0: {}
 
   entities@4.5.0: {}
 
   entities@6.0.1: {}
+
+  environment@1.1.0: {}
 
   es-module-lexer@2.3.0: {}
 
@@ -4812,8 +4971,7 @@ snapshots:
       '@esbuild/win32-ia32': 0.28.1
       '@esbuild/win32-x64': 0.28.1
 
-  escalade@3.2.0:
-    optional: true
+  escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
 
@@ -5029,8 +5187,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  get-caller-file@2.0.5:
-    optional: true
+  get-caller-file@2.0.5: {}
 
   get-tsconfig@5.0.0-beta.4:
     dependencies:
@@ -5253,6 +5410,8 @@ snapshots:
       property-information: 7.2.0
       space-separated-tokens: 2.0.2
 
+  highlight.js@10.7.3: {}
+
   html-escaper@2.0.2: {}
 
   html-escaper@3.0.3: {}
@@ -5304,8 +5463,7 @@ snapshots:
 
   is-extglob@2.1.1: {}
 
-  is-fullwidth-code-point@3.0.0:
-    optional: true
+  is-fullwidth-code-point@3.0.0: {}
 
   is-glob@4.0.3:
     dependencies:
@@ -5453,6 +5611,19 @@ snapshots:
   markdown-extensions@2.0.0: {}
 
   markdown-table@3.0.4: {}
+
+  marked-terminal@7.3.0(marked@15.0.12):
+    dependencies:
+      ansi-escapes: 7.3.0
+      ansi-regex: 6.2.2
+      chalk: 5.6.2
+      cli-highlight: 2.1.11
+      cli-table3: 0.6.5
+      marked: 15.0.12
+      node-emoji: 2.2.0
+      supports-hyperlinks: 3.2.0
+
+  marked@15.0.12: {}
 
   mdast-util-definitions@6.0.0:
     dependencies:
@@ -5931,6 +6102,12 @@ snapshots:
 
   ms@2.1.3: {}
 
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
   nanoid@3.3.15: {}
 
   natural-compare@1.4.0: {}
@@ -5941,6 +6118,13 @@ snapshots:
     dependencies:
       '@types/nlcst': 2.0.3
 
+  node-emoji@2.2.0:
+    dependencies:
+      '@sindresorhus/is': 4.6.0
+      char-regex: 1.0.2
+      emojilib: 2.4.0
+      skin-tone: 2.0.0
+
   node-fetch-native@1.6.7: {}
 
   node-mock-http@1.0.4: {}
@@ -5950,6 +6134,8 @@ snapshots:
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
+
+  object-assign@4.1.1: {}
 
   obug@2.1.3: {}
 
@@ -6043,6 +6229,14 @@ snapshots:
       unist-util-modify-children: 4.0.0
       unist-util-visit-children: 3.0.0
       vfile: 6.0.3
+
+  parse5-htmlparser2-tree-adapter@6.0.1:
+    dependencies:
+      parse5: 6.0.1
+
+  parse5@5.1.1: {}
+
+  parse5@6.0.1: {}
 
   parse5@7.3.0:
     dependencies:
@@ -6267,8 +6461,7 @@ snapshots:
       mdast-util-to-markdown: 2.1.2
       unified: 11.0.5
 
-  require-directory@2.1.1:
-    optional: true
+  require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
 
@@ -6452,6 +6645,10 @@ snapshots:
       arg: 5.0.2
       sax: 1.6.0
 
+  skin-tone@2.0.0:
+    dependencies:
+      unicode-emoji-modifier-base: 1.0.0
+
   smol-toml@1.7.0: {}
 
   sonic-boom@4.2.1:
@@ -6479,7 +6676,6 @@ snapshots:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
-    optional: true
 
   stringify-entities@4.0.4:
     dependencies:
@@ -6489,7 +6685,6 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
-    optional: true
 
   style-to-js@1.1.21:
     dependencies:
@@ -6502,6 +6697,11 @@ snapshots:
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  supports-hyperlinks@3.2.0:
+    dependencies:
+      has-flag: 4.0.0
+      supports-color: 7.2.0
 
   svgo@4.0.1:
     dependencies:
@@ -6520,6 +6720,14 @@ snapshots:
       minipass: 7.1.3
       minizlib: 3.1.0
       yallist: 5.0.0
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
 
   thread-stream@4.2.0:
     dependencies:
@@ -6591,6 +6799,8 @@ snapshots:
   undici-types@6.21.0: {}
 
   undici-types@7.18.2: {}
+
+  unicode-emoji-modifier-base@1.0.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -6759,19 +6969,29 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-    optional: true
 
   xxhash-wasm@1.1.0: {}
 
-  y18n@5.0.8:
-    optional: true
+  y18n@5.0.8: {}
 
   yallist@5.0.0: {}
+
+  yargs-parser@20.2.9: {}
 
   yargs-parser@21.1.1:
     optional: true
 
   yargs-parser@22.0.0: {}
+
+  yargs@16.2.2:
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 20.2.9
 
   yargs@17.7.3:
     dependencies:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,13 @@ import {
 import { loadLocalEnvFile } from "./env.js";
 import { maskSecret } from "./review/model-profiles.js";
 import {
+  getReviewPublicationMode,
+  scopeReviewDedupeKeyToPublicationMode,
+  setReviewPublicationMode,
+  type ReviewPublicationMode,
+} from "./review/publication.js";
+import { reviewResultSchema, type ReviewResult } from "./review/types.js";
+import {
   collectMetrics,
   displayUsageUnit,
   formatUsageAmount,
@@ -59,6 +66,10 @@ import {
   watchReviewJob,
   type ReviewWatchSummary,
 } from "./cli/review-watch.js";
+import {
+  formatReviewReportForTerminal,
+  writeReviewReport,
+} from "./cli/review-report.js";
 import { getGitLabTenantConfig } from "./platforms/gitlab/tenant-config.js";
 import {
   CliOutput,
@@ -247,6 +258,9 @@ const mergeRequestReviewSchema = z
     forceNew: z.boolean(),
     watchRequested: z.boolean(),
     noWatchRequested: z.boolean(),
+    noPublishRequested: z.boolean(),
+    noCommentRequested: z.boolean(),
+    reportPath: z.string().min(1).optional(),
   })
   .superRefine((value, ctx) => {
     if (
@@ -279,6 +293,21 @@ const mergeRequestReviewSchema = z
         code: z.ZodIssueCode.custom,
         message: "Provide either --watch or --no-watch, not both.",
         path: ["watchRequested"],
+      });
+    }
+    const noPublish = value.noPublishRequested || value.noCommentRequested;
+    if (value.reportPath !== undefined && !noPublish) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "--report/-r requires --no-publish or --no-comment.",
+        path: ["reportPath"],
+      });
+    }
+    if (value.reportPath !== undefined && value.noWatchRequested) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Cannot combine --no-watch with --report or -r.",
+        path: ["reportPath"],
       });
     }
     if (
@@ -1461,6 +1490,25 @@ export function parseCliArgs(argv: string[]): ParsedCliArgs {
 
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index];
+    if (token === "-r" || token?.startsWith("-r=")) {
+      const inlineValue = token === "-r" ? undefined : token.slice(3);
+      if (inlineValue !== undefined) {
+        options.report = inlineValue;
+        continue;
+      }
+      const nextToken = argv[index + 1];
+      if (
+        nextToken &&
+        !nextToken.startsWith("--") &&
+        !isRecognizedShortOption(nextToken)
+      ) {
+        options.report = nextToken;
+        index += 1;
+      } else {
+        options.report = true;
+      }
+      continue;
+    }
     if (!token?.startsWith("--")) {
       positionals.push(token ?? "");
       continue;
@@ -1478,7 +1526,11 @@ export function parseCliArgs(argv: string[]): ParsedCliArgs {
     }
 
     const nextToken = argv[index + 1];
-    if (nextToken && !nextToken.startsWith("--")) {
+    if (
+      nextToken &&
+      !nextToken.startsWith("--") &&
+      !isRecognizedShortOption(nextToken)
+    ) {
       options[key] = nextToken;
       index += 1;
       continue;
@@ -1488,6 +1540,10 @@ export function parseCliArgs(argv: string[]): ParsedCliArgs {
   }
 
   return { positionals, options };
+}
+
+function isRecognizedShortOption(token: string): boolean {
+  return token === "-r" || token.startsWith("-r=");
 }
 
 async function withStorage<T>(
@@ -1623,7 +1679,7 @@ function printHelp(
     "model-profile clear-default [--sqlite-database-path <path>] [--storage-provider-module <module>]",
     "storage migrate --from-storage-provider-module <module> [--from-sqlite-database-path <path>] --to-storage-provider-module <module> [--to-sqlite-database-path <path>]",
     "mr describe (--tenant-id <id> | --key <key>) --code-review-id <id> [--current-interaction-job-id <id>] [--trigger-comment-id <id> --trigger-comment-action <create|update> [--trigger-comment-updated-at <iso>] [--trigger-comment-body <text>]] [--sqlite-database-path <path>] [--storage-provider-module <module>]",
-    "mr review (--tenant-id <id> | --key <tenant-key>) (--trigger-comment-url <url> | --trigger-comment-id <id> | --trigger-text <text> | --trigger-text-file <path>) [--code-review-id <id>] [--force-new] [--watch | --no-watch] [--sqlite-database-path <path>] [--storage-provider-module <module>] [--run-log-dir <path>]",
+    "mr review (--tenant-id <id> | --key <tenant-key>) (--trigger-comment-url <url> | --trigger-comment-id <id> | --trigger-text <text> | --trigger-text-file <path>) [--code-review-id <id>] [--force-new] [--watch | --no-watch] [--no-publish | --no-comment] [--report <path> | -r <path>] [--sqlite-database-path <path>] [--storage-provider-module <module>] [--run-log-dir <path>]",
     "metrics sessions [--connection <name>] [--from <YYYY-MM-DD>] [--to <YYYY-MM-DD>] [--all-sessions] [--sqlite-database-path <path>] [--storage-provider-module <module>]",
     "metrics collect [--run-log-dir <path>] [--dry-run] [--sqlite-database-path <path>] [--storage-provider-module <module>]",
   );
@@ -1874,7 +1930,14 @@ async function runMergeRequestReviewCommand(
     forceNew: Object.hasOwn(options, "force-new"),
     watchRequested: Object.hasOwn(options, "watch"),
     noWatchRequested: Object.hasOwn(options, "no-watch"),
+    noPublishRequested: Object.hasOwn(options, "no-publish"),
+    noCommentRequested: Object.hasOwn(options, "no-comment"),
+    reportPath: options.report,
   });
+  const publicationMode: ReviewPublicationMode =
+    input.noPublishRequested || input.noCommentRequested
+      ? "no-publish"
+      : "publish";
   const selector = await resolveLocalReviewSelector(input);
   await initializePlatformRegistry({
     platformModules: config.platformModules,
@@ -1909,7 +1972,7 @@ async function runMergeRequestReviewCommand(
     }
 
     const requestId = createId("local-review");
-    const interactionJob = await platform.createLocalInteractionJob({
+    const platformInteractionJob = await platform.createLocalInteractionJob({
       resolvedTenant,
       storage,
       selector,
@@ -1917,11 +1980,28 @@ async function runMergeRequestReviewCommand(
       requestId,
       createdAt: new Date().toISOString(),
     });
+    const interactionJob = {
+      ...platformInteractionJob,
+      dedupeKey: scopeReviewDedupeKeyToPublicationMode(
+        platformInteractionJob.dedupeKey,
+        publicationMode,
+      ),
+      triggerJson:
+        publicationMode === "publish"
+          ? platformInteractionJob.triggerJson
+          : setReviewPublicationMode(
+              platformInteractionJob.triggerJson,
+              publicationMode,
+            ),
+    };
     const submitted = await storage.createOrGetInteractionJob({
       ...interactionJob,
       tenantId: resolvedTenant.tenant.id,
     });
-    if (submitted.created || submitted.job.commentId !== null) {
+    if (
+      publicationMode === "publish" &&
+      (submitted.created || submitted.job.commentId !== null)
+    ) {
       const lifecycle = platform.createTriggerLifecycle({
         resolvedTenant,
         job: submitted.job,
@@ -1974,6 +2054,22 @@ async function runMergeRequestReviewCommand(
         codeReviewId: submitted.job.codeReviewId,
         signal: controller.signal,
       });
+      if (
+        summary.jobStatus === "completed" &&
+        getReviewPublicationMode(submitted.job.triggerJson) === "no-publish"
+      ) {
+        const reviewResult = await loadCompletedReviewResult(storage, summary);
+        if (input.reportPath) {
+          await writeReviewReport(
+            resolve(process.cwd(), input.reportPath),
+            reviewResult,
+          );
+        } else {
+          output().event({ type: "review_result", result: reviewResult }, () =>
+            formatReviewReportForTerminal(reviewResult, output()),
+          );
+        }
+      }
       return summary.jobStatus === "completed" ? 0 : 1;
     } catch (error) {
       if (error instanceof ReviewWatchAbortedError && signalExitCode) {
@@ -1985,6 +2081,27 @@ async function runMergeRequestReviewCommand(
       process.removeListener("SIGTERM", handleSigterm);
     }
   });
+}
+
+async function loadCompletedReviewResult(
+  storage: StorageHelpers,
+  summary: ReviewWatchSummary,
+): Promise<ReviewResult> {
+  if (!summary.runId) {
+    throw new Error(
+      `Completed review job ${summary.jobId} has no interaction run.`,
+    );
+  }
+  const run = await storage.stores.interactionRuns.get(summary.runId);
+  if (!run) {
+    throw new Error(
+      `Completed review job ${summary.jobId} references missing run ${summary.runId}.`,
+    );
+  }
+  if (!run.resultJson) {
+    throw new Error(`Completed review run ${run.id} has no review result.`);
+  }
+  return reviewResultSchema.parse(JSON.parse(run.resultJson) as unknown);
 }
 
 async function resolveLocalReviewSelector(

--- a/src/cli/review-report.ts
+++ b/src/cli/review-report.ts
@@ -1,0 +1,157 @@
+import { writeFile } from "node:fs/promises";
+
+import { Marked } from "marked";
+import { markedTerminal } from "marked-terminal";
+
+import type { ReviewAnchor, ReviewResult } from "../review/types.js";
+import type { CliOutput } from "./output.js";
+
+export function formatReviewReportMarkdown(result: ReviewResult): string {
+  const lines = [
+    "# Review result",
+    "",
+    `**Overall severity:** ${capitalize(result.overview.overallSeverity)}`,
+    "",
+    result.overview.summary.trim(),
+  ];
+
+  if (result.overview.overallAssessment) {
+    lines.push("", result.overview.overallAssessment.trim());
+  }
+
+  if (result.overview.mergeReadiness) {
+    lines.push(
+      "",
+      "## Merge readiness",
+      "",
+      `**Status:** ${formatLabel(result.overview.mergeReadiness.status)}`,
+      "",
+      `**Confidence:** ${capitalize(result.overview.mergeReadiness.confidence)}`,
+      "",
+      result.overview.mergeReadiness.summary.trim(),
+    );
+  }
+
+  if (result.overview.highlights?.length) {
+    lines.push(
+      "",
+      "## Highlights",
+      "",
+      ...result.overview.highlights.map(
+        (highlight) => `- ${escapeMarkdownText(highlight)}`,
+      ),
+    );
+  }
+
+  lines.push("", `## Findings (${result.findings.length})`, "");
+  if (result.findings.length === 0) {
+    lines.push("No findings.");
+  } else {
+    for (const [index, finding] of result.findings.entries()) {
+      lines.push(
+        `### ${index + 1}. ${escapeMarkdownText(finding.title)}`,
+        "",
+        `- **Severity:** ${capitalize(finding.severity)}`,
+        `- **Category:** ${capitalize(finding.category)}`,
+      );
+      if (finding.confidence) {
+        lines.push(`- **Confidence:** ${capitalize(finding.confidence)}`);
+      }
+      if (finding.anchor) {
+        lines.push(`- **Location:** ${formatAnchor(finding.anchor)}`);
+      }
+      lines.push("", finding.body.trim());
+      if (finding.suggestion) {
+        lines.push(
+          "",
+          "#### Suggested change",
+          "",
+          fencedCode(finding.suggestion.replacement, "suggestion"),
+        );
+      }
+      lines.push("");
+    }
+  }
+
+  return `${lines.join("\n").trimEnd()}\n`;
+}
+
+export function formatReviewReportForTerminal(
+  result: ReviewResult,
+  output: CliOutput,
+): string {
+  const marked = new Marked();
+  marked.use(
+    markedTerminal({
+      width: output.columns,
+      reflowText: true,
+      showSectionPrefix: false,
+      emoji: output.unicode,
+      code: (value) => output.style("warning", value),
+      blockquote: (value) => output.style("muted", value),
+      html: (value) => output.style("muted", value),
+      heading: (value) => output.style("heading", value),
+      firstHeading: (value) => output.style("heading", value),
+      hr: (value) => output.style("muted", value),
+      listitem: (value) => value,
+      table: (value) => value,
+      paragraph: (value) => value,
+      strong: (value) => output.style("strong", value),
+      em: (value) => value,
+      codespan: (value) => output.style("warning", value),
+      del: (value) => output.style("muted", value),
+      link: (value) => value,
+      href: (value) => value,
+    }),
+  );
+  const rendered = marked.parse(formatReviewReportMarkdown(result));
+  if (typeof rendered !== "string") {
+    throw new Error("Terminal report rendering unexpectedly became async.");
+  }
+  return rendered.trimEnd();
+}
+
+export async function writeReviewReport(
+  path: string,
+  result: ReviewResult,
+): Promise<void> {
+  await writeFile(path, formatReviewReportMarkdown(result), "utf8");
+}
+
+function formatAnchor(anchor: ReviewAnchor): string {
+  const lineRange =
+    anchor.startLine === anchor.endLine
+      ? `line ${anchor.startLine}`
+      : `lines ${anchor.startLine}-${anchor.endLine}`;
+  return `${inlineCode(anchor.path)}, ${lineRange} (${anchor.side} side)`;
+}
+
+function inlineCode(value: string): string {
+  const longestRun = Math.max(
+    0,
+    ...Array.from(value.matchAll(/`+/g), (match) => match[0].length),
+  );
+  const delimiter = "`".repeat(longestRun + 1);
+  return `${delimiter}${value}${delimiter}`;
+}
+
+function fencedCode(value: string, language: string): string {
+  const longestRun = Math.max(
+    2,
+    ...Array.from(value.matchAll(/`+/g), (match) => match[0].length),
+  );
+  const fence = "`".repeat(longestRun + 1);
+  return `${fence}${language}\n${value.trimEnd()}\n${fence}`;
+}
+
+function escapeMarkdownText(value: string): string {
+  return value.replace(/([\\`*_[\]<>#])/g, "\\$1");
+}
+
+function capitalize(value: string): string {
+  return `${value.charAt(0).toUpperCase()}${value.slice(1)}`;
+}
+
+function formatLabel(value: string): string {
+  return value.split("_").filter(Boolean).map(capitalize).join(" ");
+}

--- a/src/jobs/review-worker.ts
+++ b/src/jobs/review-worker.ts
@@ -6,10 +6,12 @@ import type {
   PlatformMaterializedWorkspace,
   PlatformReviewRoutingContext,
   PlatformReviewRuntime,
+  PlatformTriggerLifecycle,
   ResolvedTenant,
 } from "../platforms/IPlatform.js";
 import { getPlatformBySlug } from "../platforms/platform-registry.js";
 import {
+  NoOpPlatformTriggerLifecycle,
   syncPlatformTriggerLifecycle,
   syncPlatformTriggerLifecycleForJob,
 } from "../platforms/trigger-lifecycle.js";
@@ -24,6 +26,7 @@ import {
   ModelProfileConfigurationError,
   resolveReviewProviderConfig,
 } from "../review/model-profiles.js";
+import { getReviewPublicationMode } from "../review/publication.js";
 import type { ReviewProviderFactory } from "../review/provider.js";
 import { InteractionRunArtifacts } from "../review/run-artifacts.js";
 import type {
@@ -180,11 +183,11 @@ export class ReviewWorker {
       if (!platform) {
         return;
       }
-      const lifecycle = platform.createTriggerLifecycle({
+      const lifecycle = this.createTriggerLifecycle(
+        platform,
         resolvedTenant,
         job,
-        logger: this.logger,
-      });
+      );
       await syncPlatformTriggerLifecycleForJob({
         logger: this.logger,
         job,
@@ -240,11 +243,11 @@ export class ReviewWorker {
       if (!platform) {
         return;
       }
-      const lifecycle = platform.createTriggerLifecycle({
+      const lifecycle = this.createTriggerLifecycle(
+        platform,
         resolvedTenant,
         job,
-        logger: this.logger,
-      });
+      );
 
       const message =
         job.lastError ??
@@ -285,11 +288,13 @@ export class ReviewWorker {
     }
     const { tenant, connection } = resolvedTenant;
     const platform = this.resolvePlatform(tenant.platform);
-    const triggerLifecycle = platform.createTriggerLifecycle({
+    const publicationEnabled =
+      getReviewPublicationMode(job.triggerJson) === "publish";
+    const triggerLifecycle = this.createTriggerLifecycle(
+      platform,
       resolvedTenant,
       job,
-      logger: this.logger,
-    });
+    );
 
     context.assertOwned();
     await syncPlatformTriggerLifecycle({
@@ -544,6 +549,7 @@ export class ReviewWorker {
               interactionJobId: job.id,
               runDirectory: runArtifacts.runDirectory,
               memoryEnabled: routingContext.projectMemory.enabled,
+              platformWritesEnabled: publicationEnabled,
               onMetrics: this.createMetricsSink(jobStore, context, {
                 interactionRunId: interactionRun.id,
                 triggerKind: trigger.kind,
@@ -666,6 +672,7 @@ export class ReviewWorker {
             interactionJobId: job.id,
             runDirectory: runArtifacts.runDirectory,
             memoryEnabled: hydratedContext.projectMemory.enabled,
+            platformWritesEnabled: publicationEnabled,
             onMetrics: this.createMetricsSink(jobStore, context, {
               interactionRunId: interactionRun.id,
               triggerKind: reviewContext.trigger.kind,
@@ -719,34 +726,43 @@ export class ReviewWorker {
           throw new LeaseLostError();
         }
 
-        context.assertOwned();
-        reconcileSummary = await this.reconciler.reconcile({
-          platform,
-          tenant,
-          connection,
-          context: hydratedContext.summaryContext,
-          mappings,
-          interactionJobId: job.id,
-          interactionRunId: interactionRun.id,
-          reviewResult,
-          storage: scoped,
-          guard: context,
-          publicationAdapter: runRuntime.createReviewPublicationAdapter({
-            context: hydratedContext,
+        if (publicationEnabled) {
+          context.assertOwned();
+          reconcileSummary = await this.reconciler.reconcile({
+            platform,
+            tenant,
+            connection,
+            context: hydratedContext.summaryContext,
+            mappings,
+            interactionJobId: job.id,
             interactionRunId: interactionRun.id,
-          }),
-        });
-        context.assertOwned();
+            reviewResult,
+            storage: scoped,
+            guard: context,
+            publicationAdapter: runRuntime.createReviewPublicationAdapter({
+              context: hydratedContext,
+              interactionRunId: interactionRun.id,
+            }),
+          });
+          context.assertOwned();
 
-        await this.logRunEvent(
-          runArtifacts,
-          "info",
-          "reconciled review result into platform discussions",
-          {
-            interactionRunId: interactionRun.id,
-            summary: reconcileSummary,
-          },
-        );
+          await this.logRunEvent(
+            runArtifacts,
+            "info",
+            "reconciled review result into platform discussions",
+            {
+              interactionRunId: interactionRun.id,
+              summary: reconcileSummary,
+            },
+          );
+        } else {
+          await this.logRunEvent(
+            runArtifacts,
+            "info",
+            "skipped review publication for local test",
+            { interactionRunId: interactionRun.id },
+          );
+        }
       }
 
       if (interactionPlan.replyNeeded && trigger.kind !== "manual-review") {
@@ -795,6 +811,7 @@ export class ReviewWorker {
               memoryEnabled:
                 reviewContext?.projectMemory.enabled ??
                 routingContext.projectMemory.enabled,
+              platformWritesEnabled: publicationEnabled,
               onMetrics: this.createMetricsSink(jobStore, context, {
                 interactionRunId: interactionRun.id,
                 triggerKind: trigger.kind,
@@ -818,12 +835,14 @@ export class ReviewWorker {
         );
 
         context.assertOwned();
-        const publishOutcomes = await runRuntime.publishChatterReplies({
-          codeReviewId: routingContext.codeReviewId,
-          result: replyResult,
-          plannedTargets: interactionPlan.responseTargets,
-          guard: context,
-        });
+        const publishOutcomes = publicationEnabled
+          ? await runRuntime.publishChatterReplies({
+              codeReviewId: routingContext.codeReviewId,
+              result: replyResult,
+              plannedTargets: interactionPlan.responseTargets,
+              guard: context,
+            })
+          : [];
         context.assertOwned();
         await runArtifacts.writeJsonArtifact(
           join("orchestration", "reply-publish-outcomes.json"),
@@ -1177,6 +1196,21 @@ export class ReviewWorker {
     return input.runtime.loadRoutingContext(input.job);
   }
 
+  private createTriggerLifecycle(
+    platform: IPlatform,
+    resolvedTenant: ResolvedTenant,
+    job: InteractionJobRecord,
+  ): PlatformTriggerLifecycle {
+    if (getReviewPublicationMode(job.triggerJson) === "no-publish") {
+      return new NoOpPlatformTriggerLifecycle();
+    }
+    return platform.createTriggerLifecycle({
+      resolvedTenant,
+      job,
+      logger: this.logger,
+    });
+  }
+
   private async hydrateContext(input: {
     runtime: PlatformReviewRuntime;
     job: InteractionJobRecord;
@@ -1205,6 +1239,7 @@ export class ReviewWorker {
     interactionJobId: string;
     runDirectory: string;
     memoryEnabled: boolean;
+    platformWritesEnabled: boolean;
     onMetrics?:
       ((metrics: HarnessSessionMetricsEnvelope) => Promise<void>) | undefined;
   }) {
@@ -1219,6 +1254,7 @@ export class ReviewWorker {
       storage: this.storage,
       logger: this.logger,
       memoryEnabled: input.memoryEnabled,
+      platformWritesEnabled: input.platformWritesEnabled,
       logging: {
         interactionRunId: input.interactionRunId,
         interactionJobId: input.interactionJobId,

--- a/src/platforms/IPlatform.ts
+++ b/src/platforms/IPlatform.ts
@@ -267,6 +267,7 @@ export interface IPlatform {
     storage: StorageHelpers;
     logger: Logger;
     enabled: boolean;
+    platformWritesEnabled?: boolean | undefined;
     logging?: HarnessRunLoggingContext | undefined;
   }): ProjectMemoryBackend;
   buildHarnessTenantContext(input: {
@@ -274,6 +275,7 @@ export interface IPlatform {
     storage: StorageHelpers;
     logger: Logger;
     memoryEnabled: boolean;
+    platformWritesEnabled?: boolean | undefined;
     logging?: HarnessRunLoggingContext | undefined;
   }): HarnessTenantContext;
   getReviewSummaryInstructions(resolvedTenant: ResolvedTenant): string[];

--- a/src/platforms/github/platform.ts
+++ b/src/platforms/github/platform.ts
@@ -981,6 +981,7 @@ export default class GitHubPlatform implements IPlatform {
     storage: StorageHelpers;
     logger: Logger;
     enabled: boolean;
+    platformWritesEnabled?: boolean | undefined;
     logging?: HarnessRunLoggingContext | undefined;
   }) {
     return createGitHubProjectMemoryBackend({
@@ -995,6 +996,7 @@ export default class GitHubPlatform implements IPlatform {
     storage: StorageHelpers;
     logger: Logger;
     memoryEnabled: boolean;
+    platformWritesEnabled?: boolean | undefined;
     logging?: HarnessRunLoggingContext | undefined;
   }) {
     return {

--- a/src/platforms/gitlab/platform.ts
+++ b/src/platforms/gitlab/platform.ts
@@ -444,6 +444,7 @@ export default class GitLabPlatform implements IPlatform {
     storage: StorageHelpers;
     logger: Logger;
     enabled: boolean;
+    platformWritesEnabled?: boolean | undefined;
     logging?: HarnessRunLoggingContext | undefined;
   }) {
     return createGitLabProjectMemoryBackendForTenant({
@@ -456,6 +457,7 @@ export default class GitLabPlatform implements IPlatform {
     storage: StorageHelpers;
     logger: Logger;
     memoryEnabled: boolean;
+    platformWritesEnabled?: boolean | undefined;
     logging?: HarnessRunLoggingContext | undefined;
   }) {
     return {
@@ -467,6 +469,7 @@ export default class GitLabPlatform implements IPlatform {
         logger: input.logger,
         logging: input.logging,
         enabled: input.memoryEnabled,
+        platformWritesEnabled: input.platformWritesEnabled,
       }),
     };
   }

--- a/src/platforms/gitlab/project-memory-backend.ts
+++ b/src/platforms/gitlab/project-memory-backend.ts
@@ -44,6 +44,7 @@ export function createGitLabProjectMemoryBackendForTenant(input: {
   logger: Logger;
   logging?: HarnessRunLoggingContext | undefined;
   enabled: boolean;
+  platformWritesEnabled?: boolean | undefined;
   stores: Pick<StorageStores, "projectMemories">;
 }): ProjectMemoryBackend {
   const tenantConfig = getGitLabTenantConfig(input.resolvedTenant.tenant);
@@ -76,6 +77,7 @@ export function createGitLabProjectMemoryBackend(input: {
   projectId: number;
   tenantId: string;
   enabled: boolean;
+  platformWritesEnabled?: boolean | undefined;
   stores: Pick<StorageStores, "projectMemories">;
   logger?: Logger | undefined;
 }): ProjectMemoryBackend {
@@ -93,6 +95,7 @@ class GitLabProjectMemorySelectionBackend implements ProjectMemoryBackend {
       projectId: number;
       tenantId: string;
       stores: Pick<StorageStores, "projectMemories">;
+      platformWritesEnabled?: boolean | undefined;
       logger?: Logger | undefined;
     },
   ) {}
@@ -129,16 +132,35 @@ class GitLabProjectMemorySelectionBackend implements ProjectMemoryBackend {
         );
       }
 
-      return new GitLabWikiProjectMemoryBackend({
+      const backend = new GitLabWikiProjectMemoryBackend({
         client: this.options.client,
         projectId: this.options.projectId,
       });
+      return this.options.platformWritesEnabled === false
+        ? new ReadOnlyProjectMemoryBackend(backend)
+        : backend;
     }
 
     return new InStoreMemoryProvider({
       stores: this.options.stores,
       tenantId: this.options.tenantId,
     });
+  }
+}
+
+class ReadOnlyProjectMemoryBackend implements ProjectMemoryBackend {
+  public constructor(private readonly backend: ProjectMemoryBackend) {}
+
+  public getCapability(): Promise<ProjectMemoryCapability> {
+    return this.backend.getCapability();
+  }
+
+  public load(): Promise<ProjectMemoryContext> {
+    return this.backend.load();
+  }
+
+  public saveEntries(): Promise<ProjectMemoryContext> {
+    return this.backend.load();
   }
 }
 

--- a/src/platforms/gitlab/project-memory-backend.ts
+++ b/src/platforms/gitlab/project-memory-backend.ts
@@ -67,6 +67,7 @@ export function createGitLabProjectMemoryBackendForTenant(input: {
     projectId: tenantConfig.projectId,
     tenantId: input.resolvedTenant.tenant.id,
     enabled: input.enabled,
+    platformWritesEnabled: input.platformWritesEnabled,
     stores: input.stores,
     logger: input.logger,
   });

--- a/src/review/local-trigger.ts
+++ b/src/review/local-trigger.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { reviewPublicationModeSchema } from "./publication.js";
+
 export const localReviewTriggerSchema = z.object({
   kind: z.literal("reviewphin-local-review"),
   source: z.literal("cli"),
@@ -7,6 +9,7 @@ export const localReviewTriggerSchema = z.object({
   codeReviewId: z.number().int().positive(),
   instruction: z.string().trim().min(1),
   createdAt: z.string().datetime({ offset: true }),
+  publicationMode: reviewPublicationModeSchema.optional(),
 });
 
 export type LocalReviewTrigger = z.infer<typeof localReviewTriggerSchema>;

--- a/src/review/publication.ts
+++ b/src/review/publication.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+
+import { sha256 } from "../utils/hash.js";
+
+export const reviewPublicationModeSchema = z.enum(["publish", "no-publish"]);
+
+export type ReviewPublicationMode = z.infer<typeof reviewPublicationModeSchema>;
+
+const DEFAULT_REVIEW_PUBLICATION_MODE: ReviewPublicationMode = "publish";
+
+export function getReviewPublicationMode(
+  triggerJson: string | null | undefined,
+): ReviewPublicationMode {
+  if (!triggerJson) {
+    return DEFAULT_REVIEW_PUBLICATION_MODE;
+  }
+  const trigger = parseTriggerObject(triggerJson);
+  return reviewPublicationModeSchema
+    .optional()
+    .default(DEFAULT_REVIEW_PUBLICATION_MODE)
+    .parse(trigger.publicationMode);
+}
+
+export function setReviewPublicationMode(
+  triggerJson: string,
+  publicationMode: ReviewPublicationMode,
+): string {
+  const trigger = parseTriggerObject(triggerJson);
+  return JSON.stringify({ ...trigger, publicationMode });
+}
+
+export function scopeReviewDedupeKeyToPublicationMode(
+  dedupeKey: string,
+  publicationMode: ReviewPublicationMode,
+): string {
+  return publicationMode === DEFAULT_REVIEW_PUBLICATION_MODE
+    ? dedupeKey
+    : sha256(`${dedupeKey}::publication-mode:${publicationMode}`);
+}
+
+function parseTriggerObject(triggerJson: string): Record<string, unknown> {
+  const trigger = JSON.parse(triggerJson) as unknown;
+  if (!trigger || typeof trigger !== "object" || Array.isArray(trigger)) {
+    throw new Error("Review trigger JSON must contain an object.");
+  }
+  return trigger as Record<string, unknown>;
+}

--- a/src/types/marked-terminal.d.ts
+++ b/src/types/marked-terminal.d.ts
@@ -1,0 +1,30 @@
+declare module "marked-terminal" {
+  import type { MarkedExtension } from "marked";
+
+  export interface MarkedTerminalOptions {
+    readonly width?: number;
+    readonly reflowText?: boolean;
+    readonly showSectionPrefix?: boolean;
+    readonly emoji?: boolean;
+    readonly code?: (value: string) => string;
+    readonly blockquote?: (value: string) => string;
+    readonly html?: (value: string) => string;
+    readonly heading?: (value: string) => string;
+    readonly firstHeading?: (value: string) => string;
+    readonly hr?: (value: string) => string;
+    readonly listitem?: (value: string) => string;
+    readonly table?: (value: string) => string;
+    readonly paragraph?: (value: string) => string;
+    readonly strong?: (value: string) => string;
+    readonly em?: (value: string) => string;
+    readonly codespan?: (value: string) => string;
+    readonly del?: (value: string) => string;
+    readonly link?: (value: string) => string;
+    readonly href?: (value: string) => string;
+  }
+
+  export function markedTerminal(
+    options?: MarkedTerminalOptions,
+    highlightOptions?: Record<string, unknown>,
+  ): MarkedExtension;
+}

--- a/test/cli-help.test.ts
+++ b/test/cli-help.test.ts
@@ -105,6 +105,8 @@ describe("CLI help", () => {
     expect(help).toContain("--trigger-comment-url <url>");
     expect(help).toContain("--trigger-text-file <path>");
     expect(help).toContain("[--watch | --no-watch]");
+    expect(help).toContain("[--no-publish | --no-comment]");
+    expect(help).toContain("[--report <path> | -r <path>]");
   });
 
   it("validates mr review selectors without appending usage", async () => {

--- a/test/mr-review-cli.test.ts
+++ b/test/mr-review-cli.test.ts
@@ -17,6 +17,45 @@ afterEach(() => {
 });
 
 describe("mr review CLI", () => {
+  it.each(["--report", "-r"])(
+    "rejects %s with --no-watch before queueing",
+    async (reportOption) => {
+      await expect(
+        runCli([
+          "mr",
+          "review",
+          "--key",
+          "https://gitlab.example.com::123",
+          "--trigger-text",
+          "Review this change.",
+          "--code-review-id",
+          "7",
+          "--no-publish",
+          "--no-watch",
+          reportOption,
+          "review.md",
+        ]),
+      ).rejects.toThrow("Cannot combine --no-watch with --report or -r.");
+    },
+  );
+
+  it("requires no-publish mode for report files", async () => {
+    await expect(
+      runCli([
+        "mr",
+        "review",
+        "--key",
+        "https://gitlab.example.com::123",
+        "--trigger-text",
+        "Review this change.",
+        "--code-review-id",
+        "7",
+        "--report",
+        "review.md",
+      ]),
+    ).rejects.toThrow("--report/-r requires --no-publish or --no-comment.");
+  });
+
   it("submits a fresh text job without starting a worker and emits one JSON summary", async () => {
     const directory = await mkdtemp(join(tmpdir(), "mr-review-cli-"));
     const databasePath = join(directory, "reviewphin.sqlite");
@@ -121,6 +160,7 @@ describe("mr review CLI", () => {
           "Review the retry boundary.",
           "--code-review-id",
           "7",
+          "--no-comment",
           "--no-watch",
           "--sqlite-database-path",
           databasePath,
@@ -136,6 +176,17 @@ describe("mr review CLI", () => {
 
     expect(prettyOutput).toContain("Review submitted.");
     expect(diagnostics).toBe("");
+
+    const updatedStorage = await openSqliteTestStorage(databasePath);
+    const updatedJobs = await listAll(updatedStorage.stores.interactionJobs);
+    await updatedStorage.close();
+    const localTestJob = updatedJobs.find((job) =>
+      job.triggerJson.includes("Review the retry boundary."),
+    );
+    expect(localTestJob).toBeDefined();
+    expect(
+      parseLocalReviewTrigger(JSON.parse(localTestJob!.triggerJson)),
+    ).toEqual(expect.objectContaining({ publicationMode: "no-publish" }));
   });
 });
 

--- a/test/project-memory.test.ts
+++ b/test/project-memory.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { createLogger } from "../src/logger.js";
 import { GitLabApiError } from "../src/platforms/gitlab/client.js";
 import {
   createGitLabProjectMemoryBackend,
+  createGitLabProjectMemoryBackendForTenant,
   GitLabWikiProjectMemoryBackend,
 } from "../src/platforms/gitlab/project-memory-backend.js";
 import {
@@ -19,6 +21,10 @@ import {
   REVIEWPHIN_MEMORY_PAGE_TITLE,
   projectMemoryToolInputSchema,
 } from "../src/memory/types.js";
+import {
+  createGitLabConnectionRecord,
+  createGitLabTenantRecord,
+} from "./helpers/gitlab-tenant.js";
 
 describe("project memory", () => {
   it("renders and parses the managed wiki format deterministically", () => {
@@ -506,6 +512,66 @@ describe("InStoreMemoryProvider", () => {
 });
 
 describe("GitLab project memory selection", () => {
+  it("forwards the platform write fence through the tenant factory", async () => {
+    const requests: Array<{ method: string; url: string }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async (
+          request: string | URL | Request,
+          init?: RequestInit,
+        ): Promise<Response> => {
+          const url = new URL(
+            typeof request === "string"
+              ? request
+              : request instanceof URL
+                ? request.toString()
+                : request.url,
+          );
+          const method =
+            init?.method ??
+            (request instanceof Request ? request.method : "GET");
+          requests.push({ method, url: url.toString() });
+          if (url.pathname.endsWith("/projects/123")) {
+            return jsonResponse({ id: 123, wiki_enabled: true });
+          }
+          if (url.pathname.endsWith("/projects/123/wikis/reviewphin-memory")) {
+            return jsonResponse({
+              title: REVIEWPHIN_MEMORY_PAGE_TITLE,
+              slug: "reviewphin-memory",
+              format: "markdown",
+              content:
+                "## Remembered project knowledge\n- Keep the existing memory.",
+            });
+          }
+          throw new Error(`Unexpected ${method} request to ${url}`);
+        },
+      ),
+    );
+
+    try {
+      const backend = createGitLabProjectMemoryBackendForTenant({
+        resolvedTenant: {
+          tenant: createGitLabTenantRecord(),
+          connection: createGitLabConnectionRecord(),
+        },
+        enabled: true,
+        platformWritesEnabled: false,
+        stores: { projectMemories: createProjectMemoryStore() },
+        logger: createLogger("silent"),
+      });
+
+      await expect(
+        backend.saveEntries([{ text: "Do not publish this memory." }]),
+      ).resolves.toMatchObject({
+        entries: [{ text: "Keep the existing memory." }],
+      });
+      expect(requests.map((request) => request.method)).toEqual(["GET", "GET"]);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("uses store-backed memory when project metadata reports wiki disabled", async () => {
     const store = createProjectMemoryStore();
     await store.upsert({
@@ -688,4 +754,14 @@ function createProjectMemoryStore() {
       }
     }),
   };
+}
+
+function jsonResponse(value: unknown): Response {
+  return new Response(JSON.stringify(value), {
+    status: 200,
+    headers: {
+      "content-type": "application/json",
+      "x-next-page": "",
+    },
+  });
 }

--- a/test/project-memory.test.ts
+++ b/test/project-memory.test.ts
@@ -472,15 +472,12 @@ describe("InStoreMemoryProvider", () => {
     });
 
     await expect(
-      backend.saveEntries(
-        [{ text: "Use Jest and pnpm." }],
-        {
-          baseEntries: [
-            { text: "Use Jest for tests." },
-            { text: "Use pnpm for scripts." },
-          ],
-        },
-      ),
+      backend.saveEntries([{ text: "Use Jest and pnpm." }], {
+        baseEntries: [
+          { text: "Use Jest for tests." },
+          { text: "Use pnpm for scripts." },
+        ],
+      }),
     ).resolves.toMatchObject({
       entries: [
         { text: "Use Zod and avoid broad snapshot tests." },
@@ -563,8 +560,7 @@ describe("GitLab project memory selection", () => {
           title: REVIEWPHIN_MEMORY_PAGE_TITLE,
           slug: "reviewphin-memory",
           format: "markdown",
-          content:
-            "## Remembered project knowledge\n- Use GitLab wiki memory.",
+          content: "## Remembered project knowledge\n- Use GitLab wiki memory.",
         })),
         listProjectWikiPages: vi.fn(async () => []),
       } as never,
@@ -579,6 +575,75 @@ describe("GitLab project memory selection", () => {
       entries: [{ text: "Use GitLab wiki memory." }],
     });
     await expect(store.get("tenant-1")).resolves.toBeNull();
+  });
+
+  it("keeps GitLab wiki memory read-only when platform writes are disabled", async () => {
+    const store = createProjectMemoryStore();
+    const createProjectWikiPage = vi.fn();
+    const updateProjectWikiPage = vi.fn();
+    const backend = createGitLabProjectMemoryBackend({
+      client: {
+        getProject: vi.fn(async () => ({
+          id: 1085,
+          web_url: "https://gitlab.example.com/group/project",
+          path_with_namespace: "group/project",
+          http_url_to_repo: "https://gitlab.example.com/group/project.git",
+          wiki_enabled: true,
+        })),
+        getProjectWikiPage: vi.fn(async () => ({
+          title: REVIEWPHIN_MEMORY_PAGE_TITLE,
+          slug: "reviewphin-memory",
+          format: "markdown",
+          content:
+            "## Remembered project knowledge\n- Keep the existing memory.",
+        })),
+        listProjectWikiPages: vi.fn(async () => []),
+        createProjectWikiPage,
+        updateProjectWikiPage,
+      } as never,
+      projectId: 1085,
+      tenantId: "tenant-1",
+      enabled: true,
+      platformWritesEnabled: false,
+      stores: { projectMemories: store },
+    });
+
+    await expect(
+      backend.saveEntries([{ text: "Do not publish this memory." }]),
+    ).resolves.toMatchObject({
+      entries: [{ text: "Keep the existing memory." }],
+    });
+    expect(createProjectWikiPage).not.toHaveBeenCalled();
+    expect(updateProjectWikiPage).not.toHaveBeenCalled();
+  });
+
+  it("still writes store-backed GitLab memory when platform writes are disabled", async () => {
+    const store = createProjectMemoryStore();
+    const backend = createGitLabProjectMemoryBackend({
+      client: {
+        getProject: vi.fn(async () => ({
+          id: 1085,
+          web_url: "https://gitlab.example.com/group/project",
+          path_with_namespace: "group/project",
+          http_url_to_repo: "https://gitlab.example.com/group/project.git",
+          wiki_enabled: false,
+        })),
+      } as never,
+      projectId: 1085,
+      tenantId: "tenant-1",
+      enabled: true,
+      platformWritesEnabled: false,
+      stores: { projectMemories: store },
+    });
+
+    await expect(
+      backend.saveEntries([{ text: "Keep storage memory enabled." }]),
+    ).resolves.toMatchObject({
+      entries: [{ text: "Keep storage memory enabled." }],
+    });
+    await expect(store.get("tenant-1")).resolves.toMatchObject({
+      entriesJson: JSON.stringify([{ text: "Keep storage memory enabled." }]),
+    });
   });
 });
 

--- a/test/review-publication.test.ts
+++ b/test/review-publication.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getReviewPublicationMode,
+  scopeReviewDedupeKeyToPublicationMode,
+  setReviewPublicationMode,
+} from "../src/review/publication.js";
+
+describe("review publication mode", () => {
+  it("treats triggers written before publication modes as publishing", () => {
+    expect(getReviewPublicationMode('{"kind":"gitlab-comment"}')).toBe(
+      "publish",
+    );
+    expect(getReviewPublicationMode(undefined)).toBe("publish");
+  });
+
+  it("adds the mode without changing native trigger fields", () => {
+    const triggerJson = setReviewPublicationMode(
+      JSON.stringify({ kind: "github-comment", commentId: 42 }),
+      "no-publish",
+    );
+
+    expect(JSON.parse(triggerJson)).toEqual({
+      kind: "github-comment",
+      commentId: 42,
+      publicationMode: "no-publish",
+    });
+    expect(getReviewPublicationMode(triggerJson)).toBe("no-publish");
+  });
+
+  it("keeps publishing dedupe keys stable and isolates local tests", () => {
+    expect(scopeReviewDedupeKeyToPublicationMode("dedupe", "publish")).toBe(
+      "dedupe",
+    );
+    const first = scopeReviewDedupeKeyToPublicationMode("dedupe", "no-publish");
+    expect(first).not.toBe("dedupe");
+    expect(first).toBe(
+      scopeReviewDedupeKeyToPublicationMode("dedupe", "no-publish"),
+    );
+  });
+});

--- a/test/review-report.test.ts
+++ b/test/review-report.test.ts
@@ -1,0 +1,96 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  formatReviewReportForTerminal,
+  formatReviewReportMarkdown,
+  writeReviewReport,
+} from "../src/cli/review-report.js";
+import { CliOutput, createStringWriter } from "../src/cli/output.js";
+import type { ReviewResult } from "../src/review/types.js";
+
+const reviewResult: ReviewResult = {
+  overview: {
+    summary: "Authorization boundaries need attention.",
+    overallSeverity: "high",
+    overallAssessment: "The implementation is close, but not ready.",
+    mergeReadiness: {
+      status: "needs_attention",
+      confidence: "high",
+      summary: "Fix the authorization bypass before merging.",
+    },
+    highlights: ["The storage path remains backward compatible."],
+  },
+  findings: [
+    {
+      title: "Reject untrusted `tenantId` values",
+      body: "Validate the identifier before using it.\n\n- Reject missing tenants\n- Keep the error actionable",
+      severity: "high",
+      category: "security",
+      confidence: "high",
+      anchor: {
+        path: "src/auth.ts",
+        startLine: 10,
+        endLine: 12,
+        side: "new",
+      },
+      suggestion: {
+        replacement: 'if (!tenant) {\n  throw new Error("Unknown tenant");\n}',
+        startLine: 10,
+        endLine: 12,
+      },
+    },
+  ],
+  priorDispositions: [],
+};
+
+describe("review report", () => {
+  it("renders a complete Markdown report", () => {
+    const report = formatReviewReportMarkdown(reviewResult);
+
+    expect(report).toContain("# Review result");
+    expect(report).toContain("## Merge readiness");
+    expect(report).toContain("## Findings (1)");
+    expect(report).toContain("`src/auth.ts`, lines 10-12 (new side)");
+    expect(report).toContain("```suggestion");
+    expect(report).toMatch(/\n$/);
+    expect(report).not.toContain("\u001B[");
+  });
+
+  it("renders Markdown semantics as width-aware terminal text", () => {
+    let stdout = "";
+    const output = new CliOutput("pretty", {
+      stdout: createStringWriter((text) => (stdout += text)),
+      stdoutIsTTY: true,
+      columns: 52,
+      color: false,
+    });
+
+    const report = formatReviewReportForTerminal(reviewResult, output);
+
+    expect(report).toContain("Review result");
+    expect(report).toContain("Authorization boundaries need");
+    expect(report).toContain("* Reject missing tenants");
+    expect(report).not.toContain("**Overall severity:**");
+    expect(stdout).toBe("");
+  });
+
+  it("replaces an existing report instead of appending", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "review-report-"));
+    const path = join(directory, "review.md");
+    try {
+      await writeFile(path, "old report", "utf8");
+
+      await writeReviewReport(path, reviewResult);
+
+      const report = await readFile(path, "utf8");
+      expect(report).toBe(formatReviewReportMarkdown(reviewResult));
+      expect(report).not.toContain("old report");
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/review-worker-orchestration.test.ts
+++ b/test/review-worker-orchestration.test.ts
@@ -5,6 +5,7 @@ import type { Logger } from "pino";
 
 import { ReviewWorker } from "../src/jobs/review-worker.js";
 import { createLogger } from "../src/logger.js";
+import GitLabPlatform from "../src/platforms/gitlab/platform.js";
 import type {
   IPlatform,
   PlatformReviewRuntime,
@@ -1896,5 +1897,151 @@ describe("ReviewWorker orchestration", () => {
     expect(reviewContext.scope.priorFindings[0]?.status).toBe("dismissed");
 
     globalThis.fetch = originalFetch;
+  });
+
+  it("stores local-test results without constructing publication paths", async () => {
+    const trigger = {
+      kind: "reviewphin-local-review",
+      source: "cli",
+      requestId: "request-no-publish",
+      codeReviewId: 7,
+      instruction: "Review without publishing.",
+      createdAt: "2026-08-01T12:00:00.000Z",
+      publicationMode: "no-publish",
+    } as const;
+    const job = {
+      id: "job-no-publish",
+      tenantId: tenant.id,
+      dedupeKey: "dedupe-no-publish",
+      projectId: tenant.projectId,
+      codeReviewId: 7,
+      commentId: null,
+      triggerJson: JSON.stringify(trigger),
+      headSha: "abc123",
+      status: "queued" as const,
+      payloadJson: JSON.stringify(trigger),
+      retryCount: 0,
+      lastError: null,
+      enqueuedAt: new Date().toISOString(),
+      startedAt: null,
+      finishedAt: null,
+    };
+    const run = { id: "run-no-publish" };
+    const jobStore = createClaimAwareJobStoreFake({
+      get: async () => job as never,
+      run: run as never,
+    });
+    const reviewResult = {
+      overview: {
+        summary: "No issues found.",
+        overallSeverity: "low" as const,
+      },
+      findings: [],
+      priorDispositions: [],
+    };
+    const routingContext = wrapGitLabPlatformContext({
+      tenant,
+      job,
+      mergeRequest: {
+        id: 1,
+        iid: 7,
+        project_id: tenant.projectId,
+        title: "Add worker",
+        description: "Adds the worker",
+        web_url: "https://gitlab.example.com/group/project/-/merge_requests/7",
+        source_branch: "feature",
+        target_branch: "main",
+        author: { id: 42, username: "developer", name: "Dev User" },
+      },
+      changes: [],
+      notes: [],
+      discussions: [],
+      workspace: {
+        rootPath: join("tmp", "workspace-no-publish"),
+        cleanupRoot: join("tmp", "cleanup-no-publish"),
+        strategy: "git",
+      },
+      projectMemory: {
+        enabled: true,
+        page: null,
+        entries: [],
+      },
+    });
+    const platform = new GitLabPlatform(createLogger("silent"));
+    const createTriggerLifecycle = vi.spyOn(platform, "createTriggerLifecycle");
+    const buildHarnessTenantContext = vi.spyOn(
+      platform,
+      "buildHarnessTenantContext",
+    );
+    const createReviewPublicationAdapter = vi.fn(() => {
+      throw new Error("publication adapter must not be created");
+    });
+    const reconciler = { reconcile: vi.fn() };
+
+    const worker = new ReviewWorker({
+      storage: {
+        stores: {
+          interactionJobs: jobStore,
+          discussionMappings: { list: vi.fn(async () => []) },
+          modelProfiles: {
+            get: vi.fn(async () => null),
+            find: vi.fn(async () => null),
+          },
+        },
+        getInteractionJobById: vi.fn(async () => job),
+        getModelProfileByName: vi.fn(async () => null),
+        getDefaultModelProfile: vi.fn(async () => null),
+        getLatestCompletedInteractionForCodeReview: vi.fn(async () => null),
+        listPriorReviewFindings: vi.fn(async () => []),
+      } as never,
+      tenantRegistry: {
+        getResolvedTenantById: vi.fn(async () => ({ tenant, connection })),
+      } as never,
+      reviewRuntimeFactory: createReviewRuntimeFactory({
+        loadRoutingContext: vi.fn(async () => routingContext),
+        hydrate: vi.fn(async () => routingContext),
+        createReviewPublicationAdapter,
+        cleanupWorkspace: vi.fn(async () => {}),
+      }),
+      reviewProviderFactory: {
+        createProvider: vi.fn(() => ({
+          name: "copilot-sdk",
+          review: vi.fn(async () => reviewResult),
+        })),
+      },
+      chatterRunnerFactory: {
+        createRunner: vi.fn(() => ({ run: vi.fn() })),
+      } as never,
+      reconciler: reconciler as never,
+      logger: createLogger("silent"),
+      runLogDir: join("tmp", "run-logs"),
+      maxJobRetries: 3,
+      retryBackoffMs: 1000,
+      platformResolver: () => platform,
+    });
+
+    await expect(
+      worker.processClaimedJob(job as never, createClaimContext(job.id)),
+    ).resolves.toBeUndefined();
+
+    expect(createTriggerLifecycle).not.toHaveBeenCalled();
+    expect(createReviewPublicationAdapter).not.toHaveBeenCalled();
+    expect(reconciler.reconcile).not.toHaveBeenCalled();
+    expect(buildHarnessTenantContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        memoryEnabled: true,
+        platformWritesEnabled: false,
+      }),
+    );
+    expect(jobStore.transitionInteractionRunForClaim).toHaveBeenCalledWith(
+      expect.objectContaining({
+        interactionRunId: run.id,
+        status: "completed",
+        resultJson: JSON.stringify(reviewResult),
+      }),
+    );
+    expect(jobStore.transitionClaim).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "completed" }),
+    );
   });
 });

--- a/test/review-worker-trigger-lifecycle.test.ts
+++ b/test/review-worker-trigger-lifecycle.test.ts
@@ -376,4 +376,52 @@ describe("ReviewWorker provider trigger lifecycle", () => {
     expect(lifecycle.retry).not.toHaveBeenCalled();
     expect(lifecycle.failed).not.toHaveBeenCalled();
   });
+
+  it("keeps local-test lifecycle reconciliation off the platform", async () => {
+    const job = {
+      id: "job-no-publish",
+      tenantId: "tenant-github",
+      status: "queued",
+      lastError: null,
+      triggerJson: JSON.stringify({
+        kind: "github-comment",
+        publicationMode: "no-publish",
+      }),
+    };
+    const resolvedTenant = {
+      tenant: { id: job.tenantId, platform: "github" },
+      connection: { id: "connection-github" },
+    };
+    const platform = {
+      createTriggerLifecycle: vi.fn(),
+    } as unknown as IPlatform;
+    const worker = new ReviewWorker({
+      storage: {
+        stores: {
+          interactionJobs: {
+            get: vi.fn(async () => job),
+          },
+        },
+      } as never,
+      tenantRegistry: {
+        getResolvedTenantById: vi.fn(async () => resolvedTenant),
+      } as never,
+      reviewProviderFactory: {} as never,
+      chatterRunnerFactory: {} as never,
+      reconciler: {} as never,
+      logger: createLogger("silent"),
+      runLogDir: "tmp/test-trigger-lifecycle",
+      maxJobRetries: 3,
+      retryBackoffMs: 1000,
+      platformResolver: () => platform,
+    });
+
+    await worker.reconcileTriggerLifecycle(job as never);
+    await worker.reconcileOrphanLifecycle({
+      id: "run-no-publish",
+      interactionJobId: job.id,
+    } as never);
+
+    expect(platform.createTriggerLifecycle).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

- add `--no-publish` and the exact `--no-comment` alias for local CLI review tests
- load completed review results from storage and render them to the console or overwrite a Markdown report through `--report`/`-r`
- preserve normal analysis and storage while fencing platform lifecycle updates, discussions, replies, reviews, statuses, and GitLab wiki writes
- isolate local-test deduplication from publishing runs and document the new CLI behavior

## Validation

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm test` (551 tests)
- [x] `pnpm docs:build`
- [x] Tests cover new or changed behavior
- [x] Documentation reflects user-facing changes
- [x] The change contains no credentials, private code, or sensitive logs

## Changelog

<details><summary>Changelog: minor</summary>

### Added

- Reviewers can run local CLI reviews with `--no-publish` or `--no-comment` and receive stored results without changing GitHub or GitLab.
- Reviewers can save a completed local review as an overwritten Markdown report with `--report` or `-r`.

</details>
