### PR TITLE
Add stored MR report CLI command

### DIFF
--- a/.agents/plans/13.tenant-autoregistration.html
+++ b/.agents/plans/13.tenant-autoregistration.html
@@ -491,7 +491,9 @@
         <nav class="footer-nav" aria-label="Plan navigation">
           <a href="12.gitlab-token-permissions-documentation.html"
             >← GitLab token permissions</a
-          ><a href="index.html">All plans →</a>
+          ><a href="14.unified-finding-identity.html"
+            >Next: finding identity draft →</a
+          >
         </nav>
       </main>
     </div>

--- a/.agents/plans/14.unified-finding-identity.html
+++ b/.agents/plans/14.unified-finding-identity.html
@@ -1,0 +1,605 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Draft Plan 14 — Use one durable key for each finding</title>
+    <link rel="stylesheet" href="_plan.css" />
+  </head>
+  <body data-priority="medium">
+    <a class="skip-link" href="#content">Skip to plan</a>
+    <div class="shell">
+      <aside class="rail">
+        <div class="rail-inner">
+          <a class="brand" href="index.html"
+            ><span class="brand-mark">◉</span><span>ReviewPhin plans</span></a
+          >
+          <p class="rail-label">Plan 14</p>
+          <p class="rail-value">One key per finding</p>
+          <p class="rail-label">Decision status</p>
+          <p class="rail-value">Draft · parked</p>
+          <nav class="toc" aria-label="On this page">
+            <a href="#problem">What is wrong?</a>
+            <a href="#goal">What do we want?</a>
+            <a href="#fix">How do we fix it?</a>
+            <a href="#steps">Work steps</a>
+            <a href="#done">How do we know it works?</a>
+          </nav>
+        </div>
+      </aside>
+
+      <main id="content">
+        <header class="hero">
+          <p class="eyebrow">Draft Plan 14 · finding lifecycle</p>
+          <h1>
+            Give every review finding one durable key from creation to closure.
+          </h1>
+          <p class="lede">
+            A finding saved without publishing has no GitHub or GitLab thread.
+            Today the reviewer can close only findings that have a thread, so a
+            fixed local finding can remain open forever. The revised contract
+            gives the reviewer one finding key that works with or without a
+            published comment.
+          </p>
+          <div class="meta-grid">
+            <div class="meta-item">
+              <span>Importance</span><strong>Deferred design</strong>
+            </div>
+            <div class="meta-item">
+              <span>Who notices</span
+              ><strong>Review readers and operators</strong>
+            </div>
+            <div class="meta-item">
+              <span>Main area</span
+              ><strong>Finding state and review prompts</strong>
+            </div>
+            <div class="meta-item">
+              <span>Stored data</span><strong>Decision still required</strong>
+            </div>
+          </div>
+          <div class="callout warning">
+            <strong>Draft status:</strong> keep this plan as the preferred
+            direction, but do not implement it yet. Before work starts, decide
+            how several finding changes commit atomically, survive retries, and
+            behave when a worker loses its claim. That decision may require a
+            storage contract revision even if no new database fields are added.
+          </div>
+          <div class="outcome">
+            <strong>Finished result:</strong> the reviewer copies one durable
+            finding key when it continues, replaces, resolves, or dismisses an
+            earlier issue. ReviewPhin updates the saved finding and, when one
+            exists, the matching platform thread. No-publish and published
+            reviews follow the same finding rules.
+          </div>
+        </header>
+
+        <section id="problem">
+          <h2>What is wrong today?</h2>
+          <div class="card-grid">
+            <article class="card">
+              <h3>Local findings have no way to close</h3>
+              <p>
+                A no-publish review saves a finding but creates no platform
+                thread. A later review can see that the issue is fixed, yet it
+                cannot name the saved finding in its closure instructions.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Readiness can remain wrong forever</h3>
+              <p>
+                Once old findings correctly count toward readiness, an old local
+                finding stays active across every later review. Reports continue
+                to say that work is needed after the code is fixed.
+              </p>
+            </article>
+            <article class="card">
+              <h3>The reviewer sees several kinds of identifiers</h3>
+              <p>
+                Saved findings, ReviewPhin discussion mappings, and platform
+                threads have different identifiers. Asking the reviewer to
+                choose among them makes the output contract harder to follow.
+              </p>
+            </article>
+            <article class="card">
+              <h3>The old behavior only hid the gap</h3>
+              <p>
+                Earlier local reports could say “ready” because they ignored old
+                findings. That did not close the finding; it merely stopped
+                considering it when readiness was calculated.
+              </p>
+            </article>
+          </div>
+        </section>
+
+        <section id="goal">
+          <h2>What do we want instead?</h2>
+          <div class="flow" aria-label="One finding key from prompt to closure">
+            <div>
+              <strong>1. Show one key</strong
+              ><span
+                >Every earlier finding or finding discussion gives the reviewer
+                the same durable finding key.</span
+              >
+            </div>
+            <div>
+              <strong>2. Copy the key</strong
+              ><span
+                >The reviewer copies that key when an issue continues, changes,
+                is fixed, or should be dismissed.</span
+              >
+            </div>
+            <div>
+              <strong>3. Apply the outcome</strong
+              ><span
+                >ReviewPhin calculates one lifecycle outcome, updates a platform
+                thread when needed, and commits the same saved state.</span
+              >
+            </div>
+          </div>
+          <ul class="checklist">
+            <li>
+              The reviewer uses one opaque finding key and never constructs or
+              edits it.
+            </li>
+            <li>
+              ReviewPhin assigns a key to a new finding. On later reviews, the
+              reviewer can only copy a key that ReviewPhin supplied in the
+              earlier-finding or discussion context.
+            </li>
+            <li>
+              The existing findings and prior-outcomes collections remain; no
+              second collection is added for local findings.
+            </li>
+            <li>
+              A current finding links to the key of the earlier finding it
+              continues or replaces. A prior outcome uses that same key to
+              resolve, dismiss, or reply about the earlier finding.
+            </li>
+            <li>
+              A closure must be explicit. Omitting an earlier finding never
+              silently marks it fixed.
+            </li>
+            <li>
+              Platform thread and comment identifiers stay inside publication
+              and conversation handling where they are actually needed.
+            </li>
+            <li>
+              Published and no-publish findings produce the same saved status
+              and the same readiness answer.
+            </li>
+            <li>
+              Existing stored findings and mappings are reused without a new
+              database column or migration.
+            </li>
+          </ul>
+        </section>
+
+        <section id="fix">
+          <h2>How do we fix it?</h2>
+          <table>
+            <thead>
+              <tr>
+                <th>Problem</th>
+                <th>Planned change</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  Earlier findings and discussions expose different identifiers.
+                </td>
+                <td>
+                  Give both prompt inputs the same durable finding key. Remove
+                  platform addresses from the reviewer-facing finding contract
+                  when the reviewer does not need them.
+                </td>
+              </tr>
+              <tr>
+                <td>A current finding must point back to an earlier issue.</td>
+                <td>
+                  Keep the existing finding object and let it copy the earlier
+                  finding key. ReviewPhin uses that link even when the title,
+                  wording, or line has changed.
+                </td>
+              </tr>
+              <tr>
+                <td>A closure currently names only a discussion.</td>
+                <td>
+                  Keep the existing prior-outcomes collection, but make every
+                  entry name the durable finding key. Do not add a second
+                  local-only outcome collection.
+                </td>
+              </tr>
+              <tr>
+                <td>A finding may or may not have a platform thread.</td>
+                <td>
+                  Always update saved finding state through the durable key. If
+                  a mapping exists, also update or resolve that platform thread.
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  An unknown or ambiguous key could target the wrong issue.
+                </td>
+                <td>
+                  Validate every copied key against the context supplied to the
+                  reviewer. An unknown key never changes earlier saved state or
+                  a platform thread. A current finding with an unknown earlier
+                  key is still saved as a new finding so the issue is not lost.
+                  If one key maps to several live threads, the saved finding may
+                  still be updated by its exact key, but all platform mutations
+                  for that key are skipped. Record both cases as structured
+                  diagnostics.
+                </td>
+              </tr>
+              <tr>
+                <td>Older saved results contain the previous identifiers.</td>
+                <td>
+                  At the stored-result read boundary, retain their overview and
+                  findings but discard historical lifecycle pointers that name
+                  only a discussion or thread. Those pointers are not displayed
+                  in reports and cannot be converted safely into finding keys.
+                  The current model contract accepts only finding keys.
+                </td>
+              </tr>
+            </tbody>
+          </table>
+          <div class="callout warning">
+            <strong>Important boundary:</strong> this plan unifies identifiers
+            for the reviewer’s finding lifecycle. A conversational reply still
+            needs the exact message or thread target supplied to the chatter
+            role. Do not force finding keys into unrelated reply routing.
+          </div>
+          <div class="callout">
+            <strong>Lifecycle rule:</strong> a linked current finding means the
+            concern continues. If its newly calculated key differs from the
+            copied earlier key, ReviewPhin retires the earlier finding and saves
+            the current one as its replacement. A key cannot be both continued
+            and resolved or dismissed in the same response. Duplicate or
+            contradictory references make the response invalid before any
+            lifecycle change is applied.
+          </div>
+        </section>
+
+        <section id="steps">
+          <h2>Work steps</h2>
+          <ol class="sequence">
+            <li>
+              <div>
+                <strong>Build one finding-key lookup.</strong> Combine earlier
+                saved findings and bot-owned finding discussions by their
+                durable key. Keep every matching live thread so duplicate
+                mappings are detected instead of overwritten. Keep
+                conversation-only routing out of this lookup.
+              </div>
+            </li>
+            <li>
+              <div>
+                <strong>Give prompt inputs one finding key.</strong> Add the
+                durable key to earlier discussion context and stop exposing
+                unnecessary platform addresses to the reviewer. Keep the same
+                key already present on saved prior findings.
+              </div>
+            </li>
+            <li>
+              <div>
+                <strong>Simplify the current response contract.</strong> Reuse
+                the existing finding and prior-outcome objects. Make both copy
+                the durable key. Keep only resolve and reply as prior-outcome
+                actions; a linked current finding already represents keep or
+                update. Require either resolved or dismissed for closure, and
+                require the reply body for a reply. Generate the prompt schema
+                from the strict current response schema, with no legacy
+                alternatives.
+              </div>
+            </li>
+            <li>
+              <div>
+                <strong>Make the prompt rules direct.</strong> Tell the reviewer
+                to copy keys exactly, link every continued issue, explicitly
+                close fixed or invalid issues, and leave an issue open when the
+                evidence is uncertain. Remove instructions that still ask for a
+                discussion identifier.
+              </div>
+            </li>
+            <li>
+              <div>
+                <strong>Project one lifecycle outcome.</strong> Turn only
+                validated closures and replacements into an in-memory transition
+                set. Project active findings from that set, then calculate
+                readiness. Published and no-publish runs must compute the same
+                outcome, and neither may infer a closure from omission.
+              </div>
+            </li>
+            <li>
+              <div>
+                <strong>Update the platform when possible.</strong> Resolve or
+                update a mapped GitHub or GitLab thread from the same finding
+                key. With no matching thread, a closure remains local, a linked
+                current finding gets a new thread when publishing is enabled,
+                and a requested reply is skipped with a diagnostic. One match is
+                safe to mutate. More than one match is ambiguous, so skip the
+                platform change while preserving the saved finding outcome.
+              </div>
+            </li>
+            <li>
+              <div>
+                <strong>Commit the saved lifecycle safely.</strong> After the
+                platform phase succeeds—or immediately when publishing is
+                disabled—apply the same transition set while the run still owns
+                the job, then save the final result. A failed platform phase
+                must not commit closures or replacements that a retry can no
+                longer see.
+              </div>
+            </li>
+            <li>
+              <div>
+                <strong>Keep old reports readable.</strong> Normalize historical
+                results only when they are read. Drop old discussion-only
+                lifecycle pointers, retain report content, and do not weaken
+                validation of a new model response to accommodate old data.
+              </div>
+            </li>
+            <li>
+              <div>
+                <strong>Test complete lifecycles.</strong> Cover two local runs,
+                two published runs, changed finding text and anchors, unknown
+                keys, duplicate thread mappings, contradictory output, old saved
+                output, claim loss, and matching readiness across reports and
+                platform summaries.
+              </div>
+            </li>
+          </ol>
+
+          <details>
+            <summary>Technical notes for the implementing agent</summary>
+            <ul>
+              <li>
+                In <a href="../../src/review/types.ts"><code>types.ts</code></a
+                >, replace
+                <code>reviewFindingSchema.priorDiscussionId</code> with an
+                optional <code>priorIdentityKey</code>, and replace
+                <code>priorDispositionSchema.discussionId</code> with required
+                <code>identityKey</code>. Make prior dispositions a strict
+                discriminated union: <code>resolve</code> requires
+                <code>resolution</code>, and <code>reply</code> requires
+                <code>replyBody</code>. Remove the no-op <code>keep</code> and
+                <code>update</code> disposition actions. Add
+                <code>identityKey</code> to
+                <code>ProviderDiscussionContext</code>. Add response-level
+                validation for duplicate prior keys and for a key that is both
+                continued and resolved or dismissed.
+              </li>
+              <li>
+                Keep <code>reviewResultSchema</code> as the one current reviewer
+                response schema. Do not add a no-publish response schema or a
+                second top-level disposition array. The compact JSON Schema in
+                <a href="../../src/prompts/prompt-builders.ts"
+                  ><code>prompt-builders.ts</code></a
+                >
+                must continue to be generated directly from it.
+              </li>
+              <li>
+                Update <code>buildCompactReviewContext</code> so
+                <code>reviewScope.priorFindings</code>,
+                <code>reviewScope.targetDiscussion</code>, and
+                <code>priorDiscussions</code> expose the canonical
+                <code>identityKey</code>. Omit <code>findingId</code>,
+                <code>platformDiscussionId</code>, and
+                <code>platformCommentId</code> from reviewer prompt objects.
+                Keep provider identifiers in runtime and chatter objects that
+                need exact reply routing.
+              </li>
+              <li>
+                Update
+                <a href="../../prompts/review/main.md"><code>main.md</code></a
+                >,
+                <a href="../../prompts/review/incremental-rereview.md"
+                  ><code>incremental-rereview.md</code></a
+                >,
+                <a href="../../prompts/review/review-author.md"
+                  ><code>review-author.md</code></a
+                >, and
+                <a href="../../prompts/review/summary-follow-up.md"
+                  ><code>summary-follow-up.md</code></a
+                >. Search all review prompt fragments for conflicting
+                <code>priorDiscussionId</code>, <code>discussionId</code>,
+                reply, and resolution guidance before finalizing the wording.
+              </li>
+              <li>
+                In
+                <a href="../../src/reconcile/discussion-reconciler.ts"
+                  ><code>discussion-reconciler.ts</code></a
+                >, make <code>KnownDiscussion</code>,
+                <code>buildProviderDiscussions</code>, matching, replacement,
+                disposition application, and summary projection key off
+                <code>identityKey</code>. Set that key from the stored mapping
+                when one exists; for an unmapped ReviewPhin discussion, use the
+                same deterministic fallback already used when its state is
+                persisted. Build
+                <code>Map&lt;string, KnownDiscussion[]&gt;</code>, not a map
+                that silently keeps one discussion per key. A missing entry is a
+                local-only finding; when a linked current finding is being
+                published, queue it as a new discussion. One entry is safe to
+                mutate. More than one entry records an ambiguity and skips the
+                platform mutation. Return enough reconciliation outcome for the
+                worker to commit the matching saved transition only after the
+                platform phase finishes successfully; do not calculate readiness
+                from mid-reconciliation writes. Move prior-finding calls to
+                <code>updateReviewFindingStatus</code> and
+                <code>retireReplacedFinding</code> out of the reconciler; keep
+                discussion-mapping writes there.
+              </li>
+              <li>
+                In
+                <a href="../../src/review/active-findings.ts"
+                  ><code>active-findings.ts</code></a
+                >, consume finding dispositions directly by
+                <code>identityKey</code> and remove
+                <code>discussionIdentities</code>. A linked current finding
+                removes its <code>priorIdentityKey</code> before adding its
+                newly calculated key; a resolve outcome removes its
+                <code>identityKey</code>. Keep omission conservative: an open
+                prior finding remains active unless one of those explicit
+                actions retires it. Add focused unit coverage in a new
+                <code>test/active-findings.test.ts</code>.
+              </li>
+              <li>
+                Project active findings once in the worker and pass that result
+                into publication summary rendering. Remove the reconciler's
+                second storage-backed <code>projectActiveFindings</code> pass so
+                published and no-publish readiness cannot diverge because they
+                read lifecycle state at different moments.
+              </li>
+              <li>
+                In
+                <a href="../../src/jobs/review-worker.ts"
+                  ><code>review-worker.ts</code></a
+                >, build and validate the lifecycle transition set before
+                projecting active findings. Persist current-run findings, run
+                reconciliation when publishing is enabled, and only after it
+                succeeds apply prior-finding status changes through the
+                claim-scoped
+                <code>updateReviewFindingStatusForClaim</code> path. A
+                no-publish run skips directly to the same status application.
+                Update only prior rows, use
+                <code>currentStatuses: ["open"]</code> for closure and
+                replacement, and treat <code>false</code> as lease loss. Write
+                unknown and ambiguous key diagnostics to the structured run log
+                and an orchestration artifact.
+              </li>
+              <li>
+                GitHub and GitLab prompt contexts are built in
+                <a href="../../src/platforms/github/review-runtime.ts"
+                  ><code>github/review-runtime.ts</code></a
+                >
+                and
+                <a href="../../src/platforms/gitlab/review-runtime.ts"
+                  ><code>gitlab/review-runtime.ts</code></a
+                >. Keep provider thread IDs in runtime objects for actual API
+                calls even if they leave the reviewer prompt.
+              </li>
+              <li>
+                Extend
+                <a href="../../src/review/persisted-review-result.ts"
+                  ><code>persisted-review-result.ts</code></a
+                >
+                only for older records already in storage. Historical
+                <code>priorDiscussionId</code> and <code>discussionId</code> or
+                <code>threadId</code> values are not safe live mutation targets
+                without a verified mapping. Strip the old finding link and drop
+                those prior disposition entries while retaining the overview and
+                findings needed by reports and incremental history.
+              </li>
+              <li>
+                No new stored field is currently expected. Existing review
+                finding and discussion mapping records already contain
+                <code>identityKey</code>. However, the draft must not assume
+                that existing one-at-a-time status updates are sufficient.
+                Decide whether the transition set needs a claim-checked batch
+                operation or an explicitly idempotent recovery protocol. That
+                choice may require a storage contract revision. Run the
+                repository schema-verification skill before implementation is
+                approved and again before merging any storage change.
+              </li>
+              <li>
+                Focus tests in
+                <a href="../../test/review-result-schema.test.ts"
+                  ><code>review-result-schema.test.ts</code></a
+                >,
+                <a href="../../test/review-prompt.test.ts"
+                  ><code>review-prompt.test.ts</code></a
+                >,
+                <a href="../../test/review-scope.test.ts"
+                  ><code>review-scope.test.ts</code></a
+                >,
+                <a href="../../test/discussion-reconciler.test.ts"
+                  ><code>discussion-reconciler.test.ts</code></a
+                >,
+                <a href="../../test/review-worker-orchestration.test.ts"
+                  ><code>review-worker-orchestration.test.ts</code></a
+                >,
+                <a href="../../test/github-requested-action-happy-path.test.ts"
+                  ><code>github-requested-action-happy-path.test.ts</code></a
+                >, and
+                <a href="../../test/mr-report-cli.test.ts"
+                  ><code>mr-report-cli.test.ts</code></a
+                >.
+              </li>
+            </ul>
+          </details>
+        </section>
+
+        <section id="done">
+          <h2>How do we know it works?</h2>
+          <ul class="checklist">
+            <li>
+              A first no-publish run stores one open finding. A second
+              no-publish run explicitly resolves it, stores the old finding as
+              resolved, and produces a ready report.
+            </li>
+            <li>
+              Resolving the same kind of finding after publication updates the
+              stored status and resolves the matching platform thread when the
+              platform supports it.
+            </li>
+            <li>
+              A current finding can link to and replace an earlier finding even
+              after its title, explanation, file line, or anchor changes.
+            </li>
+            <li>
+              Merely omitting an earlier finding leaves it open and keeps
+              readiness conservative.
+            </li>
+            <li>
+              An unknown key does not change an earlier finding or any platform
+              thread. A duplicated thread mapping does not block an exact saved
+              finding outcome, but it changes no platform thread. Both cases
+              leave a structured diagnostic with the key and skipped action.
+            </li>
+            <li>
+              Duplicate references and a response that both continues and closes
+              the same key fail validation before saved or platform state
+              changes.
+            </li>
+            <li>
+              If publication fails before reconciliation finishes, the run does
+              not commit its prior-finding closures or replacements. A retry can
+              still see the earlier open state and complete the platform work.
+            </li>
+            <li>
+              The current prompt schema contains one finding identifier and no
+              legacy discussion-address alternative for finding lifecycle
+              actions. Prior outcomes expose only strict resolve and reply
+              variants.
+            </li>
+            <li>
+              Older saved results still open in CLI reports and incremental
+              history loading without weakening current model validation.
+            </li>
+            <li>
+              Platform summaries, stored reports, and later review context all
+              agree about the same set of active findings and readiness.
+            </li>
+            <li>
+              Chatter can still reply to an exact requested comment or thread;
+              finding-key cleanup does not break conversation routing.
+            </li>
+          </ul>
+          <p>
+            <strong>Checks to run:</strong> targeted response-schema, prompt,
+            review-scope, worker orchestration, reconciler, GitHub requested
+            action, and merge-request report tests, <code>pnpm typecheck</code>,
+            <code>pnpm lint</code>, <code>pnpm test</code>, and
+            <code>pnpm build</code>.
+          </p>
+        </section>
+
+        <nav class="footer-nav" aria-label="Plan navigation">
+          <a href="13.tenant-autoregistration.html">← Tenant onboarding</a
+          ><a href="index.html">All plans →</a>
+        </nav>
+      </main>
+    </div>
+  </body>
+</html>

--- a/.agents/plans/index.html
+++ b/.agents/plans/index.html
@@ -15,7 +15,7 @@
             ><span class="brand-mark">◉</span><span>ReviewPhin plans</span></a
           >
           <p class="rail-label">Checked</p>
-          <p class="rail-value">25 July 2026</p>
+          <p class="rail-value">2 August 2026</p>
           <p class="rail-label">Database format</p>
           <p class="rail-value">storage-v006</p>
           <nav class="toc" aria-label="On this page">
@@ -29,14 +29,16 @@
       <main id="content">
         <header class="hero">
           <p class="eyebrow">Work we want to do</p>
-          <h1>Twelve plans, in the order that matters most.</h1>
+          <h1>Nine active plans and one parked draft.</h1>
           <p class="lede">
             Start at the top. The first plans fix things that can confuse users
             or produce bad review results. Later plans improve operator tools,
             documentation, and code health.
           </p>
           <div class="meta-grid">
-            <div class="meta-item"><span>Plans</span><strong>12</strong></div>
+            <div class="meta-item">
+              <span>Listed plans</span><strong>10</strong>
+            </div>
             <div class="meta-item">
               <span>Most urgent</span><strong>Safe publication</strong>
             </div>
@@ -165,6 +167,19 @@
                 an authenticated first webhook after proving project access.
               </p>
             </article>
+            <article class="card">
+              <span class="badge contract">14 · parked design draft</span>
+              <h3>
+                <a href="14.unified-finding-identity.html"
+                  >Use one durable key for each finding</a
+                >
+              </h3>
+              <p>
+                Preserve the proposed direction for unifying local and published
+                finding lifecycles. Do not implement it until atomic lifecycle
+                updates and recovery behavior are decided.
+              </p>
+            </article>
           </div>
         </section>
 
@@ -178,6 +193,13 @@
               </tr>
             </thead>
             <tbody>
+              <tr>
+                <td>14. Finding identity</td>
+                <td>
+                  Draft decision. No new field is expected, but an atomic batch
+                  update may require a storage contract revision.
+                </td>
+              </tr>
               <tr>
                 <td>2. Safe publication</td>
                 <td>

--- a/docs/src/content/docs/management/cli-reference.md
+++ b/docs/src/content/docs/management/cli-reference.md
@@ -510,6 +510,38 @@ With `--output json`, watch mode emits JSONL events: `review_submitted`, `job_st
 
 The final summary contains `jobId`, `created`, `jobStatus`, `runId`, `runStatus`, `runLogDirectory`, `findingCount`, `error`, and `liveLogsAvailable`. Exit code `0` means a no-watch submission succeeded or a watched job completed. Validation and operational errors, or watched jobs ending as failed, cancelled, or expired, return `1`; interrupted watches return `130` for `SIGINT` and `143` for `SIGTERM`.
 
+### `mr report`
+
+Display completed review reports stored for a tenant. Reports include published reviews and local runs created with `--no-publish` or `--no-comment`.
+
+```bash
+reviewphin mr report \
+  --key https://gitlab.example.com::123 \
+  --latest
+```
+
+Without a result filter, the command displays every stored report for the tenant, newest first. Completed interaction runs without a review result, such as reply-only runs, are omitted.
+
+| Flag                        | Required | Description                                                                                                                |
+| --------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `--key`                     | Yes      | Stable tenant key printed by `tenant list`.                                                                                |
+| `--latest`                  | No       | Display only the newest report after applying the other filters. Cannot be combined with `--limit`.                        |
+| `--limit`                   | No       | Display at most this many reports. Must be a positive integer and cannot be combined with `--latest`.                      |
+| `--code-review-id`          | No       | Include only this merge request IID or pull request number.                                                                |
+| `--code-review`             | No       | Alias for `--code-review-id`.                                                                                              |
+| `--trigger-type`            | No       | Include only `manual-review`, `direct-mention`, `follow-up-comment`, or `summary-follow-up` reports.                       |
+| `--type`                    | No       | Alias for `--trigger-type`.                                                                                                |
+| `--publication-mode`        | No       | Include only `publish` or `no-publish` reports.                                                                            |
+| `--report`, `-r`            | No       | Write the matching reports as one UTF-8 Markdown document, replacing an existing file. No file is written when none match. |
+| `--sqlite-database-path`    | No       | Override the SQLite path.                                                                                                  |
+| `--storage-provider-module` | No       | Override the storage adapter module.                                                                                       |
+
+Trigger-type filters use persisted run metrics and fall back to trigger metadata where the type is unambiguous. Historical reports without either source remain visible as type `unknown`, but do not match a trigger-type filter.
+
+Human-readable reports identify the tenant, merge request or pull request, completion time, trigger and publication modes, head SHA, job, and run. Suggested changes show the filename, line range, and replacement. When the stored code-review snapshot contains those lines, the report also shows the exact code being replaced.
+
+With `--output json`, the command returns an array of report objects. Each object contains the stored result and a `suggestedChanges` array with `path`, `startLine`, `endLine`, `replacedText`, and `replacement`. `replacedText` is `null` when the stored diff does not contain the complete suggested range. With `--report`, JSON output instead includes the resolved report path, count, and matching report objects.
+
 ---
 
 ## Diagnostic commands

--- a/docs/src/content/docs/management/cli-reference.md
+++ b/docs/src/content/docs/management/cli-reference.md
@@ -517,7 +517,7 @@ Display completed review reports stored for a tenant. Reports include published 
 ```bash
 reviewphin mr report \
   --key https://gitlab.example.com::123 \
-  --latest
+  --from 2026-07-01
 ```
 
 Without a result filter, the command displays every stored report for the tenant, newest first. Completed interaction runs without a review result, such as reply-only runs, are omitted.
@@ -525,6 +525,7 @@ Without a result filter, the command displays every stored report for the tenant
 | Flag                        | Required | Description                                                                                                                |
 | --------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------- |
 | `--key`                     | Yes      | Stable tenant key printed by `tenant list`.                                                                                |
+| `--from`                    | No       | Include reports completed on or after this date (`YYYY-MM-DD`, UTC).                                                       |
 | `--latest`                  | No       | Display only the newest report after applying the other filters. Cannot be combined with `--limit`.                        |
 | `--limit`                   | No       | Display at most this many reports. Must be a positive integer and cannot be combined with `--latest`.                      |
 | `--code-review-id`          | No       | Include only this merge request IID or pull request number.                                                                |
@@ -537,6 +538,8 @@ Without a result filter, the command displays every stored report for the tenant
 | `--storage-provider-module` | No       | Override the storage adapter module.                                                                                       |
 
 Trigger-type filters use persisted run metrics and fall back to trigger metadata where the type is unambiguous. Historical reports without either source remain visible as type `unknown`, but do not match a trigger-type filter.
+
+Historical results that use the former `threadId` name in prior-discussion dispositions remain readable. Disposition entries without either the current or former identifier are ignored because they do not affect the displayed findings.
 
 Human-readable reports identify the tenant, merge request or pull request, completion time, trigger and publication modes, head SHA, job, and run. Suggested changes show the filename, line range, and replacement. When the stored code-review snapshot contains those lines, the report also shows the exact code being replaced.
 

--- a/prompts/reply/chatter.md
+++ b/prompts/reply/chatter.md
@@ -4,9 +4,17 @@ You are the lightweight interaction chatter for a code review workflow.
 
 Respond only for the explicit `responseTargets` provided in the context. Never invent extra targets.
 
-Keep replies concise, human, and locally appropriate to the triggering discussion or comment.
+Keep replies concise, human, and locally appropriate to the triggering discussion or comment, but do not sacrifice structure for brevity.
 
-Match the language of the triggering request unless the user asks for another language. Write for a developer who may not know this project: use plain, direct language and explain necessary project-specific terms. Lead with the answer or requested action. Keep a simple answer in one short paragraph; when a reply contains separate reasons, conditions, or steps, split them into short paragraphs or a compact Markdown list instead of compressing them into one dense paragraph.
+For reply wording:
+
+- Match the language of the triggering request unless the user asks for another language.
+- Write for a developer who may not know this project. Use plain, direct language and explain necessary project-specific terms.
+- Lead with the answer or requested action.
+- Use one paragraph only when the reply contains one idea.
+- Separate distinct reasons or conditions into short paragraphs.
+- Use a compact Markdown list for multiple steps or items.
+- Put that formatting inside `replyBody`; do not add prose fields outside the response schema.
 
 The prompt context may include the same code-review, changed-file, comment, discussion, and scope structure used by the reviewer. Compact context exposes `codeReviewComments`, `priorDiscussions`, and discussion/comment reply targets. Use that shared context as your primary evidence before reaching for tools.
 

--- a/prompts/reply/chatter.md
+++ b/prompts/reply/chatter.md
@@ -6,6 +6,8 @@ Respond only for the explicit `responseTargets` provided in the context. Never i
 
 Keep replies concise, human, and locally appropriate to the triggering discussion or comment.
 
+Match the language of the triggering request unless the user asks for another language. Write for a developer who may not know this project: use plain, direct language and explain necessary project-specific terms. Lead with the answer or requested action. Keep a simple answer in one short paragraph; when a reply contains separate reasons, conditions, or steps, split them into short paragraphs or a compact Markdown list instead of compressing them into one dense paragraph.
+
 The prompt context may include the same code-review, changed-file, comment, discussion, and scope structure used by the reviewer. Compact context exposes `codeReviewComments`, `priorDiscussions`, and discussion/comment reply targets. Use that shared context as your primary evidence before reaching for tools.
 
 Read-only repository tools are available. Use them when the prompt context is not enough to answer accurately, especially for code-oriented questions about what changed or how a patch works.

--- a/prompts/reply/chatter.md
+++ b/prompts/reply/chatter.md
@@ -20,9 +20,16 @@ The prompt context may include the same code-review, changed-file, comment, disc
 
 Read-only repository tools are available. Use them when the prompt context is not enough to answer accurately, especially for code-oriented questions about what changed or how a patch works.
 
-When `phase` is `memory`, focus on deciding whether durable project memory should be written. Use `add_memory_entry` only for stable project policy, long-term preference, or future-facing guidance. Do not write memory for one-off patch remarks.
+When `phase` is `memory`:
 
-When `phase` is `reply`, produce one reply item per included target that needs a reply.
+- Decide whether durable project memory should be written. Use `add_memory_entry` only for stable project policy, long-term preference, or future-facing guidance. Do not write memory for one-off patch remarks.
+- Return a `memory` result with status `written` or `skipped`.
+- Return an empty `replies` array.
+
+When `phase` is `reply`:
+
+- Set `memory` to `null`.
+- Return exactly one reply for every provided `responseTarget`.
 
 Do not turn a reply into a broad code review. Summarize or explain the visible code-review context, and reserve defect hunting or formal findings for reviewer-owned flows.
 

--- a/prompts/reply/memory-update.md
+++ b/prompts/reply/memory-update.md
@@ -5,4 +5,4 @@ This phase runs before any optional reviewer pass.
 - Decide whether the grouped targets contain durable project memory worth saving.
 - If durable memory should be written, call `add_memory_entry` at most once for the batch.
 - Still return the JSON payload even when you write memory through the tool.
-- Do not generate reply bodies in this phase unless the schema explicitly includes them.
+- Return an empty `replies` array; replies are generated only in the reply phase.

--- a/prompts/review/main.md
+++ b/prompts/review/main.md
@@ -31,6 +31,7 @@ Use `overview` to describe the current overall state of the entire code review, 
 
 - Make `overview.summary` a one-sentence synopsis of the review result.
 - Use `overview.overallAssessment` for the short explanatory conclusion: state what matters across the review without repeating the synopsis.
+- Set `overview.mergeReadiness.status` to `ready` when there are no actionable findings, `blocked` when any actionable finding is critical, and `needs_attention` otherwise.
 - Use `overview.mergeReadiness.summary` only to explain the readiness status and the work, if any, that remains before merge.
 
 When `reviewScope.previousReview.overviewSummary` is present, treat it as a draft: preserve what remains true, revise it with the latest evidence and prior-finding state, and remove what is stale. Return one rewritten summary, not an appended update or review history.

--- a/prompts/review/main.md
+++ b/prompts/review/main.md
@@ -12,7 +12,14 @@ Start from the complete manifest, prioritize the newest delta, open findings, un
 
 Only report actionable findings that should become review discussions on the current platform. Do not restate neutral summaries as findings.
 
-Write each finding for a developer who may not know this project. Use plain, direct language and explain project-specific terms when they are necessary. State what is wrong, the concrete behavior or risk it causes, and what needs to change. Keep a short finding in one paragraph when that is clearest. When those parts need separate explanation, use short paragraphs or a compact Markdown list instead of compressing them into one dense paragraph.
+Write each finding for a developer who may not know this project:
+
+- Use plain, direct language and explain project-specific terms when they are necessary.
+- Make the problem, its concrete effect or risk, and the required change easy to identify.
+- Use separate short paragraphs when more than one of those parts needs explanation.
+- Use a compact Markdown list for multiple cases or steps.
+- Put that formatting inside the finding's `body`; do not add separate problem, impact, or fix fields.
+- Do not compress distinct points into one paragraph.
 
 Check the edited scope for concrete, actionable unused code introduced or left behind by the patch, such as unused locals, helper functions, imports, parameters, or computed values. Do not speculate about repository-wide dead code you cannot verify from the diff or inspected context.
 
@@ -52,12 +59,19 @@ Do not compose human-facing conversational replies outside existing bot-owned fi
 
 Do not say that a prior discussion is resolved, closed, or no longer needed unless you also include the matching `priorDispositions` entry with action `resolve` for that discussion.
 
-When you can express a safe, concrete fix directly from the visible diff and nearby code, include a `suggestion` with replacement text instead of only describing the change. Prefer suggestions for small-to-medium self-contained fixes on the new side of the diff.
+When a safe, concrete fix can replace a small-to-medium new-side range in the review diff, include a `suggestion` instead of only describing the change.
 
-Anchor a finding to the tightest valid changed-line range when it can be tied to specific code. Otherwise, report it without an anchor. Before returning, recheck every unanchored finding to see whether a valid changed-line anchor is available.
+Apply these anchor rules to each new finding:
 
-The anchor must point to the changed line that causes the reported behavior, not merely to a nearby file or related code. Name other relevant files or lines in the body when they help explain the evidence.
+- Anchor only when a line available in the review diff usefully locates the issue.
+- Prefer the tightest relevant new-side line or range.
+- An unchanged context line inside a diff hunk is valid when the patch should have changed that code but left it intact.
+- Use an old-side anchor only when removed code itself is the subject.
+- An anchor locates the issue; it does not need to be its only cause. For an omission or an interaction across locations, anchor the most relevant available diff line and name the other locations in the body.
+- If no relevant line is available in the diff, omit the anchor and identify the file, symbol, and line in the body when known.
+- Never choose an unrelated changed line merely to make the finding inline.
+- Before returning, recheck each anchor against the diff and each unanchored finding for a relevant diff line.
 
-Only emit a `suggestion` when the finding anchor points at the exact new-side lines to replace. Keep suggestion replacement as raw code text only, with no Markdown fences or commentary.
+Only emit a `suggestion` with a new-side anchor whose line range exactly matches the suggestion range. Keep the replacement as raw code text only, with no Markdown fences or commentary.
 
 Return JSON only. Do not wrap it in Markdown fences.

--- a/prompts/review/main.md
+++ b/prompts/review/main.md
@@ -29,6 +29,10 @@ For standalone unused-code cleanup findings, follow instruction precedence from 
 
 Use `overview` to describe the current overall state of the entire code review, assess merge readiness with confidence, and include concise highlights when useful. It must stand alone, regardless of this pass's inspection scope, and not summarize only the latest pass.
 
+- Make `overview.summary` a one-sentence synopsis of the review result.
+- Use `overview.overallAssessment` for the short explanatory conclusion: state what matters across the review without repeating the synopsis.
+- Use `overview.mergeReadiness.summary` only to explain the readiness status and the work, if any, that remains before merge.
+
 When `reviewScope.previousReview.overviewSummary` is present, treat it as a draft: preserve what remains true, revise it with the latest evidence and prior-finding state, and remove what is stale. Return one rewritten summary, not an appended update or review history.
 
 When continuing an existing bot-owned discussion, set `priorDiscussionId` on the finding instead of creating a duplicate discussion.

--- a/prompts/review/main.md
+++ b/prompts/review/main.md
@@ -12,6 +12,8 @@ Start from the complete manifest, prioritize the newest delta, open findings, un
 
 Only report actionable findings that should become review discussions on the current platform. Do not restate neutral summaries as findings.
 
+Write each finding for a developer who may not know this project. Use plain, direct language and explain project-specific terms when they are necessary. State what is wrong, the concrete behavior or risk it causes, and what needs to change. Keep a short finding in one paragraph when that is clearest. When those parts need separate explanation, use short paragraphs or a compact Markdown list instead of compressing them into one dense paragraph.
+
 Check the edited scope for concrete, actionable unused code introduced or left behind by the patch, such as unused locals, helper functions, imports, parameters, or computed values. Do not speculate about repository-wide dead code you cannot verify from the diff or inspected context.
 
 For standalone unused-code cleanup findings, follow instruction precedence from lowest to highest: these instructions, `projectMemory`, code-review-level user comments, then the current `reviewTrigger`. If the same evidence shows a separate correctness, security, or performance issue, assess that independently.
@@ -53,6 +55,8 @@ Do not say that a prior discussion is resolved, closed, or no longer needed unle
 When you can express a safe, concrete fix directly from the visible diff and nearby code, include a `suggestion` with replacement text instead of only describing the change. Prefer suggestions for small-to-medium self-contained fixes on the new side of the diff.
 
 Anchor a finding to the tightest valid changed-line range when it can be tied to specific code. Otherwise, report it without an anchor. Before returning, recheck every unanchored finding to see whether a valid changed-line anchor is available.
+
+The anchor must point to the changed line that causes the reported behavior, not merely to a nearby file or related code. Name other relevant files or lines in the body when they help explain the evidence.
 
 Only emit a `suggestion` when the finding anchor points at the exact new-side lines to replace. Keep suggestion replacement as raw code text only, with no Markdown fences or commentary.
 

--- a/prompts/review/review-author.md
+++ b/prompts/review/review-author.md
@@ -4,6 +4,8 @@ You are a review author.
 
 Produce only actionable, platform-ready review findings and explicit keep/update/reply/resolve dispositions for prior bot-owned discussions.
 
+Write for a developer who may not know this project. Use plain, direct language. For each finding, make the problem, its concrete effect or risk, and the required change easy to identify. Use short paragraphs or a compact Markdown list when the explanation has distinct parts; do not pack them into one dense paragraph.
+
 Treat the latest `reviewTrigger` as an explicit user instruction. If the user is asking for better wording or tone on an existing bot-owned discussion, return an updated finding for that same `priorDiscussionId` instead of defaulting to a reply.
 
 If a human already replied in a bot-owned discussion, prefer a new reply over silently editing the original comment. If you still revise the original comment because the user asked for clarification, wording changes, or corrections, also return a `priorDispositions` entry with action `reply` whose `replyBody` tells the user the original comment was edited.

--- a/prompts/review/review-author.md
+++ b/prompts/review/review-author.md
@@ -4,11 +4,9 @@ You are a review author.
 
 Produce only actionable, platform-ready review findings and explicit keep/update/reply/resolve dispositions for prior bot-owned discussions.
 
-Write for a developer who may not know this project. Use plain, direct language. For each finding, make the problem, its concrete effect or risk, and the required change easy to identify. Use short paragraphs or a compact Markdown list when the explanation has distinct parts; do not pack them into one dense paragraph.
-
 Treat the latest `reviewTrigger` as an explicit user instruction. If the user is asking for better wording or tone on an existing bot-owned discussion, return an updated finding for that same `priorDiscussionId` instead of defaulting to a reply.
 
-If a human already replied in a bot-owned discussion, prefer a new reply over silently editing the original comment. If you still revise the original comment because the user asked for clarification, wording changes, or corrections, also return a `priorDispositions` entry with action `reply` whose `replyBody` tells the user the original comment was edited.
+If a human already replied in a bot-owned discussion and the concern still applies, prefer a new reply over silently editing the original comment. If you still revise the original comment because the user asked for clarification, wording changes, or corrections, also return a `priorDispositions` entry with action `reply` whose `replyBody` tells the user the original comment was edited.
 
 Use read-only inspection tools for repository context.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -361,6 +361,7 @@ const mergeRequestReportSchema = z
   .object({
     tenantKey: z.string().min(1),
     codeReviewId: z.coerce.number().int().positive().optional(),
+    from: z.string().optional(),
     latest: z.boolean(),
     limit: z.coerce.number().int().positive().optional(),
     publicationMode: reviewPublicationModeSchema.optional(),
@@ -1703,7 +1704,7 @@ function printHelp(
     "model-profile clear-default [--sqlite-database-path <path>] [--storage-provider-module <module>]",
     "storage migrate --from-storage-provider-module <module> [--from-sqlite-database-path <path>] --to-storage-provider-module <module> [--to-sqlite-database-path <path>]",
     "mr describe (--tenant-id <id> | --key <key>) --code-review-id <id> [--current-interaction-job-id <id>] [--trigger-comment-id <id> --trigger-comment-action <create|update> [--trigger-comment-updated-at <iso>] [--trigger-comment-body <text>]] [--sqlite-database-path <path>] [--storage-provider-module <module>]",
-    "mr report --key <tenant-key> [--latest | --limit <count>] [--code-review-id <id> | --code-review <id>] [--trigger-type <manual-review|direct-mention|follow-up-comment|summary-follow-up> | --type <type>] [--publication-mode <publish|no-publish>] [--report <path> | -r <path>] [--sqlite-database-path <path>] [--storage-provider-module <module>]",
+    "mr report --key <tenant-key> [--from <YYYY-MM-DD>] [--latest | --limit <count>] [--code-review-id <id> | --code-review <id>] [--trigger-type <manual-review|direct-mention|follow-up-comment|summary-follow-up> | --type <type>] [--publication-mode <publish|no-publish>] [--report <path> | -r <path>] [--sqlite-database-path <path>] [--storage-provider-module <module>]",
     "mr review (--tenant-id <id> | --key <tenant-key>) (--trigger-comment-url <url> | --trigger-comment-id <id> | --trigger-text <text> | --trigger-text-file <path>) [--code-review-id <id>] [--force-new] [--watch | --no-watch] [--no-publish | --no-comment] [--report <path> | -r <path>] [--sqlite-database-path <path>] [--storage-provider-module <module>] [--run-log-dir <path>]",
     "metrics sessions [--connection <name>] [--from <YYYY-MM-DD>] [--to <YYYY-MM-DD>] [--all-sessions] [--sqlite-database-path <path>] [--storage-provider-module <module>]",
     "metrics collect [--run-log-dir <path>] [--dry-run] [--sqlite-database-path <path>] [--storage-provider-module <module>]",
@@ -1949,9 +1950,11 @@ async function runMergeRequestReportCommand(
     "code-review",
   );
   const triggerType = resolveEquivalentOptions(options, "trigger-type", "type");
+  const dateRange = parseMetricsDateRange({ from: options.from });
   const input = mergeRequestReportSchema.parse({
     tenantKey: options.key,
     codeReviewId,
+    from: dateRange.from ?? undefined,
     latest: Object.hasOwn(options, "latest"),
     limit: options.limit,
     publicationMode: options["publication-mode"],

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -15,6 +15,7 @@ import { loadLocalEnvFile } from "./env.js";
 import type { ModelCatalogClientFactory } from "./review/model-catalog.js";
 import { maskSecret } from "./review/model-profiles.js";
 import {
+  reviewPublicationModeSchema,
   getReviewPublicationMode,
   scopeReviewDedupeKeyToPublicationMode,
   setReviewPublicationMode,
@@ -70,9 +71,17 @@ import {
   type ReviewWatchSummary,
 } from "./cli/review-watch.js";
 import {
+  formatMarkdownForTerminal,
   formatReviewReportForTerminal,
   writeReviewReport,
 } from "./cli/review-report.js";
+import {
+  formatStoredReviewReportsMarkdown,
+  loadStoredReviewReports,
+  REVIEW_REPORT_TRIGGER_TYPES,
+  toStoredReviewReportOutput,
+  writeStoredReviewReports,
+} from "./cli/stored-review-reports.js";
 import {
   listAvailableModels,
   validateProfileModels,
@@ -346,6 +355,21 @@ const mergeRequestReviewSchema = z
         path: ["codeReviewId"],
       });
     }
+  });
+
+const mergeRequestReportSchema = z
+  .object({
+    tenantKey: z.string().min(1),
+    codeReviewId: z.coerce.number().int().positive().optional(),
+    latest: z.boolean(),
+    limit: z.coerce.number().int().positive().optional(),
+    publicationMode: reviewPublicationModeSchema.optional(),
+    triggerType: z.enum(REVIEW_REPORT_TRIGGER_TYPES).optional(),
+    reportPath: z.string().min(1).optional(),
+  })
+  .refine((value) => !(value.latest && value.limit !== undefined), {
+    message: "Cannot combine --latest with --limit.",
+    path: ["limit"],
   });
 
 interface CodeReviewTriggerDedupeInput {
@@ -1428,6 +1452,10 @@ async function runCliCommand(
     return runMergeRequestReviewCommand(options, config, logger);
   }
 
+  if (resource === "mr" && action === "report") {
+    return runMergeRequestReportCommand(options, config);
+  }
+
   if (resource === "metrics" && action === "sessions") {
     const config = loadConfig();
     return withStorage(options, config, async (storage) => {
@@ -1675,6 +1703,7 @@ function printHelp(
     "model-profile clear-default [--sqlite-database-path <path>] [--storage-provider-module <module>]",
     "storage migrate --from-storage-provider-module <module> [--from-sqlite-database-path <path>] --to-storage-provider-module <module> [--to-sqlite-database-path <path>]",
     "mr describe (--tenant-id <id> | --key <key>) --code-review-id <id> [--current-interaction-job-id <id>] [--trigger-comment-id <id> --trigger-comment-action <create|update> [--trigger-comment-updated-at <iso>] [--trigger-comment-body <text>]] [--sqlite-database-path <path>] [--storage-provider-module <module>]",
+    "mr report --key <tenant-key> [--latest | --limit <count>] [--code-review-id <id> | --code-review <id>] [--trigger-type <manual-review|direct-mention|follow-up-comment|summary-follow-up> | --type <type>] [--publication-mode <publish|no-publish>] [--report <path> | -r <path>] [--sqlite-database-path <path>] [--storage-provider-module <module>]",
     "mr review (--tenant-id <id> | --key <tenant-key>) (--trigger-comment-url <url> | --trigger-comment-id <id> | --trigger-text <text> | --trigger-text-file <path>) [--code-review-id <id>] [--force-new] [--watch | --no-watch] [--no-publish | --no-comment] [--report <path> | -r <path>] [--sqlite-database-path <path>] [--storage-provider-module <module>] [--run-log-dir <path>]",
     "metrics sessions [--connection <name>] [--from <YYYY-MM-DD>] [--to <YYYY-MM-DD>] [--all-sessions] [--sqlite-database-path <path>] [--storage-provider-module <module>]",
     "metrics collect [--run-log-dir <path>] [--dry-run] [--sqlite-database-path <path>] [--storage-provider-module <module>]",
@@ -1908,6 +1937,85 @@ async function runCodeReviewDescribeCommand(
     });
     return 0;
   });
+}
+
+async function runMergeRequestReportCommand(
+  options: Record<string, string | boolean>,
+  config: ReturnType<typeof loadConfig>,
+): Promise<number> {
+  const codeReviewId = resolveEquivalentOptions(
+    options,
+    "code-review-id",
+    "code-review",
+  );
+  const triggerType = resolveEquivalentOptions(options, "trigger-type", "type");
+  const input = mergeRequestReportSchema.parse({
+    tenantKey: options.key,
+    codeReviewId,
+    latest: Object.hasOwn(options, "latest"),
+    limit: options.limit,
+    publicationMode: options["publication-mode"],
+    triggerType,
+    reportPath: options.report,
+  });
+
+  return withStorage(options, config, async (storage) => {
+    const tenant = await storage.stores.tenants.find({
+      key: { eq: input.tenantKey },
+    });
+    if (!tenant) {
+      throw new Error(`Tenant ${input.tenantKey} was not found.`);
+    }
+
+    const reports = await loadStoredReviewReports(storage, tenant, input);
+    const reportOutput = reports.map(toStoredReviewReportOutput);
+    if (input.reportPath && reports.length > 0) {
+      const reportPath = resolve(process.cwd(), input.reportPath);
+      await writeStoredReviewReports(reportPath, reports);
+      output().result(
+        {
+          count: reports.length,
+          reportPath,
+          reports: reportOutput,
+        },
+        {
+          pretty: `Wrote ${reports.length} review ${
+            reports.length === 1 ? "report" : "reports"
+          } to ${reportPath}.`,
+        },
+      );
+      return 0;
+    }
+
+    output().result(reportOutput, {
+      pretty:
+        reports.length === 0
+          ? output().style("muted", "No stored review reports found.")
+          : () =>
+              formatMarkdownForTerminal(
+                formatStoredReviewReportsMarkdown(reports),
+                output(),
+              ),
+    });
+    return 0;
+  });
+}
+
+function resolveEquivalentOptions(
+  options: Record<string, string | boolean>,
+  preferred: string,
+  alias: string,
+): string | boolean | undefined {
+  const preferredValue = options[preferred];
+  const aliasValue = options[alias];
+  if (
+    preferredValue !== undefined &&
+    aliasValue !== undefined &&
+    preferredValue !== aliasValue
+  ) {
+    throw new Error(`--${preferred} and --${alias} must have the same value.`);
+  }
+  return preferredValue ?? aliasValue;
 }
 
 async function runMergeRequestReviewCommand(

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,7 +21,8 @@ import {
   setReviewPublicationMode,
   type ReviewPublicationMode,
 } from "./review/publication.js";
-import { reviewResultSchema, type ReviewResult } from "./review/types.js";
+import type { ReviewResult } from "./review/types.js";
+import { parsePersistedReviewResult } from "./review/persisted-review-result.js";
 import {
   collectMetrics,
   displayUsageUnit,
@@ -2208,7 +2209,8 @@ async function loadCompletedReviewResult(
   if (!run.resultJson) {
     throw new Error(`Completed review run ${run.id} has no review result.`);
   }
-  return reviewResultSchema.parse(JSON.parse(run.resultJson) as unknown);
+  // Normalize only because a watched run may resolve to an older stored record.
+  return parsePersistedReviewResult(run.resultJson);
 }
 
 async function resolveLocalReviewSelector(

--- a/src/cli/review-report.ts
+++ b/src/cli/review-report.ts
@@ -3,12 +3,25 @@ import { writeFile } from "node:fs/promises";
 import { Marked } from "marked";
 import { markedTerminal } from "marked-terminal";
 
-import type { ReviewAnchor, ReviewResult } from "../review/types.js";
+import type {
+  CodeReviewChange,
+  ReviewAnchor,
+  ReviewResult,
+} from "../review/types.js";
 import type { CliOutput } from "./output.js";
 
-export function formatReviewReportMarkdown(result: ReviewResult): string {
+export interface ReviewReportFormatOptions {
+  readonly changes?: readonly CodeReviewChange[] | undefined;
+  readonly headingLevel?: number | undefined;
+}
+
+export function formatReviewReportMarkdown(
+  result: ReviewResult,
+  options: ReviewReportFormatOptions = {},
+): string {
+  const headingLevel = options.headingLevel ?? 1;
   const lines = [
-    "# Review result",
+    heading(headingLevel, "Review result"),
     "",
     `**Overall severity:** ${capitalize(result.overview.overallSeverity)}`,
     "",
@@ -22,7 +35,7 @@ export function formatReviewReportMarkdown(result: ReviewResult): string {
   if (result.overview.mergeReadiness) {
     lines.push(
       "",
-      "## Merge readiness",
+      heading(headingLevel + 1, "Merge readiness"),
       "",
       `**Status:** ${formatLabel(result.overview.mergeReadiness.status)}`,
       "",
@@ -35,7 +48,7 @@ export function formatReviewReportMarkdown(result: ReviewResult): string {
   if (result.overview.highlights?.length) {
     lines.push(
       "",
-      "## Highlights",
+      heading(headingLevel + 1, "Highlights"),
       "",
       ...result.overview.highlights.map(
         (highlight) => `- ${escapeMarkdownText(highlight)}`,
@@ -43,13 +56,20 @@ export function formatReviewReportMarkdown(result: ReviewResult): string {
     );
   }
 
-  lines.push("", `## Findings (${result.findings.length})`, "");
+  lines.push(
+    "",
+    heading(headingLevel + 1, `Findings (${result.findings.length})`),
+    "",
+  );
   if (result.findings.length === 0) {
     lines.push("No findings.");
   } else {
     for (const [index, finding] of result.findings.entries()) {
       lines.push(
-        `### ${index + 1}. ${escapeMarkdownText(finding.title)}`,
+        heading(
+          headingLevel + 2,
+          `${index + 1}. ${escapeMarkdownText(finding.title)}`,
+        ),
         "",
         `- **Severity:** ${capitalize(finding.severity)}`,
         `- **Category:** ${capitalize(finding.category)}`,
@@ -62,9 +82,29 @@ export function formatReviewReportMarkdown(result: ReviewResult): string {
       }
       lines.push("", finding.body.trim());
       if (finding.suggestion) {
+        const source = extractSuggestionSource(
+          options.changes ?? [],
+          finding.anchor ?? null,
+          finding.suggestion.startLine,
+          finding.suggestion.endLine,
+        );
         lines.push(
           "",
-          "#### Suggested change",
+          heading(headingLevel + 3, "Suggested change"),
+          "",
+          ...(finding.anchor
+            ? [
+                `- **File:** ${inlineCode(finding.anchor.path)}`,
+                `- **Lines:** ${formatLineRange(
+                  finding.suggestion.startLine,
+                  finding.suggestion.endLine,
+                )}`,
+                "",
+              ]
+            : []),
+          ...(source !== null
+            ? ["**Replace:**", "", fencedCode(source, "text"), "", "**With:**"]
+            : ["**Replace the indicated lines with:**"]),
           "",
           fencedCode(finding.suggestion.replacement, "suggestion"),
         );
@@ -78,6 +118,17 @@ export function formatReviewReportMarkdown(result: ReviewResult): string {
 
 export function formatReviewReportForTerminal(
   result: ReviewResult,
+  output: CliOutput,
+  options: ReviewReportFormatOptions = {},
+): string {
+  return formatMarkdownForTerminal(
+    formatReviewReportMarkdown(result, options),
+    output,
+  );
+}
+
+export function formatMarkdownForTerminal(
+  markdown: string,
   output: CliOutput,
 ): string {
   const marked = new Marked();
@@ -104,7 +155,7 @@ export function formatReviewReportForTerminal(
       href: (value) => value,
     }),
   );
-  const rendered = marked.parse(formatReviewReportMarkdown(result));
+  const rendered = marked.parse(markdown);
   if (typeof rendered !== "string") {
     throw new Error("Terminal report rendering unexpectedly became async.");
   }
@@ -114,16 +165,66 @@ export function formatReviewReportForTerminal(
 export async function writeReviewReport(
   path: string,
   result: ReviewResult,
+  options: ReviewReportFormatOptions = {},
 ): Promise<void> {
-  await writeFile(path, formatReviewReportMarkdown(result), "utf8");
+  await writeFile(path, formatReviewReportMarkdown(result, options), "utf8");
+}
+
+function heading(level: number, value: string): string {
+  return `${"#".repeat(Math.max(1, level))} ${value}`;
 }
 
 function formatAnchor(anchor: ReviewAnchor): string {
-  const lineRange =
-    anchor.startLine === anchor.endLine
-      ? `line ${anchor.startLine}`
-      : `lines ${anchor.startLine}-${anchor.endLine}`;
+  const lineRange = formatLineRange(anchor.startLine, anchor.endLine);
   return `${inlineCode(anchor.path)}, ${lineRange} (${anchor.side} side)`;
+}
+
+function formatLineRange(startLine: number, endLine: number): string {
+  return startLine === endLine
+    ? `line ${startLine}`
+    : `lines ${startLine}-${endLine}`;
+}
+
+export function extractSuggestionSource(
+  changes: readonly CodeReviewChange[],
+  anchor: ReviewAnchor | null,
+  startLine: number,
+  endLine: number,
+): string | null {
+  if (!anchor || anchor.side !== "new") {
+    return null;
+  }
+  const change = changes.find((entry) => entry.newPath === anchor.path);
+  if (!change?.diff) {
+    return null;
+  }
+
+  const linesByNumber = new Map<number, string>();
+  let newLine: number | null = null;
+  for (const line of change.diff.replace(/\r\n/g, "\n").split("\n")) {
+    const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
+    if (hunk) {
+      newLine = Number(hunk[1]);
+      continue;
+    }
+    if (newLine === null || line.startsWith("\\")) {
+      continue;
+    }
+    if (line.startsWith("-")) {
+      continue;
+    }
+    if (line.startsWith("+") || line.startsWith(" ")) {
+      if (newLine >= startLine && newLine <= endLine) {
+        linesByNumber.set(newLine, line.slice(1));
+      }
+      newLine += 1;
+    }
+  }
+
+  const source = Array.from({ length: endLine - startLine + 1 }, (_, index) =>
+    linesByNumber.get(startLine + index),
+  );
+  return source.every((line) => line !== undefined) ? source.join("\n") : null;
 }
 
 function inlineCode(value: string): string {

--- a/src/cli/review-report.ts
+++ b/src/cli/review-report.ts
@@ -26,24 +26,22 @@ export function formatReviewReportMarkdown(
     `**Overall severity:** ${capitalize(result.overview.overallSeverity)}`,
     "",
     result.overview.summary.trim(),
+    "",
+    heading(headingLevel + 1, "Overall assessment"),
+    "",
+    result.overview.overallAssessment.trim(),
   ];
 
-  if (result.overview.overallAssessment) {
-    lines.push("", result.overview.overallAssessment.trim());
-  }
-
-  if (result.overview.mergeReadiness) {
-    lines.push(
-      "",
-      heading(headingLevel + 1, "Merge readiness"),
-      "",
-      `**Status:** ${formatLabel(result.overview.mergeReadiness.status)}`,
-      "",
-      `**Confidence:** ${capitalize(result.overview.mergeReadiness.confidence)}`,
-      "",
-      result.overview.mergeReadiness.summary.trim(),
-    );
-  }
+  lines.push(
+    "",
+    heading(headingLevel + 1, "Merge readiness"),
+    "",
+    `**Status:** ${formatLabel(result.overview.mergeReadiness.status)}`,
+    "",
+    `**Confidence:** ${capitalize(result.overview.mergeReadiness.confidence)}`,
+    "",
+    result.overview.mergeReadiness.summary.trim(),
+  );
 
   if (result.overview.highlights?.length) {
     lines.push(

--- a/src/cli/stored-review-reports.ts
+++ b/src/cli/stored-review-reports.ts
@@ -5,11 +5,11 @@ import {
   type ReviewPublicationMode,
 } from "../review/publication.js";
 import {
-  reviewResultSchema,
   type CodeReviewChange,
   type ReviewResult,
   type ReviewTriggerKind,
 } from "../review/types.js";
+import { parsePersistedReviewResult } from "../review/persisted-review-result.js";
 import type {
   CodeReviewSnapshotRecord,
   InteractionJobRecord,
@@ -142,37 +142,11 @@ export async function loadStoredReviewReports(
       triggerType: triggerTypeByRunId.get(run.id) ?? null,
       startedAt: run.startedAt,
       finishedAt: run.finishedAt,
-      result: parseStoredReviewResult(run.resultJson!),
+      // Normalize only because CLI reports can read older records from storage.
+      result: parsePersistedReviewResult(run.resultJson!),
       changes: parseReviewChanges(snapshotByRunId.get(run.id)?.changesJson),
     };
   });
-}
-
-function parseStoredReviewResult(resultJson: string): ReviewResult {
-  const parsed = JSON.parse(resultJson) as unknown;
-  if (!isRecord(parsed) || !Array.isArray(parsed.priorDispositions)) {
-    return reviewResultSchema.parse(parsed);
-  }
-
-  return reviewResultSchema.parse({
-    ...parsed,
-    priorDispositions: parsed.priorDispositions.flatMap((disposition) => {
-      if (!isRecord(disposition)) {
-        return [];
-      }
-      if (typeof disposition.discussionId === "string") {
-        return [disposition];
-      }
-      if (typeof disposition.threadId === "string") {
-        return [{ ...disposition, discussionId: disposition.threadId }];
-      }
-      return [];
-    }),
-  });
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
 export function formatStoredReviewReportsMarkdown(

--- a/src/cli/stored-review-reports.ts
+++ b/src/cli/stored-review-reports.ts
@@ -1,0 +1,355 @@
+import { writeFile } from "node:fs/promises";
+
+import {
+  getReviewPublicationMode,
+  type ReviewPublicationMode,
+} from "../review/publication.js";
+import {
+  reviewResultSchema,
+  type CodeReviewChange,
+  type ReviewResult,
+  type ReviewTriggerKind,
+} from "../review/types.js";
+import type {
+  CodeReviewSnapshotRecord,
+  InteractionJobRecord,
+  InteractionRunMetricsRecord,
+  InteractionRunRecord,
+  TenantRecord,
+} from "../storage/contract/index.js";
+import { listAll, type StorageHelpers } from "../storage/storage-helpers.js";
+import {
+  extractSuggestionSource,
+  formatReviewReportMarkdown,
+} from "./review-report.js";
+
+export const REVIEW_REPORT_TRIGGER_TYPES = [
+  "manual-review",
+  "direct-mention",
+  "follow-up-comment",
+  "summary-follow-up",
+] as const satisfies readonly ReviewTriggerKind[];
+
+export interface StoredReviewReportFilters {
+  readonly codeReviewId?: number | undefined;
+  readonly latest: boolean;
+  readonly limit?: number | undefined;
+  readonly publicationMode?: ReviewPublicationMode | undefined;
+  readonly triggerType?: ReviewTriggerKind | undefined;
+}
+
+export interface StoredReviewReport {
+  readonly tenantId: string;
+  readonly tenantKey: string;
+  readonly codeReviewId: number;
+  readonly interactionJobId: string;
+  readonly interactionRunId: string;
+  readonly headSha: string;
+  readonly publicationMode: ReviewPublicationMode;
+  readonly triggerType: ReviewTriggerKind | null;
+  readonly startedAt: string;
+  readonly finishedAt: string | null;
+  readonly result: ReviewResult;
+  readonly changes: readonly CodeReviewChange[];
+}
+
+export interface StoredReviewReportOutput extends Omit<
+  StoredReviewReport,
+  "changes"
+> {
+  readonly suggestedChanges: ReadonlyArray<{
+    readonly finding: string;
+    readonly path: string | null;
+    readonly startLine: number;
+    readonly endLine: number;
+    readonly replacedText: string | null;
+    readonly replacement: string;
+  }>;
+}
+
+export async function loadStoredReviewReports(
+  storage: StorageHelpers,
+  tenant: TenantRecord,
+  filters: StoredReviewReportFilters,
+): Promise<StoredReviewReport[]> {
+  const jobs = await listAll(storage.stores.interactionJobs, {
+    filters: {
+      tenantId: { eq: tenant.id },
+      ...(filters.codeReviewId === undefined
+        ? {}
+        : { codeReviewId: { eq: filters.codeReviewId } }),
+    },
+  });
+  const eligibleJobs = jobs.filter(
+    (job) =>
+      filters.publicationMode === undefined ||
+      getReviewPublicationMode(job.triggerJson) === filters.publicationMode,
+  );
+  if (eligibleJobs.length === 0) {
+    return [];
+  }
+
+  const jobById = new Map(eligibleJobs.map((job) => [job.id, job]));
+  let runs = (
+    await listAll(storage.stores.interactionRuns, {
+      filters: {
+        tenantId: { eq: tenant.id },
+        status: { eq: "completed" },
+        resultJson: { isNull: false },
+      },
+      order: [
+        { field: "finishedAt", direction: "desc" },
+        { field: "id", direction: "desc" },
+      ],
+    })
+  ).filter((run) => jobById.has(run.interactionJobId));
+
+  let triggerTypeByRunId: Map<string, ReviewTriggerKind>;
+  if (filters.triggerType) {
+    triggerTypeByRunId = await loadTriggerTypes(storage, runs, jobById);
+    runs = runs.filter(
+      (run) => triggerTypeByRunId.get(run.id) === filters.triggerType,
+    );
+  } else {
+    triggerTypeByRunId = new Map();
+  }
+
+  const selectedRuns = runs.slice(
+    0,
+    filters.latest ? 1 : (filters.limit ?? runs.length),
+  );
+  if (selectedRuns.length === 0) {
+    return [];
+  }
+
+  if (!filters.triggerType) {
+    triggerTypeByRunId = await loadTriggerTypes(storage, selectedRuns, jobById);
+  }
+  const snapshotByRunId = await loadSnapshots(storage, selectedRuns);
+
+  return selectedRuns.map((run) => {
+    const job = jobById.get(run.interactionJobId)!;
+    return {
+      tenantId: tenant.id,
+      tenantKey: tenant.key,
+      codeReviewId: job.codeReviewId,
+      interactionJobId: job.id,
+      interactionRunId: run.id,
+      headSha: job.headSha,
+      publicationMode: getReviewPublicationMode(job.triggerJson),
+      triggerType: triggerTypeByRunId.get(run.id) ?? null,
+      startedAt: run.startedAt,
+      finishedAt: run.finishedAt,
+      result: reviewResultSchema.parse(JSON.parse(run.resultJson!) as unknown),
+      changes: parseReviewChanges(snapshotByRunId.get(run.id)?.changesJson),
+    };
+  });
+}
+
+export function formatStoredReviewReportsMarkdown(
+  reports: readonly StoredReviewReport[],
+): string {
+  const documents = reports
+    .map((report) =>
+      [
+        "# Merge request review report",
+        "",
+        `- **Tenant:** ${inlineCode(report.tenantKey)}`,
+        `- **Code review:** ${report.codeReviewId}`,
+        `- **Completed:** ${report.finishedAt ?? report.startedAt}`,
+        `- **Trigger type:** ${report.triggerType ?? "unknown"}`,
+        `- **Publication mode:** ${report.publicationMode}`,
+        `- **Head SHA:** ${inlineCode(report.headSha)}`,
+        `- **Interaction job:** ${inlineCode(report.interactionJobId)}`,
+        `- **Interaction run:** ${inlineCode(report.interactionRunId)}`,
+        "",
+        formatReviewReportMarkdown(report.result, {
+          changes: report.changes,
+          headingLevel: 2,
+        }).trimEnd(),
+      ].join("\n"),
+    )
+    .join("\n\n---\n\n");
+  return `${documents}\n`;
+}
+
+export async function writeStoredReviewReports(
+  path: string,
+  reports: readonly StoredReviewReport[],
+): Promise<void> {
+  await writeFile(path, formatStoredReviewReportsMarkdown(reports), "utf8");
+}
+
+export function toStoredReviewReportOutput(
+  report: StoredReviewReport,
+): StoredReviewReportOutput {
+  return {
+    tenantId: report.tenantId,
+    tenantKey: report.tenantKey,
+    codeReviewId: report.codeReviewId,
+    interactionJobId: report.interactionJobId,
+    interactionRunId: report.interactionRunId,
+    headSha: report.headSha,
+    publicationMode: report.publicationMode,
+    triggerType: report.triggerType,
+    startedAt: report.startedAt,
+    finishedAt: report.finishedAt,
+    result: report.result,
+    suggestedChanges: report.result.findings.flatMap((finding) => {
+      if (!finding.suggestion) {
+        return [];
+      }
+      return [
+        {
+          finding: finding.title,
+          path: finding.anchor?.path ?? null,
+          startLine: finding.suggestion.startLine,
+          endLine: finding.suggestion.endLine,
+          replacedText: extractSuggestionSource(
+            report.changes,
+            finding.anchor ?? null,
+            finding.suggestion.startLine,
+            finding.suggestion.endLine,
+          ),
+          replacement: finding.suggestion.replacement,
+        },
+      ];
+    }),
+  };
+}
+
+async function loadTriggerTypes(
+  storage: StorageHelpers,
+  runs: readonly InteractionRunRecord[],
+  jobById: ReadonlyMap<string, InteractionJobRecord>,
+): Promise<Map<string, ReviewTriggerKind>> {
+  const metrics = await loadMetrics(
+    storage,
+    runs.map((run) => run.id),
+  );
+  const typeByRunId = new Map<string, ReviewTriggerKind>();
+  for (const entry of metrics) {
+    if (isReviewTriggerKind(entry.triggerKind)) {
+      typeByRunId.set(entry.interactionRunId, entry.triggerKind);
+    }
+  }
+  for (const run of runs) {
+    if (typeByRunId.has(run.id)) {
+      continue;
+    }
+    const job = jobById.get(run.interactionJobId);
+    const fallback = job ? inferTriggerType(job.triggerJson) : null;
+    if (fallback) {
+      typeByRunId.set(run.id, fallback);
+    }
+  }
+  return typeByRunId;
+}
+
+async function loadMetrics(
+  storage: StorageHelpers,
+  runIds: readonly string[],
+): Promise<InteractionRunMetricsRecord[]> {
+  const metrics: InteractionRunMetricsRecord[] = [];
+  for (let offset = 0; offset < runIds.length; offset += 100) {
+    metrics.push(
+      ...(await listAll(storage.stores.interactionRunMetrics, {
+        filters: {
+          interactionRunId: { in: runIds.slice(offset, offset + 100) },
+        },
+      })),
+    );
+  }
+  return metrics;
+}
+
+async function loadSnapshots(
+  storage: StorageHelpers,
+  runs: readonly InteractionRunRecord[],
+): Promise<Map<string, CodeReviewSnapshotRecord>> {
+  const jobIds = [...new Set(runs.map((run) => run.interactionJobId))];
+  const snapshots: CodeReviewSnapshotRecord[] = [];
+  for (let offset = 0; offset < jobIds.length; offset += 100) {
+    snapshots.push(
+      ...(await listAll(storage.stores.codeReviewSnapshots, {
+        filters: {
+          interactionJobId: { in: jobIds.slice(offset, offset + 100) },
+        },
+        order: [{ field: "createdAt", direction: "desc" }],
+      })),
+    );
+  }
+
+  const latestLegacyByJobId = new Map<string, CodeReviewSnapshotRecord>();
+  const byRunId = new Map<string, CodeReviewSnapshotRecord>();
+  for (const snapshot of snapshots) {
+    if (snapshot.interactionRunId) {
+      if (!byRunId.has(snapshot.interactionRunId)) {
+        byRunId.set(snapshot.interactionRunId, snapshot);
+      }
+    } else if (!latestLegacyByJobId.has(snapshot.interactionJobId)) {
+      latestLegacyByJobId.set(snapshot.interactionJobId, snapshot);
+    }
+  }
+  for (const run of runs) {
+    const legacy = latestLegacyByJobId.get(run.interactionJobId);
+    if (!byRunId.has(run.id) && legacy) {
+      byRunId.set(run.id, legacy);
+    }
+  }
+  return byRunId;
+}
+
+function inferTriggerType(triggerJson: string): ReviewTriggerKind | null {
+  const trigger = JSON.parse(triggerJson) as unknown;
+  if (!trigger || typeof trigger !== "object" || Array.isArray(trigger)) {
+    return null;
+  }
+  const value = trigger as Record<string, unknown>;
+  if (isReviewTriggerKind(value.triggerKind)) {
+    return value.triggerKind;
+  }
+  return value.kind === "reviewphin-local-review" ||
+    value.kind === "github-check-run"
+    ? "manual-review"
+    : null;
+}
+
+function isReviewTriggerKind(value: unknown): value is ReviewTriggerKind {
+  return REVIEW_REPORT_TRIGGER_TYPES.includes(value as ReviewTriggerKind);
+}
+
+function parseReviewChanges(value: string | undefined): CodeReviewChange[] {
+  if (!value) {
+    return [];
+  }
+  const parsed = JSON.parse(value) as unknown;
+  if (!Array.isArray(parsed)) {
+    return [];
+  }
+  return parsed.filter(isCodeReviewChange);
+}
+
+function isCodeReviewChange(value: unknown): value is CodeReviewChange {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const change = value as Record<string, unknown>;
+  return (
+    typeof change.oldPath === "string" &&
+    typeof change.newPath === "string" &&
+    typeof change.newFile === "boolean" &&
+    typeof change.renamedFile === "boolean" &&
+    typeof change.deletedFile === "boolean" &&
+    (change.diff === undefined || typeof change.diff === "string")
+  );
+}
+
+function inlineCode(value: string): string {
+  const longestRun = Math.max(
+    0,
+    ...Array.from(value.matchAll(/`+/g), (match) => match[0].length),
+  );
+  const delimiter = "`".repeat(longestRun + 1);
+  return `${delimiter}${value}${delimiter}`;
+}

--- a/src/cli/stored-review-reports.ts
+++ b/src/cli/stored-review-reports.ts
@@ -32,6 +32,7 @@ export const REVIEW_REPORT_TRIGGER_TYPES = [
 
 export interface StoredReviewReportFilters {
   readonly codeReviewId?: number | undefined;
+  readonly from?: string | undefined;
   readonly latest: boolean;
   readonly limit?: number | undefined;
   readonly publicationMode?: ReviewPublicationMode | undefined;
@@ -96,6 +97,7 @@ export async function loadStoredReviewReports(
         tenantId: { eq: tenant.id },
         status: { eq: "completed" },
         resultJson: { isNull: false },
+        ...(filters.from ? { finishedAt: { gte: filters.from } } : {}),
       },
       order: [
         { field: "finishedAt", direction: "desc" },
@@ -140,10 +142,37 @@ export async function loadStoredReviewReports(
       triggerType: triggerTypeByRunId.get(run.id) ?? null,
       startedAt: run.startedAt,
       finishedAt: run.finishedAt,
-      result: reviewResultSchema.parse(JSON.parse(run.resultJson!) as unknown),
+      result: parseStoredReviewResult(run.resultJson!),
       changes: parseReviewChanges(snapshotByRunId.get(run.id)?.changesJson),
     };
   });
+}
+
+function parseStoredReviewResult(resultJson: string): ReviewResult {
+  const parsed = JSON.parse(resultJson) as unknown;
+  if (!isRecord(parsed) || !Array.isArray(parsed.priorDispositions)) {
+    return reviewResultSchema.parse(parsed);
+  }
+
+  return reviewResultSchema.parse({
+    ...parsed,
+    priorDispositions: parsed.priorDispositions.flatMap((disposition) => {
+      if (!isRecord(disposition)) {
+        return [];
+      }
+      if (typeof disposition.discussionId === "string") {
+        return [disposition];
+      }
+      if (typeof disposition.threadId === "string") {
+        return [{ ...disposition, discussionId: disposition.threadId }];
+      }
+      return [];
+    }),
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
 export function formatStoredReviewReportsMarkdown(

--- a/src/jobs/review-worker.ts
+++ b/src/jobs/review-worker.ts
@@ -20,6 +20,7 @@ import type {
   ReconcileSummary,
 } from "../reconcile/discussion-reconciler.js";
 import type { HarnessChatterRunnerFactory } from "../review/harness-chatter.js";
+import { projectActiveReviewFindings } from "../review/active-findings.js";
 import { buildInteractionPlan } from "../review/interaction-plan.js";
 import type { HarnessSessionMetricsEnvelope } from "../harness/types.js";
 import {
@@ -685,10 +686,18 @@ export class ReviewWorker {
             }),
           }),
         });
-        // Canonicalize current-run readiness before any no-publish output or persistence.
+        const activeFindings = projectActiveReviewFindings({
+          priorFindings: reviewContext.scope.priorFindings,
+          discussionIdentities: mappings.map((mapping) => ({
+            discussionId: mapping.id,
+            identityKey: mapping.identityKey,
+          })),
+          reviewResult: modelReviewResult,
+        });
+        // Canonicalize readiness before any no-publish output or persistence.
         reviewResult = {
           ...modelReviewResult,
-          overview: resolveReviewOverview(modelReviewResult),
+          overview: resolveReviewOverview(modelReviewResult, activeFindings),
         };
         await runArtifacts.writeJsonArtifact(
           join("orchestration", "review-result.json"),

--- a/src/jobs/review-worker.ts
+++ b/src/jobs/review-worker.ts
@@ -29,6 +29,7 @@ import {
 import { getReviewPublicationMode } from "../review/publication.js";
 import type { ReviewProviderFactory } from "../review/provider.js";
 import { InteractionRunArtifacts } from "../review/run-artifacts.js";
+import { resolveReviewOverview } from "../review/summary.js";
 import type {
   ReviewContext,
   ReviewResult,
@@ -662,7 +663,7 @@ export class ReviewWorker {
         );
 
         context.assertOwned();
-        reviewResult = await reviewProvider.review(reviewContext, {
+        const modelReviewResult = await reviewProvider.review(reviewContext, {
           attachments: imageAttachments.attachments,
           tenant: this.buildHarnessTenantContext({
             platform,
@@ -684,6 +685,11 @@ export class ReviewWorker {
             }),
           }),
         });
+        // Canonicalize current-run readiness before any no-publish output or persistence.
+        reviewResult = {
+          ...modelReviewResult,
+          overview: resolveReviewOverview(modelReviewResult),
+        };
         await runArtifacts.writeJsonArtifact(
           join("orchestration", "review-result.json"),
           reviewResult,
@@ -744,6 +750,13 @@ export class ReviewWorker {
               interactionRunId: interactionRun.id,
             }),
           });
+          // Reconciliation may carry forward active findings from earlier runs.
+          if (reconcileSummary.resolvedOverview) {
+            reviewResult = {
+              ...reviewResult,
+              overview: reconcileSummary.resolvedOverview,
+            };
+          }
           context.assertOwned();
 
           await this.logRunEvent(

--- a/src/platforms/github/client.ts
+++ b/src/platforms/github/client.ts
@@ -307,9 +307,9 @@ export interface GitHubPendingReviewComment {
   path: string;
   body: string;
   line: number;
-  side: "RIGHT";
+  side: "LEFT" | "RIGHT";
   startLine?: number | undefined;
-  startSide?: "RIGHT" | undefined;
+  startSide?: "LEFT" | "RIGHT" | undefined;
 }
 
 export class GitHubApiError extends Error {

--- a/src/platforms/github/review-publication-adapter.ts
+++ b/src/platforms/github/review-publication-adapter.ts
@@ -398,16 +398,17 @@ export class GitHubReviewPublicationAdapter implements PlatformReviewPublication
       }),
       publication.marker,
     );
-    if (anchor.side !== "new" || !diffContainsRange(file.patch, anchor)) {
+    if (!diffContainsRange(file.patch, anchor)) {
       return null;
     }
+    const side = anchor.side === "new" ? "RIGHT" : "LEFT";
     return {
       path: file.filename,
       body,
       line: anchor.endLine,
-      side: "RIGHT",
+      side,
       ...(anchor.startLine !== anchor.endLine
-        ? { startLine: anchor.startLine, startSide: "RIGHT" }
+        ? { startLine: anchor.startLine, startSide: side }
         : {}),
     };
   }

--- a/src/prompts/prompt-builders.ts
+++ b/src/prompts/prompt-builders.ts
@@ -37,7 +37,7 @@ export function buildReviewPrompt(
     ...buildAttachmentRuntimeNote(context),
     "",
     "JSON Schema (properties not listed in `required` may be omitted):",
-    JSON.stringify(reviewResponseJsonSchema, null, 2),
+    JSON.stringify(reviewResponseJsonSchema),
     "",
     "Context:",
     JSON.stringify(
@@ -60,7 +60,7 @@ export function buildChatterPrompt(context: ChatterRunContext): string {
     "- Do not include Markdown fences, introductions, explanations, or trailing text outside the JSON object.",
     "",
     "JSON Schema (properties not listed in `required` may be omitted):",
-    JSON.stringify(chatterResponseJsonSchema, null, 2),
+    JSON.stringify(chatterResponseJsonSchema),
     "",
     "Context:",
     JSON.stringify(

--- a/src/prompts/prompt-builders.ts
+++ b/src/prompts/prompt-builders.ts
@@ -1,11 +1,22 @@
 import { renderPrompt, type PromptTemplateId } from "./instruction-renderer.js";
 import { isReviewSummaryNoteBody } from "../review/summary.js";
 import type { ChatterRunContext } from "../review/harness-chatter.js";
-import type { ReviewAnchor, ReviewContext } from "../review/types.js";
+import {
+  chatterBatchResultSchema,
+  reviewResultSchema,
+  type ReviewAnchor,
+  type ReviewContext,
+} from "../review/types.js";
 import { truncate } from "../utils/text.js";
 import type { ProjectMemoryCoalesceInput } from "../memory/types.js";
 
 const DEFAULT_MAX_PROMPT_MEMORY_CHARS = 5_000;
+const reviewResponseJsonSchema = reviewResultSchema.toJSONSchema({
+  io: "input",
+});
+const chatterResponseJsonSchema = chatterBatchResultSchema.toJSONSchema({
+  io: "input",
+});
 
 export function buildProjectMemoryCoalescePrompt(
   input: ProjectMemoryCoalesceInput,
@@ -25,8 +36,8 @@ export function buildReviewPrompt(
     renderPrompt(getPromptTemplateId(context), {}),
     ...buildAttachmentRuntimeNote(context),
     "",
-    "Output field guide (fields described as optional may be omitted):",
-    JSON.stringify(reviewResponseFieldGuide, null, 2),
+    "JSON Schema (properties not listed in `required` may be omitted):",
+    JSON.stringify(reviewResponseJsonSchema, null, 2),
     "",
     "Context:",
     JSON.stringify(
@@ -44,12 +55,12 @@ export function buildChatterPrompt(context: ChatterRunContext): string {
     ...buildAttachmentRuntimeNote(context.reviewContext),
     "",
     "Formatting contract:",
-    "- Return exactly one JSON object matching the output field guide below.",
+    "- Return exactly one JSON object matching the JSON Schema below.",
     "- Put all human-facing reply text inside JSON string fields such as `replies[].replyBody`.",
     "- Do not include Markdown fences, introductions, explanations, or trailing text outside the JSON object.",
     "",
-    "Output field guide (fields described as optional may be omitted):",
-    JSON.stringify(chatterResponseFieldGuide, null, 2),
+    "JSON Schema (properties not listed in `required` may be omitted):",
+    JSON.stringify(chatterResponseJsonSchema, null, 2),
     "",
     "Context:",
     JSON.stringify(
@@ -274,60 +285,6 @@ function buildPromptProjectMemory(
     entries,
   };
 }
-
-const reviewResponseFieldGuide = {
-  overview: {
-    summary: "string",
-    overallSeverity: "low | medium | high | critical",
-    overallAssessment: "string",
-    mergeReadiness: {
-      status: "ready | needs_attention | blocked",
-      confidence: "low | medium | high",
-      summary: "string",
-    },
-    highlights: ["optional string"],
-  },
-  findings: [
-    {
-      priorDiscussionId: "optional string",
-      title: "string",
-      body: "string",
-      severity: "low | medium | high | critical",
-      category: "bug | correctness | security | performance | maintainability",
-      confidence: "optional low | medium | high",
-      anchor:
-        "optional { path: string, oldPath?: string, startLine: positive integer, endLine: positive integer, side: new | old }",
-      suggestion:
-        "optional { replacement: string, startLine: positive integer, endLine: positive integer }",
-      replyInDiscussion: "optional boolean",
-    },
-  ],
-  priorDispositions: [
-    {
-      discussionId: "string",
-      action: "keep | update | resolve | reply",
-      replyBody: "optional string",
-      resolution: "optional resolved | dismissed",
-    },
-  ],
-  replyHandoff:
-    "optional { summary: string, targets: Array<{ kind: code-review-comment | discussion-reply | summary-discussion-reply | finding-discussion-reply, commentId: positive integer, discussionId?: string (required unless kind is code-review-comment), guidance: string }> }",
-};
-
-const chatterResponseFieldGuide = {
-  memory: "optional null | { status: written | skipped, summary: string }",
-  replies: [
-    {
-      target: {
-        kind: "code-review-comment | discussion-reply | summary-discussion-reply | finding-discussion-reply",
-        commentId: 1,
-        discussionId:
-          "required for threaded reply kinds; optional for code-review-comment",
-      },
-      replyBody: "string",
-    },
-  ],
-};
 
 function buildCompactChatterContext(
   context: ChatterRunContext,

--- a/src/prompts/prompt-builders.ts
+++ b/src/prompts/prompt-builders.ts
@@ -25,8 +25,8 @@ export function buildReviewPrompt(
     renderPrompt(getPromptTemplateId(context), {}),
     ...buildAttachmentRuntimeNote(context),
     "",
-    "JSON schema:",
-    JSON.stringify(reviewResponseSchema, null, 2),
+    "Output field guide (fields described as optional may be omitted):",
+    JSON.stringify(reviewResponseFieldGuide, null, 2),
     "",
     "Context:",
     JSON.stringify(
@@ -44,12 +44,12 @@ export function buildChatterPrompt(context: ChatterRunContext): string {
     ...buildAttachmentRuntimeNote(context.reviewContext),
     "",
     "Formatting contract:",
-    "- Return exactly one JSON object matching the schema below.",
+    "- Return exactly one JSON object matching the output field guide below.",
     "- Put all human-facing reply text inside JSON string fields such as `replies[].replyBody`.",
     "- Do not include Markdown fences, introductions, explanations, or trailing text outside the JSON object.",
     "",
-    "JSON schema:",
-    JSON.stringify(chatterResponseSchema, null, 2),
+    "Output field guide (fields described as optional may be omitted):",
+    JSON.stringify(chatterResponseFieldGuide, null, 2),
     "",
     "Context:",
     JSON.stringify(
@@ -275,7 +275,7 @@ function buildPromptProjectMemory(
   };
 }
 
-const reviewResponseSchema = {
+const reviewResponseFieldGuide = {
   overview: {
     summary: "string",
     overallSeverity: "low | medium | high | critical",
@@ -295,19 +295,11 @@ const reviewResponseSchema = {
       severity: "low | medium | high | critical",
       category: "bug | correctness | security | performance | maintainability",
       confidence: "optional low | medium | high",
-      anchor: {
-        path: "string",
-        oldPath: "optional string",
-        startLine: 1,
-        endLine: 1,
-        side: "new | old",
-      },
-      suggestion: {
-        replacement: "string",
-        startLine: 1,
-        endLine: 1,
-      },
-      replyInDiscussion: false,
+      anchor:
+        "optional { path: string, oldPath?: string, startLine: positive integer, endLine: positive integer, side: new | old }",
+      suggestion:
+        "optional { replacement: string, startLine: positive integer, endLine: positive integer }",
+      replyInDiscussion: "optional boolean",
     },
   ],
   priorDispositions: [
@@ -318,25 +310,12 @@ const reviewResponseSchema = {
       resolution: "optional resolved | dismissed",
     },
   ],
-  replyHandoff: {
-    summary: "string",
-    targets: [
-      {
-        kind: "code-review-comment | discussion-reply | summary-discussion-reply | finding-discussion-reply",
-        commentId: 1,
-        discussionId:
-          "required for threaded reply kinds; optional for code-review-comment",
-        guidance: "string",
-      },
-    ],
-  },
+  replyHandoff:
+    "optional { summary: string, targets: Array<{ kind: code-review-comment | discussion-reply | summary-discussion-reply | finding-discussion-reply, commentId: positive integer, discussionId?: string (required unless kind is code-review-comment), guidance: string }> }",
 };
 
-const chatterResponseSchema = {
-  memory: {
-    status: "written | skipped",
-    summary: "string",
-  },
+const chatterResponseFieldGuide = {
+  memory: "optional null | { status: written | skipped, summary: string }",
   replies: [
     {
       target: {

--- a/src/reconcile/discussion-reconciler.ts
+++ b/src/reconcile/discussion-reconciler.ts
@@ -30,6 +30,10 @@ import {
   resolveReviewOverview,
 } from "../review/summary.js";
 import {
+  projectActiveReviewFindings,
+  type ActiveReviewFinding,
+} from "../review/active-findings.js";
+import {
   renderReviewFindingProse,
   stripReviewDiscussionMarker,
 } from "../review/discussion-format.js";
@@ -225,7 +229,6 @@ export class DiscussionReconciler {
       codeReviewId: input.context.codeReview.id,
       reviewResult: input.reviewResult,
       discussionById,
-      referencedDiscussionIds,
     });
     const summary: ReconcileSummary = {
       created: 0,
@@ -1006,84 +1009,40 @@ export class DiscussionReconciler {
     codeReviewId: number;
     reviewResult: ReviewResult;
     discussionById: ReadonlyMap<string, KnownDiscussion>;
-    referencedDiscussionIds: ReadonlySet<string>;
-  }): Promise<SummaryFinding[]> {
-    const activeFindings = new Map<string, SummaryFinding>();
+  }): Promise<ActiveReviewFinding[]> {
     const persistedFindings = await this.storage.listLatestReviewFindings(
       input.tenant.id,
       input.codeReviewId,
     );
+    const priorFindings = persistedFindings.map((finding) => ({
+      identityKey: finding.identityKey,
+      status: finding.status,
+      title: finding.title,
+      body: finding.body,
+      severity: finding.severity as ReviewFinding["severity"],
+      category: finding.category as ReviewFinding["category"],
+    }));
+    const discussionIdentities = [...input.discussionById.values()].map(
+      (knownDiscussion) => ({
+        discussionId: knownDiscussion.discussionId,
+        identityKey:
+          knownDiscussion.mapping?.identityKey ??
+          createFindingIdentityKey({
+            title: knownDiscussion.title,
+            category: knownDiscussion.mapping?.category ?? "correctness",
+            path: knownDiscussion.anchor?.path,
+            startLine: knownDiscussion.anchor?.startLine,
+            endLine: knownDiscussion.anchor?.endLine,
+            side: knownDiscussion.anchor?.side,
+          }),
+      }),
+    );
 
-    for (const finding of persistedFindings) {
-      if (finding.status !== "open") {
-        continue;
-      }
-
-      activeFindings.set(finding.identityKey, {
-        title: finding.title,
-        body: finding.body,
-        severity: finding.severity as SummaryFinding["severity"],
-        category: finding.category as SummaryFinding["category"],
-      });
-    }
-
-    for (const finding of input.reviewResult.findings) {
-      const nextIdentityKey = createFindingIdentityKey({
-        title: finding.title,
-        category: finding.category,
-        path: finding.anchor?.path,
-        startLine: finding.anchor?.startLine,
-        endLine: finding.anchor?.endLine,
-        side: finding.anchor?.side,
-      });
-      const matchedDiscussion = finding.priorDiscussionId
-        ? (input.discussionById.get(finding.priorDiscussionId) ?? null)
-        : null;
-      if (matchedDiscussion) {
-        const previousIdentityKey =
-          matchedDiscussion.mapping?.identityKey ?? null;
-        if (previousIdentityKey && previousIdentityKey !== nextIdentityKey) {
-          activeFindings.delete(previousIdentityKey);
-        }
-      }
-
-      activeFindings.set(nextIdentityKey, {
-        title: finding.title,
-        body: finding.body,
-        severity: finding.severity,
-        category: finding.category,
-      });
-    }
-
-    for (const disposition of input.reviewResult.priorDispositions) {
-      if (
-        disposition.action !== "resolve" ||
-        input.referencedDiscussionIds.has(disposition.discussionId)
-      ) {
-        continue;
-      }
-
-      const knownDiscussion = input.discussionById.get(
-        disposition.discussionId,
-      );
-      if (!knownDiscussion) {
-        continue;
-      }
-
-      const identityKey =
-        knownDiscussion.mapping?.identityKey ??
-        createFindingIdentityKey({
-          title: knownDiscussion.title,
-          category: knownDiscussion.mapping?.category ?? "correctness",
-          path: knownDiscussion.anchor?.path,
-          startLine: knownDiscussion.anchor?.startLine,
-          endLine: knownDiscussion.anchor?.endLine,
-          side: knownDiscussion.anchor?.side,
-        });
-      activeFindings.delete(identityKey);
-    }
-
-    return [...activeFindings.values()];
+    return projectActiveReviewFindings({
+      priorFindings,
+      discussionIdentities,
+      reviewResult: input.reviewResult,
+    });
   }
 }
 

--- a/src/reconcile/discussion-reconciler.ts
+++ b/src/reconcile/discussion-reconciler.ts
@@ -27,6 +27,7 @@ import { firstNonEmptyLine } from "../utils/text.js";
 import {
   buildReviewSummaryNote,
   isReviewSummaryNoteBody,
+  resolveReviewOverview,
 } from "../review/summary.js";
 import {
   renderReviewFindingProse,
@@ -69,6 +70,7 @@ export interface ReconcileSummary {
   kept: number;
   summaryCommentAction: "created" | "updated" | null;
   links: PlatformPublicationLink[];
+  resolvedOverview: ReviewResult["overview"];
 }
 
 const MANUAL_RESOLUTION_NOTICE_MARKER =
@@ -214,18 +216,6 @@ export class DiscussionReconciler {
       ]),
     );
 
-    const summary: ReconcileSummary = {
-      created: 0,
-      updated: 0,
-      replied: 0,
-      resolved: 0,
-      skippedResolution: 0,
-      skippedResolutionReasons: [],
-      kept: 0,
-      summaryCommentAction: null,
-      links: [],
-    };
-
     const referencedDiscussionIds = collectReferencedDiscussionIds(
       input.reviewResult.findings,
       discussionById,
@@ -237,6 +227,21 @@ export class DiscussionReconciler {
       discussionById,
       referencedDiscussionIds,
     });
+    const summary: ReconcileSummary = {
+      created: 0,
+      updated: 0,
+      replied: 0,
+      resolved: 0,
+      skippedResolution: 0,
+      skippedResolutionReasons: [],
+      kept: 0,
+      summaryCommentAction: null,
+      links: [],
+      resolvedOverview: resolveReviewOverview(
+        input.reviewResult,
+        projectedActiveFindings,
+      ),
+    };
 
     const pendingFindings: PendingFindingPublication[] = [];
     for (const finding of input.reviewResult.findings) {

--- a/src/review/active-findings.ts
+++ b/src/review/active-findings.ts
@@ -1,0 +1,87 @@
+import { createFindingIdentityKey } from "../utils/ids.js";
+import type { ReviewFinding, ReviewResult } from "./types.js";
+
+export type ActiveReviewFinding = Pick<
+  ReviewFinding,
+  "title" | "body" | "severity" | "category"
+>;
+
+interface PriorReviewFinding extends ActiveReviewFinding {
+  identityKey: string;
+  status: string;
+}
+
+interface DiscussionFindingIdentity {
+  discussionId: string;
+  identityKey: string;
+}
+
+export function projectActiveReviewFindings(input: {
+  priorFindings: ReadonlyArray<PriorReviewFinding>;
+  discussionIdentities: ReadonlyArray<DiscussionFindingIdentity>;
+  reviewResult: ReviewResult;
+}): ActiveReviewFinding[] {
+  const activeFindings = new Map<string, ActiveReviewFinding>();
+  for (const finding of input.priorFindings) {
+    if (finding.status === "open") {
+      activeFindings.set(finding.identityKey, toActiveFinding(finding));
+    }
+  }
+
+  const identityByDiscussionId = new Map(
+    input.discussionIdentities.map(({ discussionId, identityKey }) => [
+      discussionId,
+      identityKey,
+    ]),
+  );
+  const referencedDiscussionIds = new Set<string>();
+
+  for (const finding of input.reviewResult.findings) {
+    const nextIdentityKey = createFindingIdentityKey({
+      title: finding.title,
+      category: finding.category,
+      path: finding.anchor?.path,
+      startLine: finding.anchor?.startLine,
+      endLine: finding.anchor?.endLine,
+      side: finding.anchor?.side,
+    });
+    if (finding.priorDiscussionId) {
+      const previousIdentityKey = identityByDiscussionId.get(
+        finding.priorDiscussionId,
+      );
+      if (previousIdentityKey) {
+        referencedDiscussionIds.add(finding.priorDiscussionId);
+        if (previousIdentityKey !== nextIdentityKey) {
+          activeFindings.delete(previousIdentityKey);
+        }
+      }
+    }
+
+    activeFindings.set(nextIdentityKey, toActiveFinding(finding));
+  }
+
+  for (const disposition of input.reviewResult.priorDispositions) {
+    if (
+      disposition.action !== "resolve" ||
+      referencedDiscussionIds.has(disposition.discussionId)
+    ) {
+      continue;
+    }
+
+    const identityKey = identityByDiscussionId.get(disposition.discussionId);
+    if (identityKey) {
+      activeFindings.delete(identityKey);
+    }
+  }
+
+  return [...activeFindings.values()];
+}
+
+function toActiveFinding(finding: ActiveReviewFinding): ActiveReviewFinding {
+  return {
+    title: finding.title,
+    body: finding.body,
+    severity: finding.severity,
+    category: finding.category,
+  };
+}

--- a/src/review/merge-readiness.ts
+++ b/src/review/merge-readiness.ts
@@ -1,0 +1,13 @@
+import type { ReviewFinding, ReviewMergeReadiness } from "./types.js";
+
+export function deriveMergeReadinessStatus(
+  findings: ReadonlyArray<Pick<ReviewFinding, "severity">>,
+): ReviewMergeReadiness["status"] {
+  if (findings.length === 0) {
+    return "ready";
+  }
+  if (findings.some((finding) => finding.severity === "critical")) {
+    return "blocked";
+  }
+  return "needs_attention";
+}

--- a/src/review/persisted-review-result.ts
+++ b/src/review/persisted-review-result.ts
@@ -1,0 +1,82 @@
+import { reviewResultSchema, type ReviewResult } from "./types.js";
+
+export function parsePersistedReviewResult(resultJson: string): ReviewResult {
+  return reviewResultSchema.parse(
+    normalizeLegacyPersistedReviewResult(JSON.parse(resultJson) as unknown),
+  );
+}
+
+// This normalization exists only for older review results already in storage.
+// Live model responses must be parsed directly with reviewResultSchema.
+function normalizeLegacyPersistedReviewResult(value: unknown): unknown {
+  if (!isRecord(value) || !isRecord(value.overview)) {
+    return value;
+  }
+
+  const findings = Array.isArray(value.findings) ? value.findings : [];
+  const summary = value.overview.summary;
+  const overview = {
+    ...value.overview,
+    ...(!Object.hasOwn(value.overview, "overallAssessment") &&
+    typeof summary === "string" &&
+    summary.length > 0
+      ? { overallAssessment: summary }
+      : {}),
+    ...(!Object.hasOwn(value.overview, "mergeReadiness") &&
+    typeof summary === "string" &&
+    summary.length > 0
+      ? {
+          mergeReadiness: {
+            status: findings.length === 0 ? "ready" : "needs_attention",
+            confidence: "low",
+            summary,
+          },
+        }
+      : {}),
+  };
+
+  return {
+    ...value,
+    overview,
+    priorDispositions: normalizeLegacyPriorDispositions(
+      value.priorDispositions,
+    ),
+    ...(Object.hasOwn(value, "replyHandoff")
+      ? {
+          replyHandoff: normalizeLegacyReplyHandoff(value.replyHandoff),
+        }
+      : {}),
+  };
+}
+
+function normalizeLegacyReplyHandoff(value: unknown): unknown {
+  if (!isRecord(value) || Object.hasOwn(value, "targets")) {
+    return value;
+  }
+  return { ...value, targets: [] };
+}
+
+function normalizeLegacyPriorDispositions(value: unknown): unknown[] {
+  if (value === undefined) {
+    return [];
+  }
+  if (!Array.isArray(value)) {
+    return [value];
+  }
+  return value.flatMap((disposition) => {
+    if (!isRecord(disposition)) {
+      return [];
+    }
+    if (typeof disposition.discussionId === "string") {
+      return [disposition];
+    }
+    if (typeof disposition.threadId === "string") {
+      return [{ ...disposition, discussionId: disposition.threadId }];
+    }
+    return [];
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}

--- a/src/review/persisted-review-result.ts
+++ b/src/review/persisted-review-result.ts
@@ -1,4 +1,9 @@
-import { reviewResultSchema, type ReviewResult } from "./types.js";
+import {
+  reviewResultSchema,
+  type ReviewFinding,
+  type ReviewResult,
+} from "./types.js";
+import { deriveMergeReadinessStatus } from "./merge-readiness.js";
 
 export function parsePersistedReviewResult(resultJson: string): ReviewResult {
   return reviewResultSchema.parse(
@@ -14,6 +19,11 @@ function normalizeLegacyPersistedReviewResult(value: unknown): unknown {
   }
 
   const findings = Array.isArray(value.findings) ? value.findings : [];
+  const findingSeverities = findings.flatMap((finding) =>
+    isRecord(finding) && isReviewFindingSeverity(finding.severity)
+      ? [{ severity: finding.severity }]
+      : [],
+  );
   const summary = value.overview.summary;
   const overview = {
     ...value.overview,
@@ -27,7 +37,7 @@ function normalizeLegacyPersistedReviewResult(value: unknown): unknown {
     summary.length > 0
       ? {
           mergeReadiness: {
-            status: findings.length === 0 ? "ready" : "needs_attention",
+            status: deriveMergeReadinessStatus(findingSeverities),
             confidence: "low",
             summary,
           },
@@ -79,4 +89,15 @@ function normalizeLegacyPriorDispositions(value: unknown): unknown[] {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isReviewFindingSeverity(
+  value: unknown,
+): value is ReviewFinding["severity"] {
+  return (
+    value === "low" ||
+    value === "medium" ||
+    value === "high" ||
+    value === "critical"
+  );
 }

--- a/src/review/review-scope.ts
+++ b/src/review/review-scope.ts
@@ -8,7 +8,8 @@ import type {
 } from "./types.js";
 import type { ProjectMemoryContext } from "../memory/types.js";
 import type { GitReadonlyCapability } from "../harness/git-readonly.js";
-import { GIT_CONTENT_SIGNATURE_PREFIX, reviewResultSchema } from "./types.js";
+import { GIT_CONTENT_SIGNATURE_PREFIX } from "./types.js";
+import { parsePersistedReviewResult } from "./persisted-review-result.js";
 import type {
   PriorReviewFindingContext,
   PreviousReviewContext,
@@ -268,9 +269,8 @@ function parsePreviousReviewResult(
   }
 
   try {
-    const parsed: unknown = JSON.parse(resultJson);
-    const validated = reviewResultSchema.safeParse(parsed);
-    return validated.success ? validated.data : null;
+    // Normalize only because incremental history may contain older stored records.
+    return parsePersistedReviewResult(resultJson);
   } catch {
     return null;
   }

--- a/src/review/summary.ts
+++ b/src/review/summary.ts
@@ -19,12 +19,7 @@ const severityRank = {
   low: 3,
 } as const;
 
-interface ResolvedReviewSummaryOverview {
-  overallAssessment: string;
-  mergeReadiness: ReviewMergeReadiness;
-  overallSeverity: ReviewResult["overview"]["overallSeverity"];
-  highlights: string[];
-}
+export type ResolvedReviewOverview = ReviewResult["overview"];
 
 type SummaryFinding = Pick<
   ReviewFinding,
@@ -61,7 +56,7 @@ export function buildReviewSummaryNote(input: {
   activeFindings?: SummaryFinding[];
 }): string {
   const activeFindings = input.activeFindings ?? input.reviewResult.findings;
-  const overview = resolveSummaryOverview(
+  const overview = resolveReviewOverview(
     input.reviewResult,
     input.activeFindings,
   );
@@ -92,7 +87,7 @@ export function buildReviewSummaryNote(input: {
     "",
   ];
 
-  if (overview.highlights.length > 0) {
+  if (overview.highlights?.length) {
     lines.push("", "### Highlights", "");
     for (const highlight of overview.highlights) {
       lines.push(`- ${highlight}`);
@@ -153,28 +148,33 @@ export function buildReviewSummaryNote(input: {
   return lines.join("\n");
 }
 
-function resolveSummaryOverview(
+export function resolveReviewOverview(
   reviewResult: ReviewResult,
   activeFindings?: SummaryFinding[],
-): ResolvedReviewSummaryOverview {
+): ResolvedReviewOverview {
   const effectiveFindings = activeFindings ?? reviewResult.findings;
   const findingsDifferFromCurrentRun =
     activeFindings !== undefined &&
     !areEquivalentFindings(activeFindings, reviewResult.findings);
+  const source = findingsDifferFromCurrentRun ? "persisted" : "current";
   const providedMergeReadiness = reviewResult.overview.mergeReadiness;
   const derivedMergeReadiness = deriveMergeReadinessFromFindings(
     effectiveFindings,
-    findingsDifferFromCurrentRun ? "persisted" : "current",
+    source,
   );
   const useProvidedMergeReadiness =
-    providedMergeReadiness?.status === derivedMergeReadiness.status;
+    !findingsDifferFromCurrentRun &&
+    providedMergeReadiness.status === derivedMergeReadiness.status;
 
   return {
+    ...reviewResult.overview,
+    summary: findingsDifferFromCurrentRun
+      ? deriveOverviewSummaryFromFindings(effectiveFindings)
+      : reviewResult.overview.summary,
     overallAssessment:
-      findingsDifferFromCurrentRun && !useProvidedMergeReadiness
-        ? deriveOverallAssessmentFromFindings(effectiveFindings)
-        : (reviewResult.overview.overallAssessment ??
-          reviewResult.overview.summary),
+      findingsDifferFromCurrentRun || !useProvidedMergeReadiness
+        ? deriveOverallAssessmentFromFindings(effectiveFindings, source)
+        : reviewResult.overview.overallAssessment,
     mergeReadiness: useProvidedMergeReadiness
       ? providedMergeReadiness
       : derivedMergeReadiness,
@@ -184,7 +184,6 @@ function resolveSummaryOverview(
           reviewResult.overview.overallSeverity,
         )
       : reviewResult.overview.overallSeverity,
-    highlights: reviewResult.overview.highlights ?? [],
   };
 }
 
@@ -249,20 +248,44 @@ function compareNotesByUpdatedAtDesc<
 
 function deriveOverallAssessmentFromFindings(
   findings: ReadonlyArray<SummaryFinding>,
+  source: "current" | "persisted",
 ): string {
   if (findings.length === 0) {
-    return "No actionable findings remain after reconciling the latest review with persisted history.";
+    return source === "persisted"
+      ? "No actionable findings remain after reconciling the latest review with persisted history."
+      : "No actionable findings were identified in this review.";
   }
 
   if (findings.some((finding) => finding.severity === "critical")) {
-    return "Persisted open critical findings remain after reconciling the latest review and should be resolved before merge.";
+    return source === "persisted"
+      ? "Persisted open critical findings remain after reconciling the latest review and should be resolved before merge."
+      : "Critical findings remain and should be resolved before merge.";
   }
 
   if (findings.some((finding) => finding.severity === "high")) {
-    return "Persisted open high-severity findings remain after reconciling the latest review and should be addressed before merge.";
+    return source === "persisted"
+      ? "Persisted open high-severity findings remain after reconciling the latest review and should be addressed before merge."
+      : "High-severity findings remain and should be addressed before merge.";
   }
 
-  return "Persisted open findings remain after reconciling the latest review and should be reviewed before merge.";
+  return source === "persisted"
+    ? "Persisted open findings remain after reconciling the latest review and should be reviewed before merge."
+    : "Actionable findings remain and should be reviewed before merge.";
+}
+
+function deriveOverviewSummaryFromFindings(
+  findings: ReadonlyArray<SummaryFinding>,
+): string {
+  if (findings.length === 0) {
+    return "No actionable findings remain after reconciliation.";
+  }
+  if (findings.some((finding) => finding.severity === "critical")) {
+    return "Critical findings remain after reconciliation.";
+  }
+  if (findings.some((finding) => finding.severity === "high")) {
+    return "High-severity findings remain after reconciliation.";
+  }
+  return "Actionable findings remain after reconciliation.";
 }
 
 function deriveOverallSeverityFromFindings(
@@ -312,14 +335,14 @@ function compareFindingsBySeverity(
 }
 
 function shouldIncludeSuggestedFixesPrompt(
-  overview: ResolvedReviewSummaryOverview,
+  overview: ResolvedReviewOverview,
 ): boolean {
   return overview.mergeReadiness.status !== "ready";
 }
 
 function buildSuggestedFixesPrompt(input: {
   context: ReviewSummaryContext;
-  overview: ResolvedReviewSummaryOverview;
+  overview: ResolvedReviewOverview;
   findings: SummaryFinding[];
 }): string {
   const lines = [
@@ -336,7 +359,7 @@ function buildSuggestedFixesPrompt(input: {
     `- Readiness rationale: ${input.overview.mergeReadiness.summary}`,
   ];
 
-  if (input.overview.highlights.length > 0) {
+  if (input.overview.highlights?.length) {
     lines.push("", "Useful highlights:");
     for (const highlight of input.overview.highlights) {
       lines.push(`- ${highlight}`);
@@ -369,7 +392,7 @@ function buildSuggestedFixesPrompt(input: {
 
 function buildSuggestedFixesPromptBlock(input: {
   context: ReviewSummaryContext;
-  overview: ResolvedReviewSummaryOverview;
+  overview: ResolvedReviewOverview;
   findings: SummaryFinding[];
 }): string {
   return [

--- a/src/review/summary.ts
+++ b/src/review/summary.ts
@@ -6,6 +6,7 @@ import type {
 } from "./types.js";
 import type { IPlatform, ResolvedTenant } from "../platforms/IPlatform.js";
 import type { TenantRecord } from "../storage/contract/index.js";
+import { deriveMergeReadinessStatus } from "./merge-readiness.js";
 
 export const REVIEW_SUMMARY_NOTE_MARKER = "<!-- reviewphin-review-summary -->";
 export const REVIEW_SUMMARY_DETECTION_REGEX =
@@ -191,9 +192,10 @@ function deriveMergeReadinessFromFindings(
   findings: ReadonlyArray<Pick<ReviewFinding, "severity">>,
   source: "current" | "persisted",
 ): ReviewMergeReadiness {
-  if (findings.length === 0) {
+  const status = deriveMergeReadinessStatus(findings);
+  if (status === "ready") {
     return {
-      status: "ready",
+      status,
       confidence: "medium",
       summary:
         source === "persisted"
@@ -202,9 +204,9 @@ function deriveMergeReadinessFromFindings(
     };
   }
 
-  if (findings.some((finding) => finding.severity === "critical")) {
+  if (status === "blocked") {
     return {
-      status: "blocked",
+      status,
       confidence: "medium",
       summary:
         source === "persisted"
@@ -215,7 +217,7 @@ function deriveMergeReadinessFromFindings(
 
   if (findings.some((finding) => finding.severity === "high")) {
     return {
-      status: "needs_attention",
+      status,
       confidence: "medium",
       summary:
         source === "persisted"
@@ -225,7 +227,7 @@ function deriveMergeReadinessFromFindings(
   }
 
   return {
-    status: "needs_attention",
+    status,
     confidence: "medium",
     summary:
       source === "persisted"

--- a/src/review/types.ts
+++ b/src/review/types.ts
@@ -18,7 +18,8 @@ export const reviewAnchorSchema = z
   })
   .refine((value) => value.endLine >= value.startLine, {
     message: "endLine must be greater than or equal to startLine",
-  });
+  })
+  .describe("startLine and endLine must identify an inclusive range");
 
 export const reviewSuggestionSchema = z
   .object({
@@ -28,7 +29,8 @@ export const reviewSuggestionSchema = z
   })
   .refine((value) => value.endLine >= value.startLine, {
     message: "endLine must be greater than or equal to startLine",
-  });
+  })
+  .describe("startLine and endLine must identify an inclusive range");
 
 export const reviewFindingSchema = z.object({
   priorDiscussionId: z.string().min(1).optional(),
@@ -84,7 +86,11 @@ export const reviewerReplyTargetHandoffSchema = z
   .object({
     kind: responseTargetSchema.shape.kind,
     commentId: z.number().int().positive(),
-    discussionId: z.string().min(1).optional(),
+    discussionId: z
+      .string()
+      .min(1)
+      .optional()
+      .describe("Required unless kind is code-review-comment"),
     guidance: z.string().min(1),
   })
   .superRefine((target, context) => {
@@ -139,7 +145,11 @@ export const chatterReplySchema = z.object({
     .object({
       kind: responseTargetSchema.shape.kind,
       commentId: z.number().int().positive(),
-      discussionId: z.string().min(1).optional(),
+      discussionId: z
+        .string()
+        .min(1)
+        .optional()
+        .describe("Required unless kind is code-review-comment"),
     })
     .superRefine((target, context) => {
       if (target.kind !== "code-review-comment" && !target.discussionId) {

--- a/src/review/types.ts
+++ b/src/review/types.ts
@@ -105,7 +105,7 @@ export const reviewerReplyTargetHandoffSchema = z
 
 export const reviewerReplyHandoffSchema = z.object({
   summary: z.string().min(1),
-  targets: z.array(reviewerReplyTargetHandoffSchema).default([]),
+  targets: z.array(reviewerReplyTargetHandoffSchema),
 });
 
 export const reviewMergeReadinessSchema = z.object({
@@ -117,15 +117,15 @@ export const reviewMergeReadinessSchema = z.object({
 export const reviewOverviewSchema = z.object({
   summary: z.string().min(1),
   overallSeverity: z.enum(["low", "medium", "high", "critical"]),
-  overallAssessment: z.string().min(1).optional(),
-  mergeReadiness: reviewMergeReadinessSchema.optional(),
+  overallAssessment: z.string().min(1),
+  mergeReadiness: reviewMergeReadinessSchema,
   highlights: z.array(z.string().min(1)).max(5).optional(),
 });
 
 export const reviewResultSchema = z.object({
   overview: reviewOverviewSchema,
   findings: z.array(reviewFindingSchema),
-  priorDispositions: z.array(priorDispositionSchema).default([]),
+  priorDispositions: z.array(priorDispositionSchema),
   replyHandoff: reviewerReplyHandoffSchema.optional(),
 });
 
@@ -164,8 +164,8 @@ export const chatterReplySchema = z.object({
 });
 
 export const chatterBatchResultSchema = z.object({
-  memory: chatterMemoryOutcomeSchema.nullable().optional(),
-  replies: z.array(chatterReplySchema).default([]),
+  memory: chatterMemoryOutcomeSchema.nullable(),
+  replies: z.array(chatterReplySchema),
 });
 
 export type ReviewAnchor = z.infer<typeof reviewAnchorSchema>;

--- a/test/cli-help.test.ts
+++ b/test/cli-help.test.ts
@@ -132,6 +132,7 @@ describe("CLI help", () => {
 
     const help = output.mock.calls.join("");
     expect(help).toContain("pnpm cli mr report --key <tenant-key>");
+    expect(help).toContain("[--from <YYYY-MM-DD>]");
     expect(help).toContain("[--latest | --limit <count>]");
     expect(help).toContain("[--code-review-id <id> | --code-review <id>]");
     expect(help).toContain("[--trigger-type <manual-review|");

--- a/test/cli-help.test.ts
+++ b/test/cli-help.test.ts
@@ -124,6 +124,20 @@ describe("CLI help", () => {
     expect(help).toContain("[--report <path> | -r <path>]");
   });
 
+  it("documents mr report filters and aliases", async () => {
+    vi.stubEnv("REVIEWPHIN_CLI_COMMAND", "pnpm cli");
+    const output = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+
+    await expect(runCli(["mr", "report", "--help"])).resolves.toBe(0);
+
+    const help = output.mock.calls.join("");
+    expect(help).toContain("pnpm cli mr report --key <tenant-key>");
+    expect(help).toContain("[--latest | --limit <count>]");
+    expect(help).toContain("[--code-review-id <id> | --code-review <id>]");
+    expect(help).toContain("[--trigger-type <manual-review|");
+    expect(help).toContain("[--publication-mode <publish|no-publish>]");
+  });
+
   it("validates mr review selectors without appending usage", async () => {
     const output = vi.spyOn(process.stdout, "write").mockReturnValue(true);
     const errors = vi.spyOn(process.stderr, "write").mockReturnValue(true);

--- a/test/discussion-reconciler.test.ts
+++ b/test/discussion-reconciler.test.ts
@@ -1879,6 +1879,14 @@ describe("Discussion reconciler", () => {
     });
 
     expect(summary.summaryCommentAction).toBe("updated");
+    expect(summary.resolvedOverview).toEqual(
+      expect.objectContaining({
+        summary: "Actionable findings remain after reconciliation.",
+        mergeReadiness: expect.objectContaining({
+          status: "needs_attention",
+        }),
+      }),
+    );
     expect(createCodeReviewComment).not.toHaveBeenCalled();
     expect(updateCodeReviewComment).toHaveBeenCalledTimes(1);
     expect(updateCodeReviewComment.mock.calls[0]?.[2]).toBe(71);

--- a/test/discussion-reconciler.test.ts
+++ b/test/discussion-reconciler.test.ts
@@ -17,6 +17,15 @@ import { REVIEW_SUMMARY_NOTE_MARKER } from "../src/review/summary.js";
 import type { ReviewSummaryContext } from "../src/review/types.js";
 import { createFindingIdentityKey } from "../src/utils/ids.js";
 
+const defaultReviewOverviewDetails = {
+  overallAssessment: "Found one issue",
+  mergeReadiness: {
+    status: "needs_attention",
+    confidence: "medium",
+    summary: "Address the reported findings before merging.",
+  },
+} as const;
+
 describe("Discussion reconciler", () => {
   const logger = createLogger("silent");
   const platform = getPlatformBySlug("gitlab");
@@ -281,6 +290,7 @@ describe("Discussion reconciler", () => {
       interactionJobId: "job-publication",
       reviewResult: {
         overview: {
+          ...defaultReviewOverviewDetails,
           summary: "Found one issue",
           overallSeverity: "medium",
         },
@@ -416,6 +426,7 @@ describe("Discussion reconciler", () => {
       interactionJobId: "job-publication",
       reviewResult: {
         overview: {
+          ...defaultReviewOverviewDetails,
           summary: "Handled follow-up",
           overallSeverity: "medium",
         },
@@ -520,6 +531,7 @@ describe("Discussion reconciler", () => {
       interactionJobId: "job-publication",
       reviewResult: {
         overview: {
+          ...defaultReviewOverviewDetails,
           summary: "Found one replacement issue",
           overallSeverity: "medium",
         },
@@ -678,6 +690,7 @@ describe("Discussion reconciler", () => {
       interactionJobId: "job-publication",
       reviewResult: {
         overview: {
+          ...defaultReviewOverviewDetails,
           summary: "Found one replacement issue",
           overallSeverity: "medium",
         },
@@ -789,6 +802,7 @@ describe("Discussion reconciler", () => {
       interactionJobId: "job-publication",
       reviewResult: {
         overview: {
+          ...defaultReviewOverviewDetails,
           summary: "Handled follow-up",
           overallSeverity: "low",
         },
@@ -926,6 +940,7 @@ describe("Discussion reconciler", () => {
       interactionJobId: "job-publication",
       reviewResult: {
         overview: {
+          ...defaultReviewOverviewDetails,
           summary: "The targeted rerun looks good.",
           overallAssessment: "The targeted rerun looks good.",
           overallSeverity: "low",
@@ -1057,6 +1072,7 @@ describe("Discussion reconciler", () => {
       interactionJobId: "job-publication",
       reviewResult: {
         overview: {
+          ...defaultReviewOverviewDetails,
           summary: "Handled resolved thread",
           overallSeverity: "medium",
         },
@@ -1200,6 +1216,7 @@ describe("Discussion reconciler", () => {
         interactionJobId: "job-publication",
         reviewResult: {
           overview: {
+            ...defaultReviewOverviewDetails,
             summary: "Handled follow-up",
             overallSeverity: "low",
           },
@@ -1321,6 +1338,7 @@ describe("Discussion reconciler", () => {
       interactionJobId: "job-publication",
       reviewResult: {
         overview: {
+          ...defaultReviewOverviewDetails,
           summary: "Resolved in store",
           overallSeverity: "low",
         },
@@ -1494,6 +1512,7 @@ describe("Discussion reconciler", () => {
       interactionJobId: "job-publication",
       reviewResult: {
         overview: {
+          ...defaultReviewOverviewDetails,
           summary: "Handled resolved thread",
           overallSeverity: "medium",
         },
@@ -1616,6 +1635,7 @@ describe("Discussion reconciler", () => {
       interactionJobId: "job-publication",
       reviewResult: {
         overview: {
+          ...defaultReviewOverviewDetails,
           summary: "Finding still applies",
           overallSeverity: "medium",
         },
@@ -1720,6 +1740,7 @@ describe("Discussion reconciler", () => {
       interactionJobId: "job-publication",
       reviewResult: {
         overview: {
+          ...defaultReviewOverviewDetails,
           summary: "Looks good overall",
           overallSeverity: "low",
           mergeReadiness: {
@@ -1833,6 +1854,7 @@ describe("Discussion reconciler", () => {
       interactionJobId: "job-publication",
       reviewResult: {
         overview: {
+          ...defaultReviewOverviewDetails,
           summary: "The targeted rerun looks good.",
           overallAssessment: "The targeted rerun looks good.",
           overallSeverity: "low",
@@ -2164,6 +2186,7 @@ describe("Discussion reconciler", () => {
       interactionJobId: "job-publication",
       reviewResult: {
         overview: {
+          ...defaultReviewOverviewDetails,
           summary: "Found one issue",
           overallSeverity: "medium",
         },
@@ -2347,6 +2370,7 @@ describe("Discussion reconciler", () => {
       interactionJobId: "job-publication",
       reviewResult: {
         overview: {
+          ...defaultReviewOverviewDetails,
           summary: "Found one issue",
           overallSeverity: "medium",
         },
@@ -2478,6 +2502,7 @@ describe("Discussion reconciler", () => {
       interactionJobId: "job-publication",
       reviewResult: {
         overview: {
+          ...defaultReviewOverviewDetails,
           summary: "Found one issue",
           overallSeverity: "medium",
         },
@@ -2603,6 +2628,7 @@ describe("Discussion reconciler", () => {
       interactionJobId: "job-publication",
       reviewResult: {
         overview: {
+          ...defaultReviewOverviewDetails,
           summary: "Found one issue",
           overallSeverity: "medium",
         },
@@ -2711,6 +2737,7 @@ describe("Discussion reconciler", () => {
       interactionJobId: "job-publication",
       reviewResult: {
         overview: {
+          ...defaultReviewOverviewDetails,
           summary: "Found one issue",
           overallSeverity: "medium",
         },
@@ -2809,6 +2836,7 @@ describe("Discussion reconciler", () => {
         interactionJobId: "job-publication",
         reviewResult: {
           overview: {
+            ...defaultReviewOverviewDetails,
             summary: "Found one issue",
             overallSeverity: "medium",
           },
@@ -2902,6 +2930,7 @@ describe("Discussion reconciler", () => {
         interactionJobId: "job-publication",
         reviewResult: {
           overview: {
+            ...defaultReviewOverviewDetails,
             summary: "Found one issue",
             overallSeverity: "medium",
           },
@@ -3021,6 +3050,7 @@ describe("Discussion reconciler", () => {
       interactionJobId: "job-publication",
       reviewResult: {
         overview: {
+          ...defaultReviewOverviewDetails,
           summary: "Found one issue",
           overallSeverity: "medium" as const,
         },
@@ -3153,6 +3183,7 @@ describe("Discussion reconciler", () => {
       interactionJobId: "job-publication",
       reviewResult: {
         overview: {
+          ...defaultReviewOverviewDetails,
           summary: "Updated one issue",
           overallSeverity: "medium",
         },
@@ -3222,6 +3253,7 @@ describe("Discussion reconciler", () => {
         interactionJobId: "job-lease",
         reviewResult: {
           overview: {
+            ...defaultReviewOverviewDetails,
             summary: "Found one issue",
             overallSeverity: "medium",
           },

--- a/test/github-client.test.ts
+++ b/test/github-client.test.ts
@@ -872,6 +872,14 @@ describe("GitHubClient", () => {
           startLine: 12,
           startSide: "RIGHT",
         },
+        {
+          path: "src/legacy.ts",
+          body: "Removed finding",
+          line: 9,
+          side: "LEFT",
+          startLine: 8,
+          startSide: "LEFT",
+        },
       ],
     });
     await client.submitPullRequestReview({
@@ -893,6 +901,14 @@ describe("GitHubClient", () => {
             side: "RIGHT",
             start_line: 12,
             start_side: "RIGHT",
+          },
+          {
+            path: "src/legacy.ts",
+            body: "Removed finding",
+            line: 9,
+            side: "LEFT",
+            start_line: 8,
+            start_side: "LEFT",
           },
         ],
       }),

--- a/test/github-requested-action-happy-path.test.ts
+++ b/test/github-requested-action-happy-path.test.ts
@@ -55,6 +55,12 @@ describe("GitHub requested-action happy path", () => {
       overview: {
         summary: "One correctness issue found.",
         overallSeverity: "high" as const,
+        overallAssessment: "One correctness issue found.",
+        mergeReadiness: {
+          status: "needs_attention" as const,
+          confidence: "high" as const,
+          summary: "Fix the correctness issue before merging.",
+        },
       },
       findings: [
         {
@@ -194,9 +200,7 @@ describe("GitHub requested-action happy path", () => {
             path: "src/index.ts",
             line: 2,
             side: "RIGHT",
-            body: expect.stringContaining(
-              "```suggestion\nreturn value;\n```",
-            ),
+            body: expect.stringContaining("```suggestion\nreturn value;\n```"),
           }),
         ],
       }),
@@ -227,9 +231,7 @@ describe("GitHub requested-action happy path", () => {
     );
     expect(
       github.issueCommentCreatedOrder[0] ?? Number.MAX_SAFE_INTEGER,
-    ).toBeLessThan(
-      github.completedCheckRunOrder[0] ?? Number.MAX_SAFE_INTEGER,
-    );
+    ).toBeLessThan(github.completedCheckRunOrder[0] ?? Number.MAX_SAFE_INTEGER);
   });
 });
 
@@ -414,9 +416,7 @@ function createGitHubApiState() {
           },
         };
       }
-      if (
-        route === "GET /repos/{owner}/{repo}/check-runs/{check_run_id}"
-      ) {
+      if (route === "GET /repos/{owner}/{repo}/check-runs/{check_run_id}") {
         return {
           data: {
             id: 1357,
@@ -439,14 +439,10 @@ function createGitHubApiState() {
       ) {
         return { data: issueComments };
       }
-      if (
-        route === "GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews"
-      ) {
+      if (route === "GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews") {
         return { data: reviews };
       }
-      if (
-        route === "GET /repos/{owner}/{repo}/pulls/{pull_number}/comments"
-      ) {
+      if (route === "GET /repos/{owner}/{repo}/pulls/{pull_number}/comments") {
         return { data: reviewComments };
       }
       if (route === "POST /graphql") {
@@ -465,9 +461,7 @@ function createGitHubApiState() {
           },
         };
       }
-      if (
-        route === "POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews"
-      ) {
+      if (route === "POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews") {
         createdReviewPayloads.push(parameters);
         const review = {
           id: 500,
@@ -528,8 +522,7 @@ function createGitHubApiState() {
         const comment = {
           id: 700,
           body: parameters.body,
-          html_url:
-            "https://github.com/octo/repo/pull/42#issuecomment-700",
+          html_url: "https://github.com/octo/repo/pull/42#issuecomment-700",
           user: { id: 1, login: "reviewphin-octo[bot]", type: "Bot" },
           created_at: "2026-06-14T00:02:00.000Z",
           updated_at: "2026-06-14T00:02:00.000Z",
@@ -538,9 +531,7 @@ function createGitHubApiState() {
         issueCommentCreatedOrder.push(++operationOrder);
         return { data: comment };
       }
-      if (
-        route === "PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}"
-      ) {
+      if (route === "PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}") {
         const update = parameters as unknown as {
           status: string;
           conclusion?: string;

--- a/test/github-requested-action-happy-path.test.ts
+++ b/test/github-requested-action-happy-path.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { ReviewWorker } from "../src/jobs/review-worker.js";
 import { createLogger } from "../src/logger.js";
+import { formatReviewReportMarkdown } from "../src/cli/review-report.js";
 import type { GitHubApi } from "../src/platforms/github/client.js";
 import GitHubPlatform from "../src/platforms/github/platform.js";
 import { DiscussionReconciler } from "../src/reconcile/discussion-reconciler.js";
@@ -15,6 +16,7 @@ import type {
   TenantRecord,
 } from "../src/storage/contract/current.js";
 import type { StorageHelpers } from "../src/storage/storage-helpers.js";
+import type { ReviewResult } from "../src/review/types.js";
 import { createClaimContext } from "./helpers/claim.js";
 import { overridePlatformRuntime } from "./helpers/platform-runtime.js";
 
@@ -57,7 +59,7 @@ describe("GitHub requested-action happy path", () => {
         overallSeverity: "high" as const,
         overallAssessment: "One correctness issue found.",
         mergeReadiness: {
-          status: "needs_attention" as const,
+          status: "blocked" as const,
           confidence: "high" as const,
           summary: "Fix the correctness issue before merging.",
         },
@@ -210,6 +212,26 @@ describe("GitHub requested-action happy path", () => {
     expect(github.issueComments[0]?.body).toContain(
       "<!-- reviewphin-review-summary -->",
     );
+    expect(github.issueComments[0]?.body).toContain(
+      "- **Status:** Needs attention",
+    );
+
+    const transitionRun = vi.mocked(
+      storage.stores.interactionJobs.transitionInteractionRunForClaim,
+    );
+    const completedRunInput = transitionRun.mock.calls
+      .map(([input]) => input)
+      .find((input) => input.status === "completed");
+    expect(completedRunInput?.resultJson).toBeTruthy();
+    const persistedResult = JSON.parse(
+      completedRunInput?.resultJson ?? "null",
+    ) as ReviewResult;
+    expect(persistedResult.overview.mergeReadiness.status).toBe(
+      "needs_attention",
+    );
+    expect(formatReviewReportMarkdown(persistedResult)).toContain(
+      "**Status:** Needs Attention",
+    );
 
     const completed = github.checkRunUpdates.find(
       (update) => update.status === "completed",
@@ -222,7 +244,9 @@ describe("GitHub requested-action happy path", () => {
         }),
       ],
     });
-    expect(completed?.output.summary).toContain("One correctness issue found.");
+    expect(completed?.output.summary).toContain(
+      "High-severity findings remain and should be addressed before merge.",
+    );
     expect(completed?.output.summary).toContain(
       "https://github.com/octo/repo/pull/42#pullrequestreview-500",
     );

--- a/test/github-review-publication-adapter.test.ts
+++ b/test/github-review-publication-adapter.test.ts
@@ -197,7 +197,7 @@ describe("GitHubReviewPublicationAdapter", () => {
     );
   });
 
-  it("falls back to marked issue comments for old-side and invalid anchors", async () => {
+  it("publishes old-side anchors inline and falls back for invalid anchors", async () => {
     const state = createState();
     const adapter = createAdapter(state);
 
@@ -247,13 +247,25 @@ describe("GitHubReviewPublicationAdapter", () => {
       ],
     });
 
-    expect(state.client.createPullRequestReview).not.toHaveBeenCalled();
-    expect(state.client.submitPullRequestReview).not.toHaveBeenCalled();
-    expect(state.client.createIssueComment).toHaveBeenCalledTimes(2);
-    for (const call of state.client.createIssueComment.mock.calls) {
-      expect(call[0].body).toContain("<!-- reviewphin-finding:");
-      expect(call[0].body).not.toContain("```suggestion");
-    }
+    expect(state.client.createPullRequestReview).toHaveBeenCalledWith(
+      expect.objectContaining({
+        comments: [
+          expect.objectContaining({
+            path: "src/index.ts",
+            line: 1,
+            side: "LEFT",
+          }),
+        ],
+      }),
+    );
+    const oldSideBody = state.client.createPullRequestReview.mock.calls[0]?.[0]
+      .comments[0]?.body as string | undefined;
+    expect(oldSideBody).not.toContain("```suggestion");
+    expect(state.client.submitPullRequestReview).toHaveBeenCalledOnce();
+    expect(state.client.createIssueComment).toHaveBeenCalledOnce();
+    expect(state.client.createIssueComment.mock.calls[0]?.[0].body).toContain(
+      "<!-- reviewphin-finding:",
+    );
   });
 
   it("continues fallback findings with linked issue comments", async () => {
@@ -803,15 +815,15 @@ function createAdapter(state: ReturnType<typeof createState>) {
         sha: "blob",
         filename: "src/index.ts",
         status: "modified",
-        additions: 1,
-        deletions: 0,
-        changes: 1,
+        additions: 2,
+        deletions: 1,
+        changes: 3,
         blob_url: "https://github.com/octo/repo/blob/head/src/index.ts",
         raw_url: "https://github.com/octo/repo/raw/head/src/index.ts",
         contents_url:
           "https://api.github.com/repos/octo/repo/contents/src/index.ts",
         patch:
-          "@@ -1,1 +1,3 @@\n const value = compute();\n+value;\n+consume(value);",
+          "@@ -1,2 +1,3 @@\n-const obsolete = true;\n const value = compute();\n+value;\n+consume(value);",
       },
     ],
     issueComments: state.issueComments,

--- a/test/github-review-runtime.test.ts
+++ b/test/github-review-runtime.test.ts
@@ -582,6 +582,7 @@ describe("GitHubPlatformReviewRuntime", () => {
         codeReviewId: 42,
         plannedTargets: [issueTarget, threadTarget],
         result: {
+          memory: null,
           replies: [
             { target: issueTarget, replyBody: "Issue response" },
             { target: threadTarget, replyBody: "Thread response" },
@@ -620,6 +621,7 @@ describe("GitHubPlatformReviewRuntime", () => {
         codeReviewId: 42,
         plannedTargets: [delayedThreadTarget],
         result: {
+          memory: null,
           replies: [
             {
               target: delayedThreadTarget,
@@ -658,6 +660,7 @@ describe("GitHubPlatformReviewRuntime", () => {
         codeReviewId: 42,
         plannedTargets: [issueTarget],
         result: {
+          memory: null,
           replies: [
             { target: issueTarget, replyBody: "First response" },
             { target: issueTarget, replyBody: "Stale response" },

--- a/test/gitlab-reactions.test.ts
+++ b/test/gitlab-reactions.test.ts
@@ -911,6 +911,12 @@ function createWorker(input: {
             overview: {
               summary: "Done",
               overallSeverity: "low" as const,
+              overallAssessment: "No issues found.",
+              mergeReadiness: {
+                status: "ready" as const,
+                confidence: "high" as const,
+                summary: "The change is ready to merge.",
+              },
             },
             findings: [],
             priorDispositions: [],

--- a/test/harness-chatter.test.ts
+++ b/test/harness-chatter.test.ts
@@ -88,6 +88,37 @@ describe("HarnessChatterRunner", () => {
     );
   });
 
+  it("rejects current model responses that omit memory", async () => {
+    const runner = new HarnessChatterRunner({
+      modelConfig: createModelConfig(),
+      harnessRuntime: {
+        run: vi.fn(async () => ({
+          response: { data: { content: "{}" } },
+          parsed: { replies: [] },
+          events: [],
+        })),
+      } as never,
+    });
+
+    await expect(
+      runner.run(
+        {
+          phase: "reply",
+          replyStyle: "direct-answer",
+          trigger: createTrigger(),
+          responseTargets: [createTrigger().responseTarget],
+          reviewContext: createReviewContext(),
+          projectMemory: {
+            enabled: true,
+            page: null,
+            entries: [],
+          },
+        },
+        { tenant: createTenantRuntimeContext() },
+      ),
+    ).rejects.toThrow(/memory/);
+  });
+
   it("exposes read-only repository tools for reply passes", async () => {
     const run = vi.fn(async () => ({
       response: {
@@ -165,7 +196,9 @@ describe("HarnessChatterRunner", () => {
 
   it("passes the text-generation reasoning effort for reply passes", async () => {
     const run = vi.fn(async () => ({
-      response: { data: { content: JSON.stringify({ memory: null, replies: [] }) } },
+      response: {
+        data: { content: JSON.stringify({ memory: null, replies: [] }) },
+      },
       parsed: { memory: null, replies: [] },
       events: [],
     }));
@@ -198,7 +231,9 @@ describe("HarnessChatterRunner", () => {
 
   it("omits reasoningEffort from the chatter run spec when text-generation effort is null", async () => {
     const run = vi.fn(async () => ({
-      response: { data: { content: JSON.stringify({ memory: null, replies: [] }) } },
+      response: {
+        data: { content: JSON.stringify({ memory: null, replies: [] }) },
+      },
       parsed: { memory: null, replies: [] },
       events: [],
     }));
@@ -224,13 +259,10 @@ describe("HarnessChatterRunner", () => {
       { tenant: createTenantRuntimeContext() },
     );
 
-    const spec = (run.mock.calls[0] as unknown[])[0] as Record<
-      string,
-      unknown
-    >;
-    expect(
-      Object.prototype.hasOwnProperty.call(spec, "reasoningEffort"),
-    ).toBe(false);
+    const spec = (run.mock.calls[0] as unknown[])[0] as Record<string, unknown>;
+    expect(Object.prototype.hasOwnProperty.call(spec, "reasoningEffort")).toBe(
+      false,
+    );
   });
 
   it("uses the parsed shared-harness response payload for replies", async () => {

--- a/test/harness-review-provider.test.ts
+++ b/test/harness-review-provider.test.ts
@@ -55,20 +55,14 @@ describe("HarnessReviewProvider", () => {
       response: {
         data: {
           content: JSON.stringify({
-            overview: {
-              summary: "Looks good",
-              overallSeverity: "low",
-            },
+            overview: createCompleteOverview(),
             findings: [],
             priorDispositions: [],
           }),
         },
       },
       parsed: {
-        overview: {
-          summary: "Looks good",
-          overallSeverity: "low",
-        },
+        overview: createCompleteOverview(),
         findings: [],
         priorDispositions: [],
       },
@@ -124,19 +118,48 @@ describe("HarnessReviewProvider", () => {
     );
   });
 
+  it("rejects incomplete current model responses", async () => {
+    const run = vi.fn(async () => ({
+      response: { data: { content: "{}" } },
+      parsed: {
+        overview: {
+          summary: "Looks good",
+          overallSeverity: "low",
+        },
+        findings: [],
+      },
+      events: [],
+    }));
+    const provider = new HarnessReviewProvider({
+      logger: createLogger(),
+      modelConfig: createModelConfig(),
+      harnessRuntime: { run } as never,
+      memoryConsolidator: {
+        coalesce: vi.fn(async (input) => input.coalesceInput.entries),
+      } as never,
+      maxPromptMemoryChars: 5_000,
+    });
+
+    await expect(
+      provider.review(createReviewContext(), {
+        tenant: createTenantRuntimeContext(),
+      }),
+    ).rejects.toThrow(/overallAssessment/);
+  });
+
   it("enables git_readonly only for Git-ready reviewer sessions", async () => {
     const run = vi.fn(async () => ({
       response: {
         data: {
           content: JSON.stringify({
-            overview: { summary: "Looks good", overallSeverity: "low" },
+            overview: createCompleteOverview(),
             findings: [],
             priorDispositions: [],
           }),
         },
       },
       parsed: {
-        overview: { summary: "Looks good", overallSeverity: "low" },
+        overview: createCompleteOverview(),
         findings: [],
         priorDispositions: [],
       },
@@ -237,14 +260,14 @@ describe("HarnessReviewProvider", () => {
       response: {
         data: {
           content: JSON.stringify({
-            overview: { summary: "Looks good", overallSeverity: "low" },
+            overview: createCompleteOverview(),
             findings: [],
             priorDispositions: [],
           }),
         },
       },
       parsed: {
-        overview: { summary: "Looks good", overallSeverity: "low" },
+        overview: createCompleteOverview(),
         findings: [],
         priorDispositions: [],
       },
@@ -279,14 +302,14 @@ describe("HarnessReviewProvider", () => {
       response: {
         data: {
           content: JSON.stringify({
-            overview: { summary: "Looks good", overallSeverity: "low" },
+            overview: createCompleteOverview(),
             findings: [],
             priorDispositions: [],
           }),
         },
       },
       parsed: {
-        overview: { summary: "Looks good", overallSeverity: "low" },
+        overview: createCompleteOverview(),
         findings: [],
         priorDispositions: [],
       },
@@ -322,10 +345,7 @@ describe("HarnessReviewProvider", () => {
       response: {
         data: {
           content: JSON.stringify({
-            overview: {
-              summary: "Looks good",
-              overallSeverity: "low",
-            },
+            overview: createCompleteOverview(),
             findings: [],
             priorDispositions: [
               {
@@ -350,10 +370,7 @@ describe("HarnessReviewProvider", () => {
         },
       },
       parsed: {
-        overview: {
-          summary: "Looks good",
-          overallSeverity: "low",
-        },
+        overview: createCompleteOverview(),
         findings: [],
         priorDispositions: [
           {
@@ -432,6 +449,8 @@ describe("HarnessReviewProvider", () => {
             overview: {
               summary: "The rerun found no remaining blocking issues.",
               overallSeverity: "low",
+              overallAssessment:
+                "Everything needed for merge readiness is now addressed.",
               mergeReadiness: {
                 status: "ready",
                 confidence: "high",
@@ -465,6 +484,8 @@ describe("HarnessReviewProvider", () => {
         overview: {
           summary: "The rerun found no remaining blocking issues.",
           overallSeverity: "low",
+          overallAssessment:
+            "Everything needed for merge readiness is now addressed.",
           mergeReadiness: {
             status: "ready",
             confidence: "high",
@@ -641,6 +662,19 @@ function createReviewContext(): ReviewContext {
       interactionJobId: "job_1",
       tenantId: "tenant_1",
       runDirectory: tmpPath(),
+    },
+  };
+}
+
+function createCompleteOverview() {
+  return {
+    summary: "Looks good",
+    overallSeverity: "low" as const,
+    overallAssessment: "No issues were found.",
+    mergeReadiness: {
+      status: "ready" as const,
+      confidence: "high" as const,
+      summary: "The change is ready to merge.",
     },
   };
 }

--- a/test/mr-report-cli.test.ts
+++ b/test/mr-report-cli.test.ts
@@ -149,8 +149,20 @@ describe("mr report CLI", () => {
       );
 
       const reports = JSON.parse(stdout) as Array<{
-        result: { priorDispositions: Array<Record<string, unknown>> };
+        result: {
+          overview: {
+            overallAssessment: string;
+            mergeReadiness: { confidence: string };
+          };
+          priorDispositions: Array<Record<string, unknown>>;
+        };
       }>;
+      expect(reports[0]?.result.overview).toEqual(
+        expect.objectContaining({
+          overallAssessment: "Authorization boundaries need attention.",
+          mergeReadiness: expect.objectContaining({ confidence: "low" }),
+        }),
+      );
       expect(reports[0]?.result.priorDispositions).toEqual([
         expect.objectContaining({
           discussionId: "legacy-discussion",
@@ -232,6 +244,11 @@ async function createReportFixture(
     result: options.legacyDisposition
       ? {
           ...reviewResultWithSuggestion,
+          overview: {
+            summary: reviewResultWithSuggestion.overview.summary,
+            overallSeverity:
+              reviewResultWithSuggestion.overview.overallSeverity,
+          },
           priorDispositions: [
             { threadId: "legacy-discussion", action: "keep" },
             { action: "resolve", resolution: "dismissed" },
@@ -370,6 +387,12 @@ const reviewResultWithSuggestion: ReviewResult = {
   overview: {
     summary: "Authorization boundaries need attention.",
     overallSeverity: "high",
+    overallAssessment: "The authorization boundary is incomplete.",
+    mergeReadiness: {
+      status: "blocked",
+      confidence: "high",
+      summary: "Validate the tenant before merging.",
+    },
   },
   findings: [
     {

--- a/test/mr-report-cli.test.ts
+++ b/test/mr-report-cli.test.ts
@@ -1,0 +1,318 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { runCli } from "../src/cli.js";
+import { createStringWriter } from "../src/cli/output.js";
+import type { ReviewResult, ReviewTriggerKind } from "../src/review/types.js";
+import { createGitLabTenantInput } from "./helpers/gitlab-tenant.js";
+import { openSqliteTestStorage } from "./helpers/storage.js";
+
+const tenantKey = "https://gitlab.example.com::123";
+
+describe("mr report CLI", () => {
+  it("lists stored reports newest first and enriches suggestions from snapshots", async () => {
+    const fixture = await createReportFixture();
+    try {
+      let stdout = "";
+      await expect(
+        runCli(
+          [
+            "mr",
+            "report",
+            "--key",
+            tenantKey,
+            "--json",
+            "--sqlite-database-path",
+            fixture.databasePath,
+          ],
+          {
+            stdout: createStringWriter((text) => (stdout += text)),
+          },
+        ),
+      ).resolves.toBe(0);
+
+      const reports = JSON.parse(stdout) as Array<Record<string, unknown>>;
+      expect(reports).toHaveLength(2);
+      expect(reports.map((report) => report.codeReviewId)).toEqual([8, 7]);
+      expect(reports[0]).toEqual(
+        expect.objectContaining({
+          publicationMode: "publish",
+          triggerType: "direct-mention",
+        }),
+      );
+      expect(reports[1]).toEqual(
+        expect.objectContaining({
+          publicationMode: "no-publish",
+          triggerType: "manual-review",
+          suggestedChanges: [
+            expect.objectContaining({
+              path: "src/auth.ts",
+              startLine: 10,
+              endLine: 12,
+              replacedText: "  return tenant.data;\n}\nexport { authorize };",
+              replacement:
+                'if (!tenant) {\n  throw new Error("Unknown tenant");\n}',
+            }),
+          ],
+        }),
+      );
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  it("filters before selecting the latest report and accepts concise aliases", async () => {
+    const fixture = await createReportFixture();
+    try {
+      let stdout = "";
+      await runCli(
+        [
+          "mr",
+          "report",
+          "--key",
+          tenantKey,
+          "--code-review",
+          "7",
+          "--type",
+          "manual-review",
+          "--publication-mode",
+          "no-publish",
+          "--latest",
+          "--json",
+          "--sqlite-database-path",
+          fixture.databasePath,
+        ],
+        { stdout: createStringWriter((text) => (stdout += text)) },
+      );
+
+      const reports = JSON.parse(stdout) as Array<Record<string, unknown>>;
+      expect(reports).toHaveLength(1);
+      expect(reports[0]).toEqual(
+        expect.objectContaining({
+          codeReviewId: 7,
+          triggerType: "manual-review",
+          publicationMode: "no-publish",
+        }),
+      );
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  it("writes matching reports as one Markdown document", async () => {
+    const fixture = await createReportFixture();
+    try {
+      const reportPath = join(fixture.directory, "reports.md");
+      let stdout = "";
+      await runCli(
+        [
+          "mr",
+          "report",
+          "--key",
+          tenantKey,
+          "--latest",
+          "--report",
+          reportPath,
+          "--sqlite-database-path",
+          fixture.databasePath,
+        ],
+        { stdout: createStringWriter((text) => (stdout += text)) },
+      );
+
+      const markdown = await readFile(reportPath, "utf8");
+      expect(stdout).toContain("Wrote 1 review report");
+      expect(markdown).toContain("# Merge request review report");
+      expect(markdown).toContain("- **Code review:** 8");
+      expect(markdown).toContain("## Review result");
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  it("rejects conflicting result limits", async () => {
+    await expect(
+      runCli(["mr", "report", "--key", tenantKey, "--latest", "--limit", "2"]),
+    ).rejects.toThrow("Cannot combine --latest with --limit.");
+  });
+});
+
+async function createReportFixture() {
+  const directory = await mkdtemp(join(tmpdir(), "mr-report-cli-"));
+  const databasePath = join(directory, "reviewphin.sqlite");
+  const storage = await openSqliteTestStorage(databasePath);
+  const tenant = await storage.upsertTenant(createGitLabTenantInput());
+
+  await seedReport(storage, {
+    tenantId: tenant.id,
+    dedupeKey: "local-review",
+    codeReviewId: 7,
+    triggerJson: JSON.stringify({
+      kind: "reviewphin-local-review",
+      source: "cli",
+      requestId: "local-1",
+      codeReviewId: 7,
+      instruction: "Review this change.",
+      createdAt: "2026-08-01T10:00:00.000Z",
+      publicationMode: "no-publish",
+    }),
+    triggerType: "manual-review",
+    startedAt: "2026-08-01T10:00:00.000Z",
+    finishedAt: "2026-08-01T10:01:00.000Z",
+    result: reviewResultWithSuggestion,
+    diff: [
+      "@@ -8,5 +8,5 @@",
+      " function authorize() {",
+      "   const tenant = findTenant();",
+      "+  return tenant.data;",
+      "+}",
+      "+export { authorize };",
+    ].join("\n"),
+  });
+  await seedReport(storage, {
+    tenantId: tenant.id,
+    dedupeKey: "published-review",
+    codeReviewId: 8,
+    triggerJson: JSON.stringify({
+      kind: "github-comment",
+      triggerKind: "direct-mention",
+    }),
+    triggerType: "direct-mention",
+    startedAt: "2026-08-02T10:00:00.000Z",
+    finishedAt: "2026-08-02T10:01:00.000Z",
+    result: {
+      overview: { summary: "No issues found.", overallSeverity: "low" },
+      findings: [],
+      priorDispositions: [],
+    },
+    diff: "",
+  });
+  await storage.close();
+
+  return {
+    directory,
+    databasePath,
+    cleanup: () => rm(directory, { recursive: true, force: true }),
+  };
+}
+
+async function seedReport(
+  storage: Awaited<ReturnType<typeof openSqliteTestStorage>>,
+  input: {
+    tenantId: string;
+    dedupeKey: string;
+    codeReviewId: number;
+    triggerJson: string;
+    triggerType: ReviewTriggerKind;
+    startedAt: string;
+    finishedAt: string;
+    result: ReviewResult;
+    diff: string;
+  },
+): Promise<void> {
+  const { job } = await storage.createOrGetInteractionJob({
+    tenantId: input.tenantId,
+    dedupeKey: input.dedupeKey,
+    codeReviewId: input.codeReviewId,
+    commentId: null,
+    triggerJson: input.triggerJson,
+    headSha: `head-${input.codeReviewId}`,
+    payloadJson: "{}",
+  });
+  const run = await storage.createInteractionRun({
+    interactionJobId: job.id,
+    tenantId: input.tenantId,
+    provider: "copilot-sdk",
+    model: "gpt-5.4",
+    modelProfileName: null,
+    providerBaseUrl: null,
+    providerType: null,
+    textGenerationModel: null,
+  });
+  await storage.completeInteractionRun(run.id, JSON.stringify(input.result));
+  await storage.stores.interactionRuns.patch({
+    id: run.id,
+    value: { startedAt: input.startedAt, finishedAt: input.finishedAt },
+  });
+  await storage.createCodeReviewSnapshot({
+    interactionJobId: job.id,
+    interactionRunId: run.id,
+    tenantId: input.tenantId,
+    codeReviewId: input.codeReviewId,
+    headSha: job.headSha,
+    codeReviewJson: "{}",
+    versionsJson: "[]",
+    changesJson: JSON.stringify([
+      {
+        oldPath: "src/auth.ts",
+        newPath: "src/auth.ts",
+        diff: input.diff,
+        newFile: false,
+        renamedFile: false,
+        deletedFile: false,
+      },
+    ]),
+    commentsJson: "[]",
+    discussionsJson: "[]",
+    instructionsJson: "[]",
+    projectMemoryJson: null,
+    workspaceStrategy: "test",
+  });
+  await storage.upsertInteractionRunMetrics({
+    interactionRunId: run.id,
+    harness: "github.copilot-sdk",
+    harnessSessionKey: `session-${run.id}`,
+    sessionType: "review",
+    triggerKind: input.triggerType,
+    promptMode: "first-pass-full",
+    promptChars: 10,
+    promptContextChangedFiles: 1,
+    promptContextPriorDiscussions: 0,
+    promptContextComments: 0,
+    assistantTurns: 1,
+    assistantCalls: 1,
+    toolExecutions: 1,
+    viewToolCalls: 1,
+    globToolCalls: 0,
+    inputTokens: 100,
+    outputTokens: 10,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    reasoningTokens: 0,
+    apiDurationMs: 1_000,
+    usageUnit: null,
+    usageAmount: null,
+    usageByModelJson: "[]",
+    repeatedViewReads: 0,
+    repeatedViewPathsJson: "[]",
+  });
+}
+
+const reviewResultWithSuggestion: ReviewResult = {
+  overview: {
+    summary: "Authorization boundaries need attention.",
+    overallSeverity: "high",
+  },
+  findings: [
+    {
+      title: "Reject missing tenants",
+      body: "Validate the tenant before accessing its data.",
+      severity: "high",
+      category: "security",
+      anchor: {
+        path: "src/auth.ts",
+        startLine: 10,
+        endLine: 12,
+        side: "new",
+      },
+      suggestion: {
+        replacement: 'if (!tenant) {\n  throw new Error("Unknown tenant");\n}',
+        startLine: 10,
+        endLine: 12,
+      },
+    },
+  ],
+  priorDispositions: [],
+};

--- a/test/mr-report-cli.test.ts
+++ b/test/mr-report-cli.test.ts
@@ -102,6 +102,66 @@ describe("mr report CLI", () => {
     }
   });
 
+  it("filters reports by their inclusive completion date", async () => {
+    const fixture = await createReportFixture();
+    try {
+      let stdout = "";
+      await runCli(
+        [
+          "mr",
+          "report",
+          "--key",
+          tenantKey,
+          "--from",
+          "2026-08-02",
+          "--json",
+          "--sqlite-database-path",
+          fixture.databasePath,
+        ],
+        { stdout: createStringWriter((text) => (stdout += text)) },
+      );
+
+      const reports = JSON.parse(stdout) as Array<Record<string, unknown>>;
+      expect(reports).toHaveLength(1);
+      expect(reports[0]).toEqual(expect.objectContaining({ codeReviewId: 8 }));
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  it("reads legacy prior dispositions without discussionId", async () => {
+    const fixture = await createReportFixture({ legacyDisposition: true });
+    try {
+      let stdout = "";
+      await runCli(
+        [
+          "mr",
+          "report",
+          "--key",
+          tenantKey,
+          "--code-review",
+          "7",
+          "--json",
+          "--sqlite-database-path",
+          fixture.databasePath,
+        ],
+        { stdout: createStringWriter((text) => (stdout += text)) },
+      );
+
+      const reports = JSON.parse(stdout) as Array<{
+        result: { priorDispositions: Array<Record<string, unknown>> };
+      }>;
+      expect(reports[0]?.result.priorDispositions).toEqual([
+        expect.objectContaining({
+          discussionId: "legacy-discussion",
+          action: "keep",
+        }),
+      ]);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
   it("writes matching reports as one Markdown document", async () => {
     const fixture = await createReportFixture();
     try {
@@ -137,9 +197,17 @@ describe("mr report CLI", () => {
       runCli(["mr", "report", "--key", tenantKey, "--latest", "--limit", "2"]),
     ).rejects.toThrow("Cannot combine --latest with --limit.");
   });
+
+  it("rejects an invalid from date", async () => {
+    await expect(
+      runCli(["mr", "report", "--key", tenantKey, "--from", "2026/08/02"]),
+    ).rejects.toThrow("--from requires YYYY-MM-DD");
+  });
 });
 
-async function createReportFixture() {
+async function createReportFixture(
+  options: { legacyDisposition?: boolean } = {},
+) {
   const directory = await mkdtemp(join(tmpdir(), "mr-report-cli-"));
   const databasePath = join(directory, "reviewphin.sqlite");
   const storage = await openSqliteTestStorage(databasePath);
@@ -161,7 +229,15 @@ async function createReportFixture() {
     triggerType: "manual-review",
     startedAt: "2026-08-01T10:00:00.000Z",
     finishedAt: "2026-08-01T10:01:00.000Z",
-    result: reviewResultWithSuggestion,
+    result: options.legacyDisposition
+      ? {
+          ...reviewResultWithSuggestion,
+          priorDispositions: [
+            { threadId: "legacy-discussion", action: "keep" },
+            { action: "resolve", resolution: "dismissed" },
+          ],
+        }
+      : reviewResultWithSuggestion,
     diff: [
       "@@ -8,5 +8,5 @@",
       " function authorize() {",
@@ -208,7 +284,7 @@ async function seedReport(
     triggerType: ReviewTriggerKind;
     startedAt: string;
     finishedAt: string;
-    result: ReviewResult;
+    result: unknown;
     diff: string;
   },
 ): Promise<void> {

--- a/test/review-prompt.test.ts
+++ b/test/review-prompt.test.ts
@@ -154,29 +154,58 @@ describe("buildReviewPrompt", () => {
     expect(renderPrompt("subagent.review-author", {})).not.toContain("unused");
   });
 
-  it("asks the reviewer to recheck unanchored findings without suppressing them", () => {
+  it("allows relevant diff context anchors without encouraging unrelated inline locations", () => {
     const prompt = buildReviewPrompt(createContext());
 
+    expect(prompt).toContain("line available in the review diff");
+    expect(prompt).toContain("unchanged context line inside a diff hunk");
     expect(prompt).toContain(
-      "Anchor a finding to the tightest valid changed-line range when it can be tied to specific code.",
+      "Use an old-side anchor only when removed code itself is the subject",
+    );
+    expect(prompt).toContain("does not need to be its only cause");
+    expect(prompt).toContain(
+      "Never choose an unrelated changed line merely to make the finding inline",
     );
     expect(prompt).toContain(
-      "Otherwise, report it without an anchor. Before returning, recheck every unanchored finding",
+      "omit the anchor and identify the file, symbol, and line in the body",
+    );
+    expect(prompt).toContain(
+      "recheck each anchor against the diff and each unanchored finding",
+    );
+    expect(prompt).not.toContain(
+      "anchor must point to the changed line that causes",
     );
   });
 
-  it("asks review authors for plain, structured, correctly anchored findings", () => {
+  it("asks for plain, structured findings without duplicating that guidance in the agent role", () => {
     const prompt = buildReviewPrompt(createContext());
     const authorPrompt = renderPrompt("subagent.review-author", {});
 
     expect(prompt).toContain("a developer who may not know this project");
-    expect(prompt).toContain("what is wrong, the concrete behavior or risk");
-    expect(prompt).toContain("short paragraphs or a compact Markdown list");
-    expect(prompt).toContain("changed line that causes the reported behavior");
-    expect(authorPrompt).toContain(
-      "problem, its concrete effect or risk, and the required change",
+    expect(prompt).toContain("problem, its concrete effect or risk");
+    expect(prompt).toContain("Use separate short paragraphs");
+    expect(prompt).toContain("Use a compact Markdown list");
+    expect(prompt).toContain("Put that formatting inside the finding's `body`");
+    expect(prompt).toContain("Do not compress distinct points");
+    expect(authorPrompt).not.toContain(
+      "a developer who may not know this project",
     );
-    expect(authorPrompt).toContain("do not pack them into one dense paragraph");
+  });
+
+  it("describes optional location fields consistently with the response validator", () => {
+    const prompt = buildReviewPrompt(createContext());
+
+    expect(prompt).toContain(
+      "Output field guide (fields described as optional may be omitted):",
+    );
+    expect(prompt).toContain(
+      '"anchor": "optional { path: string, oldPath?: string',
+    );
+    expect(prompt).toContain('"suggestion": "optional { replacement: string');
+    expect(prompt).toContain('"replyHandoff": "optional { summary: string');
+    expect(prompt).toContain(
+      "new-side anchor whose line range exactly matches the suggestion range",
+    );
   });
 
   it("uses the incremental summary-follow-up registered combination", () => {
@@ -477,15 +506,23 @@ describe("buildReviewPrompt", () => {
     );
     expect(prompt).toContain("Formatting contract:");
     expect(prompt).toContain(
-      "Return exactly one JSON object matching the schema below.",
+      "Return exactly one JSON object matching the output field guide below.",
     );
     expect(prompt).toContain(
       "Do not include Markdown fences, introductions, explanations, or trailing text outside the JSON object.",
     );
     expect(prompt).toContain("Match the language of the triggering request");
     expect(prompt).toContain("Lead with the answer or requested action");
+    expect(prompt).toContain("do not sacrifice structure for brevity");
     expect(prompt).toContain(
-      "short paragraphs or a compact Markdown list instead of compressing them into one dense paragraph",
+      "Use one paragraph only when the reply contains one idea",
+    );
+    expect(prompt).toContain(
+      "Separate distinct reasons or conditions into short paragraphs",
+    );
+    expect(prompt).toContain("Put that formatting inside `replyBody`");
+    expect(prompt).toContain(
+      '"memory": "optional null | { status: written | skipped',
     );
   });
 

--- a/test/review-prompt.test.ts
+++ b/test/review-prompt.test.ts
@@ -288,6 +288,15 @@ describe("buildReviewPrompt", () => {
         "current overall state of the entire code review",
       );
       expect(prompt).toContain("assess merge readiness with confidence");
+      expect(prompt).toContain(
+        "Make `overview.summary` a one-sentence synopsis",
+      );
+      expect(prompt).toContain(
+        "Use `overview.overallAssessment` for the short explanatory conclusion",
+      );
+      expect(prompt).toContain(
+        "Use `overview.mergeReadiness.summary` only to explain the readiness status",
+      );
       expect(prompt).toContain("include concise highlights when useful");
       expect(prompt).toContain(
         "It must stand alone, regardless of this pass's inspection scope",

--- a/test/review-prompt.test.ts
+++ b/test/review-prompt.test.ts
@@ -165,6 +165,20 @@ describe("buildReviewPrompt", () => {
     );
   });
 
+  it("asks review authors for plain, structured, correctly anchored findings", () => {
+    const prompt = buildReviewPrompt(createContext());
+    const authorPrompt = renderPrompt("subagent.review-author", {});
+
+    expect(prompt).toContain("a developer who may not know this project");
+    expect(prompt).toContain("what is wrong, the concrete behavior or risk");
+    expect(prompt).toContain("short paragraphs or a compact Markdown list");
+    expect(prompt).toContain("changed line that causes the reported behavior");
+    expect(authorPrompt).toContain(
+      "problem, its concrete effect or risk, and the required change",
+    );
+    expect(authorPrompt).toContain("do not pack them into one dense paragraph");
+  });
+
   it("uses the incremental summary-follow-up registered combination", () => {
     const prompt = buildReviewPrompt(
       createContext(null, "summary-follow-up", "incremental-rereview"),
@@ -467,6 +481,11 @@ describe("buildReviewPrompt", () => {
     );
     expect(prompt).toContain(
       "Do not include Markdown fences, introductions, explanations, or trailing text outside the JSON object.",
+    );
+    expect(prompt).toContain("Match the language of the triggering request");
+    expect(prompt).toContain("Lead with the answer or requested action");
+    expect(prompt).toContain(
+      "short paragraphs or a compact Markdown list instead of compressing them into one dense paragraph",
     );
   });
 

--- a/test/review-prompt.test.ts
+++ b/test/review-prompt.test.ts
@@ -209,8 +209,17 @@ describe("buildReviewPrompt", () => {
       "JSON Schema (properties not listed in `required` may be omitted):",
     );
     expect(extractPromptJsonSchemaText(prompt)).not.toContain("\n");
-    expect(schema.required).toEqual(["overview", "findings"]);
-    expect(overview.required).toEqual(["summary", "overallSeverity"]);
+    expect(schema.required).toEqual([
+      "overview",
+      "findings",
+      "priorDispositions",
+    ]);
+    expect(overview.required).toEqual([
+      "summary",
+      "overallSeverity",
+      "overallAssessment",
+      "mergeReadiness",
+    ]);
     expect(finding.required).toEqual(["title", "body", "severity", "category"]);
     expect(anchorObject.required).toEqual([
       "path",
@@ -224,9 +233,11 @@ describe("buildReviewPrompt", () => {
       "startLine",
       "endLine",
     ]);
-    expect(getSchemaProperty(schema, "priorDispositions").default).toEqual([]);
-    expect(replyHandoff.required).toEqual(["summary"]);
-    expect(handoffTargets.default).toEqual([]);
+    expect(
+      getSchemaProperty(schema, "priorDispositions").default,
+    ).toBeUndefined();
+    expect(replyHandoff.required).toEqual(["summary", "targets"]);
+    expect(handoffTargets.default).toBeUndefined();
     expect(handoffTarget.required).toEqual(["kind", "commentId", "guidance"]);
     expect(getSchemaProperty(handoffTarget, "discussionId").description).toBe(
       "Required unless kind is code-review-comment",
@@ -476,6 +487,8 @@ describe("buildReviewPrompt", () => {
   });
 
   it("renders registered standalone prompts and parameterized templates", () => {
+    const memoryPrompt = renderPrompt("reply.memory-update", {});
+
     expect(renderPrompt("subagent.context-analyst", {})).toContain(
       "You are a read-only context analyst.",
     );
@@ -485,9 +498,13 @@ describe("buildReviewPrompt", () => {
     expect(renderPrompt("reply.direct-mention", {})).toContain(
       "You are the lightweight interaction chatter",
     );
-    expect(renderPrompt("reply.memory-update", {})).toContain(
+    expect(memoryPrompt).toContain(
       "This phase runs before any optional reviewer pass.",
     );
+    expect(memoryPrompt).toContain(
+      "Return a `memory` result with status `written` or `skipped`",
+    );
+    expect(memoryPrompt).toContain("Return an empty `replies` array");
     expect(
       renderPrompt("memory.coalesce", {
         entries: [{ text: "Keep pnpm usage consistent." }],
@@ -512,6 +529,12 @@ describe("buildReviewPrompt", () => {
         overview: {
           summary: "Still needs one fix",
           overallSeverity: "medium",
+          overallAssessment: "The validation issue still applies.",
+          mergeReadiness: {
+            status: "needs_attention",
+            confidence: "high",
+            summary: "Add the missing validation before merging.",
+          },
         },
         findings: [],
         priorDispositions: [],
@@ -555,14 +578,18 @@ describe("buildReviewPrompt", () => {
       "Separate distinct reasons or conditions into short paragraphs",
     );
     expect(prompt).toContain("Put that formatting inside `replyBody`");
+    expect(prompt).toContain("Set `memory` to `null`");
+    expect(prompt).toContain(
+      "Return exactly one reply for every provided `responseTarget`",
+    );
     expect(extractPromptJsonSchemaText(prompt)).not.toContain("\n");
     const schema = extractPromptJsonSchema(prompt);
     const replies = getSchemaProperty(schema, "replies");
     const reply = asRecord(replies.items);
     const target = getSchemaProperty(reply, "target");
-    expect(schema.required).toBeUndefined();
+    expect(schema.required).toEqual(["memory", "replies"]);
     expect(getSchemaProperty(schema, "memory").anyOf).toBeInstanceOf(Array);
-    expect(replies.default).toEqual([]);
+    expect(replies.default).toBeUndefined();
     expect(getSchemaProperty(target, "discussionId").description).toContain(
       "Required unless kind is code-review-comment",
     );

--- a/test/review-prompt.test.ts
+++ b/test/review-prompt.test.ts
@@ -295,6 +295,9 @@ describe("buildReviewPrompt", () => {
         "Use `overview.overallAssessment` for the short explanatory conclusion",
       );
       expect(prompt).toContain(
+        "`blocked` when any actionable finding is critical",
+      );
+      expect(prompt).toContain(
         "Use `overview.mergeReadiness.summary` only to explain the readiness status",
       );
       expect(prompt).toContain("include concise highlights when useful");

--- a/test/review-prompt.test.ts
+++ b/test/review-prompt.test.ts
@@ -208,6 +208,7 @@ describe("buildReviewPrompt", () => {
     expect(prompt).toContain(
       "JSON Schema (properties not listed in `required` may be omitted):",
     );
+    expect(extractPromptJsonSchemaText(prompt)).not.toContain("\n");
     expect(schema.required).toEqual(["overview", "findings"]);
     expect(overview.required).toEqual(["summary", "overallSeverity"]);
     expect(finding.required).toEqual(["title", "body", "severity", "category"]);
@@ -554,6 +555,7 @@ describe("buildReviewPrompt", () => {
       "Separate distinct reasons or conditions into short paragraphs",
     );
     expect(prompt).toContain("Put that formatting inside `replyBody`");
+    expect(extractPromptJsonSchemaText(prompt)).not.toContain("\n");
     const schema = extractPromptJsonSchema(prompt);
     const replies = getSchemaProperty(schema, "replies");
     const reply = asRecord(replies.items);
@@ -599,6 +601,10 @@ describe("buildReviewPrompt", () => {
 });
 
 function extractPromptJsonSchema(prompt: string): Record<string, unknown> {
+  return asRecord(JSON.parse(extractPromptJsonSchemaText(prompt)) as unknown);
+}
+
+function extractPromptJsonSchemaText(prompt: string): string {
   const heading =
     "JSON Schema (properties not listed in `required` may be omitted):\n";
   const start = prompt.indexOf(heading);
@@ -610,7 +616,7 @@ function extractPromptJsonSchema(prompt: string): Record<string, unknown> {
   if (schemaEnd < 0) {
     throw new Error("Prompt JSON Schema terminator was not found");
   }
-  return asRecord(JSON.parse(prompt.slice(schemaStart, schemaEnd)) as unknown);
+  return prompt.slice(schemaStart, schemaEnd);
 }
 
 function getSchemaProperty(

--- a/test/review-prompt.test.ts
+++ b/test/review-prompt.test.ts
@@ -192,17 +192,44 @@ describe("buildReviewPrompt", () => {
     );
   });
 
-  it("describes optional location fields consistently with the response validator", () => {
+  it("includes the review validator's input JSON Schema", () => {
     const prompt = buildReviewPrompt(createContext());
+    const schema = extractPromptJsonSchema(prompt);
+    const overview = getSchemaProperty(schema, "overview");
+    const finding = asRecord(getSchemaProperty(schema, "findings").items);
+    const anchor = getSchemaProperty(finding, "anchor");
+    const anchorObject = asRecord((anchor.anyOf as unknown[])[0]);
+    const suggestion = getSchemaProperty(finding, "suggestion");
+    const suggestionObject = asRecord((suggestion.anyOf as unknown[])[0]);
+    const replyHandoff = getSchemaProperty(schema, "replyHandoff");
+    const handoffTargets = getSchemaProperty(replyHandoff, "targets");
+    const handoffTarget = asRecord(handoffTargets.items);
 
     expect(prompt).toContain(
-      "Output field guide (fields described as optional may be omitted):",
+      "JSON Schema (properties not listed in `required` may be omitted):",
     );
-    expect(prompt).toContain(
-      '"anchor": "optional { path: string, oldPath?: string',
+    expect(schema.required).toEqual(["overview", "findings"]);
+    expect(overview.required).toEqual(["summary", "overallSeverity"]);
+    expect(finding.required).toEqual(["title", "body", "severity", "category"]);
+    expect(anchorObject.required).toEqual([
+      "path",
+      "startLine",
+      "endLine",
+      "side",
+    ]);
+    expect(anchorObject.description).toContain("inclusive range");
+    expect(suggestionObject.required).toEqual([
+      "replacement",
+      "startLine",
+      "endLine",
+    ]);
+    expect(getSchemaProperty(schema, "priorDispositions").default).toEqual([]);
+    expect(replyHandoff.required).toEqual(["summary"]);
+    expect(handoffTargets.default).toEqual([]);
+    expect(handoffTarget.required).toEqual(["kind", "commentId", "guidance"]);
+    expect(getSchemaProperty(handoffTarget, "discussionId").description).toBe(
+      "Required unless kind is code-review-comment",
     );
-    expect(prompt).toContain('"suggestion": "optional { replacement: string');
-    expect(prompt).toContain('"replyHandoff": "optional { summary: string');
     expect(prompt).toContain(
       "new-side anchor whose line range exactly matches the suggestion range",
     );
@@ -265,10 +292,13 @@ describe("buildReviewPrompt", () => {
     },
   );
 
-  it("includes prior finding history with status and resolve resolution schema", () => {
+  it("includes prior finding history and the disposition resolution contract", () => {
     const prompt = buildReviewPrompt(
       createContext(null, "direct-mention", "incremental-rereview"),
     );
+    const schema = extractPromptJsonSchema(prompt);
+    const priorDispositions = getSchemaProperty(schema, "priorDispositions");
+    const disposition = asRecord(priorDispositions.items);
 
     expect(prompt).toContain('"priorFindings": [');
     expect(prompt).toContain('"status": "open"');
@@ -276,7 +306,10 @@ describe("buildReviewPrompt", () => {
     expect(prompt).toContain(
       "treat `resolved` and `dismissed` prior findings as inactive by default",
     );
-    expect(prompt).toContain('"resolution": "optional resolved | dismissed"');
+    expect(getSchemaProperty(disposition, "resolution").enum).toEqual([
+      "resolved",
+      "dismissed",
+    ]);
   });
 
   it("uses a complete compact manifest and omits full diffs when Git inspection is ready", () => {
@@ -506,7 +539,7 @@ describe("buildReviewPrompt", () => {
     );
     expect(prompt).toContain("Formatting contract:");
     expect(prompt).toContain(
-      "Return exactly one JSON object matching the output field guide below.",
+      "Return exactly one JSON object matching the JSON Schema below.",
     );
     expect(prompt).toContain(
       "Do not include Markdown fences, introductions, explanations, or trailing text outside the JSON object.",
@@ -521,8 +554,15 @@ describe("buildReviewPrompt", () => {
       "Separate distinct reasons or conditions into short paragraphs",
     );
     expect(prompt).toContain("Put that formatting inside `replyBody`");
-    expect(prompt).toContain(
-      '"memory": "optional null | { status: written | skipped',
+    const schema = extractPromptJsonSchema(prompt);
+    const replies = getSchemaProperty(schema, "replies");
+    const reply = asRecord(replies.items);
+    const target = getSchemaProperty(reply, "target");
+    expect(schema.required).toBeUndefined();
+    expect(getSchemaProperty(schema, "memory").anyOf).toBeInstanceOf(Array);
+    expect(replies.default).toEqual([]);
+    expect(getSchemaProperty(target, "discussionId").description).toContain(
+      "Required unless kind is code-review-comment",
     );
   });
 
@@ -557,6 +597,35 @@ describe("buildReviewPrompt", () => {
     expect(prompt).toContain('"status": 403');
   });
 });
+
+function extractPromptJsonSchema(prompt: string): Record<string, unknown> {
+  const heading =
+    "JSON Schema (properties not listed in `required` may be omitted):\n";
+  const start = prompt.indexOf(heading);
+  if (start < 0) {
+    throw new Error("Prompt JSON Schema heading was not found");
+  }
+  const schemaStart = start + heading.length;
+  const schemaEnd = prompt.indexOf("\n\nContext:", schemaStart);
+  if (schemaEnd < 0) {
+    throw new Error("Prompt JSON Schema terminator was not found");
+  }
+  return asRecord(JSON.parse(prompt.slice(schemaStart, schemaEnd)) as unknown);
+}
+
+function getSchemaProperty(
+  schema: Record<string, unknown>,
+  property: string,
+): Record<string, unknown> {
+  return asRecord(asRecord(schema.properties)[property]);
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Expected a JSON Schema object");
+  }
+  return value as Record<string, unknown>;
+}
 
 function createContext(
   entries:

--- a/test/review-report.test.ts
+++ b/test/review-report.test.ts
@@ -55,9 +55,40 @@ describe("review report", () => {
     expect(report).toContain("## Merge readiness");
     expect(report).toContain("## Findings (1)");
     expect(report).toContain("`src/auth.ts`, lines 10-12 (new side)");
+    expect(report).toContain("- **File:** `src/auth.ts`");
+    expect(report).toContain("- **Lines:** lines 10-12");
+    expect(report).toContain("**Replace the indicated lines with:**");
     expect(report).toContain("```suggestion");
     expect(report).toMatch(/\n$/);
     expect(report).not.toContain("\u001B[");
+  });
+
+  it("shows the exact code replaced by an anchored suggestion when the diff is stored", () => {
+    const report = formatReviewReportMarkdown(reviewResult, {
+      changes: [
+        {
+          oldPath: "src/auth.ts",
+          newPath: "src/auth.ts",
+          diff: [
+            "@@ -8,5 +8,5 @@",
+            " function authorize() {",
+            "   const tenant = findTenant();",
+            "+  return tenant.data;",
+            "+}",
+            "+export { authorize };",
+          ].join("\n"),
+          newFile: false,
+          renamedFile: false,
+          deletedFile: false,
+        },
+      ],
+    });
+
+    expect(report).toContain("**Replace:**");
+    expect(report).toContain(
+      "```text\n  return tenant.data;\n}\nexport { authorize };\n```",
+    );
+    expect(report).toContain("**With:**");
   });
 
   it("renders Markdown semantics as width-aware terminal text", () => {

--- a/test/review-report.test.ts
+++ b/test/review-report.test.ts
@@ -52,6 +52,7 @@ describe("review report", () => {
     const report = formatReviewReportMarkdown(reviewResult);
 
     expect(report).toContain("# Review result");
+    expect(report).toContain("## Overall assessment");
     expect(report).toContain("## Merge readiness");
     expect(report).toContain("## Findings (1)");
     expect(report).toContain("`src/auth.ts`, lines 10-12 (new side)");

--- a/test/review-result-schema.test.ts
+++ b/test/review-result-schema.test.ts
@@ -123,4 +123,29 @@ describe("persisted review result compatibility", () => {
       targets: [],
     });
   });
+
+  it("blocks legacy results that contain critical findings", () => {
+    const result = parsePersistedReviewResult(
+      JSON.stringify({
+        overview: {
+          summary: "A critical security issue remains.",
+          overallSeverity: "critical",
+        },
+        findings: [
+          {
+            title: "Reject unauthenticated access",
+            body: "Require authentication before returning tenant data.",
+            severity: "critical",
+            category: "security",
+          },
+        ],
+      }),
+    );
+
+    expect(result.overview.mergeReadiness).toEqual({
+      status: "blocked",
+      confidence: "low",
+      summary: "A critical security issue remains.",
+    });
+  });
 });

--- a/test/review-result-schema.test.ts
+++ b/test/review-result-schema.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+
+import { parsePersistedReviewResult } from "../src/review/persisted-review-result.js";
+import {
+  chatterBatchResultSchema,
+  reviewResultSchema,
+} from "../src/review/types.js";
+
+describe("current review response schemas", () => {
+  it("requires every current review result field", () => {
+    const incompleteReview = {
+      overview: {
+        summary: "One issue found.",
+        overallSeverity: "medium",
+      },
+      findings: [],
+    };
+
+    const incompleteResult = reviewResultSchema.safeParse(incompleteReview);
+    expect(incompleteResult.success).toBe(false);
+    if (incompleteResult.success) {
+      throw new Error("Expected the incomplete review result to be rejected");
+    }
+    expect(incompleteResult.error.issues.map((issue) => issue.path)).toEqual(
+      expect.arrayContaining([
+        ["overview", "overallAssessment"],
+        ["overview", "mergeReadiness"],
+        ["priorDispositions"],
+      ]),
+    );
+    expect(
+      reviewResultSchema.safeParse({
+        ...incompleteReview,
+        overview: {
+          ...incompleteReview.overview,
+          overallAssessment: "One issue needs attention.",
+          mergeReadiness: {
+            status: "needs_attention",
+            confidence: "medium",
+            summary: "Address the issue before merging.",
+          },
+        },
+        priorDispositions: [],
+      }).success,
+    ).toBe(true);
+  });
+
+  it("requires memory and replies in every current chatter result", () => {
+    expect(chatterBatchResultSchema.safeParse({ replies: [] }).success).toBe(
+      false,
+    );
+    expect(chatterBatchResultSchema.safeParse({ memory: null }).success).toBe(
+      false,
+    );
+    expect(
+      chatterBatchResultSchema.safeParse({ memory: null, replies: [] }).success,
+    ).toBe(true);
+    expect(
+      chatterBatchResultSchema.safeParse({
+        memory: { status: "skipped", summary: "" },
+        replies: [],
+      }).success,
+    ).toBe(true);
+  });
+});
+
+describe("persisted review result compatibility", () => {
+  it("normalizes fields omitted by older stored review results", () => {
+    const result = parsePersistedReviewResult(
+      JSON.stringify({
+        overview: {
+          summary: "A historical issue needs attention.",
+          overallSeverity: "medium",
+        },
+        findings: [],
+      }),
+    );
+
+    expect(result.overview).toEqual({
+      summary: "A historical issue needs attention.",
+      overallSeverity: "medium",
+      overallAssessment: "A historical issue needs attention.",
+      mergeReadiness: {
+        status: "ready",
+        confidence: "low",
+        summary: "A historical issue needs attention.",
+      },
+    });
+    expect(result.priorDispositions).toEqual([]);
+  });
+
+  it("normalizes legacy disposition identifiers and ignores unusable entries", () => {
+    const result = parsePersistedReviewResult(
+      JSON.stringify({
+        overview: {
+          summary: "A historical issue needs attention.",
+          overallSeverity: "medium",
+        },
+        findings: [
+          {
+            title: "Fix validation",
+            body: "Validate the input before using it.",
+            severity: "medium",
+            category: "correctness",
+          },
+        ],
+        priorDispositions: [
+          { threadId: "legacy-thread", action: "keep" },
+          { action: "resolve", resolution: "dismissed" },
+        ],
+        replyHandoff: {
+          summary: "Reply using the historical handoff.",
+        },
+      }),
+    );
+
+    expect(result.overview.mergeReadiness.status).toBe("needs_attention");
+    expect(result.priorDispositions).toEqual([
+      { discussionId: "legacy-thread", action: "keep" },
+    ]);
+    expect(result.replyHandoff).toEqual({
+      summary: "Reply using the historical handoff.",
+      targets: [],
+    });
+  });
+});

--- a/test/review-scope.test.ts
+++ b/test/review-scope.test.ts
@@ -150,6 +150,12 @@ describe("buildScopedReviewContext", () => {
       "src/delta.ts",
     ]);
     expect(scoped.scope.previousReview?.reviewRunId).toBe("run_prev");
+    expect(scoped.scope.previousReview?.overviewSummary).toBe("Needs work");
+    expect(scoped.scope.previousReview?.mergeReadiness).toEqual({
+      status: "needs_attention",
+      confidence: "medium",
+      summary: "A prior issue remained open.",
+    });
     expect(scoped.scope.deltaSincePreviousReview?.changedFiles).toHaveLength(1);
   });
 

--- a/test/review-summary.test.ts
+++ b/test/review-summary.test.ts
@@ -116,6 +116,12 @@ describe("review summary comment", () => {
         overview: {
           summary: "One fix remains",
           overallSeverity: "high",
+          overallAssessment: "One high-severity correctness issue remains.",
+          mergeReadiness: {
+            status: "blocked",
+            confidence: "high",
+            summary: "Fix the prompt escaping issue before merging.",
+          },
         },
         findings: [
           {
@@ -238,6 +244,8 @@ describe("review summary comment", () => {
           summary:
             "One thread was dismissed, but merge readiness still depends on an older open storage fix.",
           overallSeverity: "medium",
+          overallAssessment:
+            "The targeted thread is resolved, but another issue remains.",
           mergeReadiness: {
             status: "needs_attention",
             confidence: "medium",

--- a/test/review-summary.test.ts
+++ b/test/review-summary.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
 
+import { formatReviewReportMarkdown } from "../src/cli/review-report.js";
 import { getPlatformBySlug } from "../src/platforms/platform-registry.js";
-import { buildReviewSummaryNote } from "../src/review/summary.js";
+import {
+  buildReviewSummaryNote,
+  resolveReviewOverview,
+} from "../src/review/summary.js";
+import type { ReviewResult } from "../src/review/types.js";
 
 const platform = getPlatformBySlug("gitlab");
 if (!platform) {
@@ -12,6 +17,27 @@ import { tmpPath } from "./test-paths.js";
 describe("review summary comment", () => {
   it("wraps the suggested fixes prompt in a fenced md block and escapes embedded fences", () => {
     const timestamp = "2026-04-27T11:00:00.000Z";
+    const reviewResult: ReviewResult = {
+      overview: {
+        summary: "One fix remains",
+        overallSeverity: "high",
+        overallAssessment: "One high-severity correctness issue remains.",
+        mergeReadiness: {
+          status: "blocked",
+          confidence: "high",
+          summary: "Fix the prompt escaping issue before merging.",
+        },
+      },
+      findings: [
+        {
+          title: "Escape fenced prompt content",
+          body: 'Preserve content like ```ts\nconst status = "blocked";\n``` in the copied prompt.',
+          severity: "high",
+          category: "correctness",
+        },
+      ],
+      priorDispositions: [],
+    };
     const note = buildReviewSummaryNote({
       platform,
       context: {
@@ -112,29 +138,18 @@ describe("review summary comment", () => {
           createdAt: timestamp,
         },
       } as never,
-      reviewResult: {
-        overview: {
-          summary: "One fix remains",
-          overallSeverity: "high",
-          overallAssessment: "One high-severity correctness issue remains.",
-          mergeReadiness: {
-            status: "blocked",
-            confidence: "high",
-            summary: "Fix the prompt escaping issue before merging.",
-          },
-        },
-        findings: [
-          {
-            title: "Escape fenced prompt content",
-            body: 'Preserve content like ```ts\nconst status = "blocked";\n``` in the copied prompt.',
-            severity: "high",
-            category: "correctness",
-          },
-        ],
-        priorDispositions: [],
-      },
+      reviewResult,
     });
 
+    const report = formatReviewReportMarkdown({
+      ...reviewResult,
+      overview: resolveReviewOverview(reviewResult),
+    });
+
+    expect(note).toContain("- **Status:** Needs attention");
+    expect(note).not.toContain("- **Status:** Blocked");
+    expect(report).toContain("**Status:** Needs Attention");
+    expect(report).not.toContain("**Status:** Blocked");
     expect(note).toContain(
       "<details><summary>Suggested fixes prompt</summary>",
     );

--- a/test/review-worker-cleanup.test.ts
+++ b/test/review-worker-cleanup.test.ts
@@ -298,6 +298,12 @@ describe("ReviewWorker cleanup", () => {
             overview: {
               summary: "Done",
               overallSeverity: "low" as const,
+              overallAssessment: "No issues found.",
+              mergeReadiness: {
+                status: "ready" as const,
+                confidence: "high" as const,
+                summary: "The change is ready to merge.",
+              },
             },
             findings: [],
             priorDispositions: [],
@@ -336,7 +342,10 @@ describe("ReviewWorker cleanup", () => {
       worker.processClaimedJob(job as never, createClaimContext(job.id)),
     ).resolves.toBeUndefined();
     expect(transitionInteractionRunForClaim).toHaveBeenCalledWith(
-      expect.objectContaining({ interactionRunId: "run_1", status: "completed" }),
+      expect.objectContaining({
+        interactionRunId: "run_1",
+        status: "completed",
+      }),
     );
     expect(transitionClaim).toHaveBeenCalledWith(
       expect.objectContaining({ jobId: job.id, status: "completed" }),

--- a/test/review-worker-orchestration.test.ts
+++ b/test/review-worker-orchestration.test.ts
@@ -1398,6 +1398,12 @@ describe("ReviewWorker orchestration", () => {
         overview: {
           summary: "No further issues found",
           overallSeverity: "low" as const,
+          overallAssessment: "No further issues were found.",
+          mergeReadiness: {
+            status: "ready" as const,
+            confidence: "high" as const,
+            summary: "The change is ready to merge.",
+          },
         },
         findings: [],
         priorDispositions: [],
@@ -1743,6 +1749,12 @@ describe("ReviewWorker orchestration", () => {
         overview: {
           summary: "No further issues found",
           overallSeverity: "low" as const,
+          overallAssessment: "No further issues were found.",
+          mergeReadiness: {
+            status: "ready" as const,
+            confidence: "high" as const,
+            summary: "The change is ready to merge.",
+          },
         },
         findings: [],
         priorDispositions: [],
@@ -1935,6 +1947,12 @@ describe("ReviewWorker orchestration", () => {
       overview: {
         summary: "No issues found.",
         overallSeverity: "low" as const,
+        overallAssessment: "No issues were found.",
+        mergeReadiness: {
+          status: "ready" as const,
+          confidence: "high" as const,
+          summary: "The change is ready to merge.",
+        },
       },
       findings: [],
       priorDispositions: [],

--- a/test/review-worker-orchestration.test.ts
+++ b/test/review-worker-orchestration.test.ts
@@ -1949,9 +1949,9 @@ describe("ReviewWorker orchestration", () => {
         overallSeverity: "low" as const,
         overallAssessment: "No issues were found.",
         mergeReadiness: {
-          status: "ready" as const,
+          status: "blocked" as const,
           confidence: "high" as const,
-          summary: "The change is ready to merge.",
+          summary: "The model supplied an inconsistent readiness decision.",
         },
       },
       findings: [],
@@ -2055,7 +2055,20 @@ describe("ReviewWorker orchestration", () => {
       expect.objectContaining({
         interactionRunId: run.id,
         status: "completed",
-        resultJson: JSON.stringify(reviewResult),
+        resultJson: JSON.stringify({
+          ...reviewResult,
+          overview: {
+            ...reviewResult.overview,
+            overallAssessment:
+              "No actionable findings were identified in this review.",
+            mergeReadiness: {
+              status: "ready",
+              confidence: "medium",
+              summary:
+                "No actionable findings were identified in this review run.",
+            },
+          },
+        }),
       }),
     );
     expect(jobStore.transitionClaim).toHaveBeenCalledWith(

--- a/test/review-worker-orchestration.test.ts
+++ b/test/review-worker-orchestration.test.ts
@@ -12,6 +12,7 @@ import type {
 } from "../src/platforms/IPlatform.js";
 import type { GitLabNoteHookPayload } from "../src/platforms/gitlab/types.js";
 import type { InteractionRunArtifacts } from "../src/review/run-artifacts.js";
+import type { ReviewContext } from "../src/review/types.js";
 import type { TenantRecord } from "../src/storage/contract/index.js";
 import type { StorageHelpers } from "../src/storage/storage-helpers.js";
 import { createGitLabConnectionRecord } from "./helpers/gitlab-tenant.js";
@@ -1911,7 +1912,7 @@ describe("ReviewWorker orchestration", () => {
     globalThis.fetch = originalFetch;
   });
 
-  it("stores local-test results without constructing publication paths", async () => {
+  it("keeps prior open findings in incremental no-publish readiness", async () => {
     const trigger = {
       kind: "reviewphin-local-review",
       source: "cli",
@@ -1943,20 +1944,36 @@ describe("ReviewWorker orchestration", () => {
       get: async () => job as never,
       run: run as never,
     });
+    const priorFinding = {
+      findingId: "finding-prior-high",
+      identityKey: "identity-prior-high",
+      status: "open" as const,
+      title: "Older high-severity finding",
+      body: "The earlier issue is still unresolved.",
+      severity: "high",
+      category: "correctness",
+      anchor: null,
+      suggestion: null,
+      interactionRunId: "run-prior",
+      reviewedAt: "2026-08-01T10:00:00.000Z",
+      headSha: "previous-head",
+    };
     const reviewResult = {
       overview: {
-        summary: "No issues found.",
+        summary: "The earlier issue still needs attention.",
         overallSeverity: "low" as const,
-        overallAssessment: "No issues were found.",
+        overallAssessment:
+          "No new issues were found, but the earlier issue remains open.",
         mergeReadiness: {
-          status: "blocked" as const,
+          status: "needs_attention" as const,
           confidence: "high" as const,
-          summary: "The model supplied an inconsistent readiness decision.",
+          summary: "The earlier high-severity issue remains open.",
         },
       },
       findings: [],
       priorDispositions: [],
     };
+    const review = vi.fn(async (_context: ReviewContext) => reviewResult);
     const routingContext = wrapGitLabPlatformContext({
       tenant,
       job,
@@ -2009,8 +2026,52 @@ describe("ReviewWorker orchestration", () => {
         getInteractionJobById: vi.fn(async () => job),
         getModelProfileByName: vi.fn(async () => null),
         getDefaultModelProfile: vi.fn(async () => null),
-        getLatestCompletedInteractionForCodeReview: vi.fn(async () => null),
-        listPriorReviewFindings: vi.fn(async () => []),
+        getLatestCompletedInteractionForCodeReview: vi.fn(async () => ({
+          interactionRunId: "run-prior",
+          interactionJobId: "job-prior",
+          finishedAt: "2026-08-01T10:00:00.000Z",
+          headSha: "previous-head",
+          resultJson: JSON.stringify({
+            overview: {
+              summary: "One earlier issue remains.",
+              overallSeverity: "high",
+              overallAssessment:
+                "The earlier high-severity issue needs attention.",
+              mergeReadiness: {
+                status: "needs_attention",
+                confidence: "high",
+                summary: "The earlier issue should be addressed before merge.",
+              },
+            },
+            findings: [
+              {
+                title: priorFinding.title,
+                body: priorFinding.body,
+                severity: priorFinding.severity,
+                category: priorFinding.category,
+              },
+            ],
+            priorDispositions: [],
+          }),
+          snapshot: {
+            id: "snapshot-prior",
+            interactionJobId: "job-prior",
+            interactionRunId: "run-prior",
+            tenantId: tenant.id,
+            codeReviewId: 7,
+            headSha: "previous-head",
+            codeReviewJson: "{}",
+            versionsJson: "[]",
+            changesJson: "[]",
+            commentsJson: "[]",
+            discussionsJson: "[]",
+            instructionsJson: "[]",
+            projectMemoryJson: null,
+            workspaceStrategy: "git",
+            createdAt: "2026-08-01T10:00:00.000Z",
+          },
+        })),
+        listPriorReviewFindings: vi.fn(async () => [priorFinding]),
       } as never,
       tenantRegistry: {
         getResolvedTenantById: vi.fn(async () => ({ tenant, connection })),
@@ -2024,7 +2085,7 @@ describe("ReviewWorker orchestration", () => {
       reviewProviderFactory: {
         createProvider: vi.fn(() => ({
           name: "copilot-sdk",
-          review: vi.fn(async () => reviewResult),
+          review,
         })),
       },
       chatterRunnerFactory: {
@@ -2045,6 +2106,17 @@ describe("ReviewWorker orchestration", () => {
     expect(createTriggerLifecycle).not.toHaveBeenCalled();
     expect(createReviewPublicationAdapter).not.toHaveBeenCalled();
     expect(reconciler.reconcile).not.toHaveBeenCalled();
+    const reviewContext = review.mock.calls[0]?.[0];
+    expect(reviewContext?.scope.mode).toBe("incremental-rereview");
+    expect(reviewContext?.scope.priorFindings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          identityKey: priorFinding.identityKey,
+          status: "open",
+          severity: "high",
+        }),
+      ]),
+    );
     expect(buildHarnessTenantContext).toHaveBeenCalledWith(
       expect.objectContaining({
         memoryEnabled: true,
@@ -2060,12 +2132,14 @@ describe("ReviewWorker orchestration", () => {
           overview: {
             ...reviewResult.overview,
             overallAssessment:
-              "No actionable findings were identified in this review.",
+              "Persisted open high-severity findings remain after reconciling the latest review and should be addressed before merge.",
+            summary: "High-severity findings remain after reconciliation.",
+            overallSeverity: "high",
             mergeReadiness: {
-              status: "ready",
+              status: "needs_attention",
               confidence: "medium",
               summary:
-                "No actionable findings were identified in this review run.",
+                "Persisted open high-severity findings remain and should be addressed before merge.",
             },
           },
         }),


### PR DESCRIPTION
## Summary

- add `mr report --key <tenant-key>` for displaying completed stored review reports newest first
- support latest, limit, code-review, trigger-type, publication-mode, JSON, and combined Markdown file output
- enrich suggested changes with file and line ranges, plus exact replaced text when it is available in the stored snapshot diff
- document the command and cover filtering, aliases, ordering, file output, and suggestion rendering

## Validation

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (576 tests)
- [x] `pnpm build`
- [x] `pnpm docs:build`
- [x] Tests cover new or changed behavior
- [x] Documentation reflects user-facing changes
- [x] The change contains no credentials, private code, or sensitive logs

## Changelog

<details><summary>Changelog: minor</summary>

### Added

- Reviewers can display and filter stored merge request or pull request reports from the CLI, including actionable suggested-change context.

### Changed

- Review findings and replies are clearer and easier to follow, with more accurate merge-readiness guidance, code locations, and suggested changes.

</details>