### PR TITLE
Add review quality benchmark skill

### DIFF
--- a/.agents/skills/review-quality-benchmark/SKILL.md
+++ b/.agents/skills/review-quality-benchmark/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: review-quality-benchmark
+description: Assess ReviewPhin review-run quality over a user-provided time period from an exported SQLite database and existing run logs, reuse cached scores, and produce a fixed-template HTML report with quality charts over time. Use when Codex needs to benchmark generated review summaries and findings, compare prompt eras or date ranges, score review quality dimensions, or refresh an existing benchmark report without repository access.
+---
+
+# Review Quality Benchmark
+
+Benchmark reviewer output from recorded run evidence only. Keep judgment agentic and keep selection, normalization, caching, validation, and HTML rendering deterministic through the bundled standalone Node.js script.
+
+## Required boundaries
+
+- Do not access target repositories, provider APIs, or the internet.
+- Do not mutate the source database or run logs.
+- Do not import ReviewPhin application modules or third-party Node.js packages.
+- Put every generated file under `<workspace>/benchmark-report/`.
+- Treat the benchmark as evidence-relative: judge how well the output is supported by the evidence recorded in the run.
+- Score runs independently against the rubric. Do not rank a run relative to neighboring runs.
+- Default to reviewer modes `review`, `first-pass-full`, and `incremental-rereview`. Exclude reply, chatter, and memory sessions unless the user explicitly requests otherwise.
+
+## Workflow
+
+1. Resolve the workspace, source SQLite database, run-log directory, inclusive `from` date, and inclusive `to` date. Use `data/review-worker.sqlite` and `data/run-logs` when present and the user did not override them.
+2. Read [references/rubric.md](references/rubric.md), [references/judge-prompt.md](references/judge-prompt.md), and [references/assessment-schema.json](references/assessment-schema.json) completely before scoring.
+3. Prepare normalized evidence packets and inspect cache state:
+
+   ```powershell
+   node .agents/skills/review-quality-benchmark/scripts/benchmark.mjs prepare `
+     --db data/review-worker.sqlite `
+     --logs data/run-logs `
+     --from 2026-07-31 `
+     --to 2026-08-06 `
+     --judge-model gpt-5.6-sol
+   ```
+
+4. Read `benchmark-report/tmp/manifest.json`. If `pendingRuns` is empty, skip directly to rendering.
+5. For each pending run, read its packet from `benchmark-report/tmp/packets/<run-id>.json`, apply the judge prompt and rubric, and write one schema-conforming JSON assessment to `benchmark-report/tmp/assessments/<run-id>.json`. Preserve the packet's `runId`, `inputDigest`, `evaluatorVersion`, and `judgeModel` exactly.
+6. Store each assessment immediately so completed work survives interruption:
+
+   ```powershell
+   node .agents/skills/review-quality-benchmark/scripts/benchmark.mjs store `
+     --file benchmark-report/tmp/assessments/<run-id>.json
+   ```
+
+7. Render the report after all possible pending runs are stored:
+
+   ```powershell
+   node .agents/skills/review-quality-benchmark/scripts/benchmark.mjs render
+   ```
+
+8. Return the report path, selected/scored/missing counts, cache reuse count, and any runs that failed assessment. Do not describe cached runs as newly assessed.
+
+## Scoring rules
+
+- Score all seven run-level categories: `noobFriendliness`, `unjargonity`, `readability`, `importance`, `targeting`, `assessmentScope`, and `groundedness`.
+- Use integer scores from 0 through 10. Higher is always better.
+- Set `importance` and `targeting` to `null` when a run emitted no findings. Never convert not-applicable values to zero.
+- Score each finding's importance, targeting, and groundedness before deriving the run-level values.
+- Judge targeting semantically from the finding, anchor, suggestion, changed-file manifest, and recorded inspection evidence. Consider whether an anchor or safe suggestion should exist, whether one exists, and whether it is useful and correct.
+- Judge groundedness only against recorded evidence. Penalize claims that overreach or contradict the trace; do not penalize the absence of external repository evidence.
+- Keep reasons concise and evidentiary. Do not quote secrets, source code blocks, or large log passages into assessments.
+
+## Date and cache behavior
+
+- Treat date-only `from` and `to` values as inclusive UTC calendar dates. Accept full ISO timestamps for precise boundaries.
+- Cache identity includes normalized run evidence, rubric and judge-prompt content, assessment schema, and judge model identifier.
+- Reuse a cached assessment only when every identity component matches.
+- Widening a period must assess only new or invalidated runs and then rerender the complete requested period.
+- Never delete the cache automatically. Use the script's `--force` option during `prepare` only when the user explicitly requests reassessment.
+
+## Output behavior
+
+- Use the bundled `assets/report-template.html` unchanged except for injection at its single `__REVIEW_BENCHMARK_DATA__` marker.
+- Let the renderer escape embedded JSON and write reports atomically.
+- Default reports to `benchmark-report/reports/review-quality-<from>--<to>.html`.
+- Keep the report self-contained and offline. Do not add runtime CDN or network dependencies.
+- Keep the timeline's shared scale switchable between the honest fixed `0–10` range and one fitted `min–max` range derived from all visible applicable scores. Do not fit each category independently.
+- Keep timeline height independent of run count. Give the SVG explicit lane-derived pixel dimensions and let long periods scroll horizontally instead of scaling the whole chart down to the panel width.
+- Preserve temporary packets and assessments under `benchmark-report/tmp` for auditability until a later benchmark invocation replaces them.
+
+## Script help
+
+Run `node .agents/skills/review-quality-benchmark/scripts/benchmark.mjs help` for all options and defaults.

--- a/.agents/skills/review-quality-benchmark/SKILL.md
+++ b/.agents/skills/review-quality-benchmark/SKILL.md
@@ -65,7 +65,7 @@ Benchmark reviewer output from recorded run evidence only. Keep judgment agentic
 - Cache identity includes normalized run evidence, rubric and judge-prompt content, assessment schema, and judge model identifier.
 - Reuse a cached assessment only when every identity component matches.
 - Widening a period must assess only new or invalidated runs and then rerender the complete requested period.
-- Never delete the cache automatically. Use the script's `--force` option during `prepare` only when the user explicitly requests reassessment.
+- Preserve unrelated cache entries. Use the script's `--force` option during `prepare` only when the user explicitly requests reassessment; it invalidates matching scores for the selected runs so interrupted reassessment cannot render stale results.
 
 ## Output behavior
 

--- a/.agents/skills/review-quality-benchmark/agents/openai.yaml
+++ b/.agents/skills/review-quality-benchmark/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Review Quality Benchmark"
+  short_description: "Score review runs and chart quality over time"
+  default_prompt: "Use $review-quality-benchmark to score review runs from the requested period and generate an HTML quality report."

--- a/.agents/skills/review-quality-benchmark/assets/report-template.html
+++ b/.agents/skills/review-quality-benchmark/assets/report-template.html
@@ -1,0 +1,1323 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Review quality benchmark</title>
+    <style>
+      :root {
+        color-scheme: light;
+        --paper: #f3f1ea;
+        --sheet: #fbfaf6;
+        --ink: #14213d;
+        --muted: #667085;
+        --line: #d7d9d3;
+        --line-strong: #b5bab3;
+        --cobalt: #3155d9;
+        --coral: #e66b4e;
+        --moss: #487c66;
+        --shadow: 0 18px 48px rgb(20 33 61 / 9%);
+        --radius: 18px;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      html {
+        background: var(--paper);
+        scroll-behavior: smooth;
+      }
+
+      body {
+        margin: 0;
+        min-width: 320px;
+        color: var(--ink);
+        background:
+          linear-gradient(rgb(49 85 217 / 3%) 1px, transparent 1px),
+          linear-gradient(90deg, rgb(49 85 217 / 3%) 1px, transparent 1px),
+          var(--paper);
+        background-size: 32px 32px;
+        font-family:
+          Inter,
+          ui-sans-serif,
+          -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
+          sans-serif;
+        font-size: 15px;
+        line-height: 1.5;
+      }
+
+      button,
+      select {
+        font: inherit;
+      }
+
+      button,
+      select,
+      [tabindex]:focus-visible {
+        outline: 3px solid rgb(49 85 217 / 28%);
+        outline-offset: 2px;
+      }
+
+      .shell {
+        width: min(1500px, calc(100% - 40px));
+        margin: 0 auto;
+        padding: 40px 0 64px;
+      }
+
+      .masthead {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) auto;
+        gap: 32px;
+        align-items: end;
+        padding: 8px 0 30px;
+        border-bottom: 2px solid var(--ink);
+      }
+
+      .eyebrow {
+        margin: 0 0 8px;
+        color: var(--cobalt);
+        font:
+          750 12px/1.2 ui-monospace,
+          SFMono-Regular,
+          Consolas,
+          monospace;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+      }
+
+      h1 {
+        max-width: 880px;
+        margin: 0;
+        font:
+          680 clamp(34px, 5vw, 68px)/0.98 Georgia,
+          serif;
+        letter-spacing: -0.04em;
+      }
+
+      .lede {
+        max-width: 760px;
+        margin: 18px 0 0;
+        color: #44506a;
+        font-size: 17px;
+      }
+
+      .status-stamp {
+        min-width: 190px;
+        padding: 16px 18px;
+        border: 1px solid var(--ink);
+        background: var(--sheet);
+        box-shadow: 6px 6px 0 var(--ink);
+      }
+
+      .status-stamp strong {
+        display: block;
+        font:
+          700 26px/1.1 Georgia,
+          serif;
+      }
+      .status-stamp span {
+        display: block;
+        margin-top: 5px;
+        color: var(--muted);
+        font-size: 12px;
+      }
+
+      .toolbar {
+        position: sticky;
+        z-index: 5;
+        top: 0;
+        display: grid;
+        grid-template-columns: repeat(4, minmax(130px, 1fr)) auto;
+        gap: 12px;
+        align-items: end;
+        margin: 24px 0;
+        padding: 14px;
+        border: 1px solid var(--line-strong);
+        border-radius: 14px;
+        background: rgb(251 250 246 / 94%);
+        box-shadow: 0 8px 28px rgb(20 33 61 / 8%);
+        backdrop-filter: blur(14px);
+      }
+
+      .field label {
+        display: block;
+        margin-bottom: 5px;
+        color: var(--muted);
+        font:
+          700 10px/1.2 ui-monospace,
+          monospace;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+
+      select {
+        width: 100%;
+        height: 38px;
+        padding: 0 34px 0 10px;
+        border: 1px solid var(--line-strong);
+        border-radius: 8px;
+        color: var(--ink);
+        background: white;
+      }
+
+      .reset {
+        height: 38px;
+        padding: 0 15px;
+        border: 1px solid var(--ink);
+        border-radius: 8px;
+        color: var(--ink);
+        background: transparent;
+        cursor: pointer;
+      }
+
+      .reset:hover {
+        color: white;
+        background: var(--ink);
+      }
+
+      .stat-grid {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 14px;
+        margin: 0 0 24px;
+      }
+
+      .stat {
+        position: relative;
+        min-height: 128px;
+        padding: 18px;
+        overflow: hidden;
+        border: 1px solid var(--line);
+        border-radius: var(--radius);
+        background: var(--sheet);
+      }
+
+      .stat::after {
+        position: absolute;
+        right: -18px;
+        bottom: -36px;
+        width: 92px;
+        height: 92px;
+        border: 18px solid rgb(49 85 217 / 7%);
+        border-radius: 50%;
+        content: "";
+      }
+      .stat-label {
+        color: var(--muted);
+        font:
+          700 11px/1.2 ui-monospace,
+          monospace;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+      }
+      .stat-value {
+        display: block;
+        margin-top: 12px;
+        font:
+          700 40px/1 Georgia,
+          serif;
+      }
+      .stat-note {
+        display: block;
+        margin-top: 8px;
+        color: var(--muted);
+        font-size: 12px;
+      }
+
+      .panel {
+        margin-top: 16px;
+        border: 1px solid var(--line-strong);
+        border-radius: var(--radius);
+        background: var(--sheet);
+        box-shadow: var(--shadow);
+      }
+      .panel-head {
+        display: flex;
+        gap: 24px;
+        justify-content: space-between;
+        align-items: start;
+        padding: 22px 24px 18px;
+        border-bottom: 1px solid var(--line);
+      }
+      .panel-head h2 {
+        margin: 0;
+        font:
+          680 25px/1.1 Georgia,
+          serif;
+        letter-spacing: -0.02em;
+      }
+      .panel-head p {
+        max-width: 680px;
+        margin: 7px 0 0;
+        color: var(--muted);
+        font-size: 13px;
+      }
+      .panel-tag {
+        flex: none;
+        padding: 5px 9px;
+        border: 1px solid var(--line-strong);
+        border-radius: 999px;
+        color: var(--muted);
+        font:
+          700 10px/1.2 ui-monospace,
+          monospace;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+      }
+      .panel-tools {
+        display: grid;
+        flex: none;
+        gap: 9px;
+        justify-items: end;
+      }
+      .scale-toggle {
+        display: inline-flex;
+        padding: 3px;
+        border: 1px solid var(--line-strong);
+        border-radius: 10px;
+        background: white;
+      }
+      .scale-button {
+        min-height: 31px;
+        padding: 0 11px;
+        border: 0;
+        border-radius: 7px;
+        color: var(--muted);
+        background: transparent;
+        font:
+          700 11px/1 ui-monospace,
+          monospace;
+        cursor: pointer;
+      }
+      .scale-button:hover {
+        color: var(--ink);
+        background: rgb(49 85 217 / 6%);
+      }
+      .scale-button[aria-pressed="true"] {
+        color: white;
+        background: var(--ink);
+      }
+
+      .chart-wrap {
+        overflow-x: auto;
+        padding: 18px 20px 10px;
+      }
+      .chart-wrap svg {
+        display: block;
+        max-width: none;
+        overflow: visible;
+      }
+      .lane-label {
+        fill: var(--ink);
+        font:
+          700 11px ui-monospace,
+          monospace;
+      }
+      .axis-label {
+        fill: var(--muted);
+        font:
+          10px ui-monospace,
+          monospace;
+      }
+      .grid-line {
+        stroke: var(--line);
+        stroke-width: 1;
+      }
+      .score-line {
+        fill: none;
+        stroke-width: 2.25;
+        stroke-linejoin: round;
+        stroke-linecap: round;
+      }
+      .score-dot {
+        cursor: pointer;
+        stroke: var(--sheet);
+        stroke-width: 2.5;
+        transition: r 120ms ease;
+      }
+      .score-dot:hover,
+      .score-dot:focus {
+        r: 6.5;
+      }
+      .release-line {
+        stroke: var(--coral);
+        stroke-width: 1.5;
+        stroke-dasharray: 3 4;
+      }
+      .prompt-line {
+        stroke: var(--cobalt);
+        stroke-width: 1;
+        stroke-dasharray: 1 5;
+        opacity: 0.65;
+      }
+      .marker-label {
+        fill: var(--coral);
+        font:
+          700 9px ui-monospace,
+          monospace;
+      }
+
+      .legend {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px 18px;
+        padding: 0 24px 20px;
+        color: var(--muted);
+        font-size: 12px;
+      }
+      .legend span {
+        display: inline-flex;
+        gap: 7px;
+        align-items: center;
+      }
+      .swatch {
+        width: 17px;
+        height: 3px;
+        border-radius: 9px;
+        background: var(--swatch);
+      }
+      .swatch.release {
+        height: 12px;
+        width: 1px;
+        border-left: 2px dashed var(--coral);
+      }
+      .swatch.prompt {
+        height: 12px;
+        width: 1px;
+        border-left: 2px dotted var(--cobalt);
+      }
+
+      .dimension-grid {
+        display: grid;
+        grid-template-columns: repeat(7, minmax(150px, 1fr));
+        gap: 10px;
+        padding: 18px 20px 22px;
+        overflow-x: auto;
+      }
+      .dimension {
+        min-width: 150px;
+        padding: 14px;
+        border-top: 4px solid var(--accent);
+        background: #fff;
+      }
+      .dimension strong {
+        display: block;
+        font:
+          700 27px/1 Georgia,
+          serif;
+      }
+      .dimension span {
+        display: block;
+        min-height: 32px;
+        margin-top: 5px;
+        font-size: 12px;
+        font-weight: 700;
+      }
+      .dimension small {
+        display: block;
+        margin-top: 7px;
+        color: var(--muted);
+        line-height: 1.35;
+      }
+
+      .table-wrap {
+        overflow-x: auto;
+      }
+      table {
+        width: 100%;
+        min-width: 930px;
+        border-collapse: collapse;
+      }
+      th,
+      td {
+        padding: 13px 16px;
+        border-bottom: 1px solid var(--line);
+        text-align: left;
+        vertical-align: middle;
+      }
+      th {
+        color: var(--muted);
+        font:
+          700 10px/1.2 ui-monospace,
+          monospace;
+        letter-spacing: 0.07em;
+        text-transform: uppercase;
+      }
+      tbody tr {
+        cursor: pointer;
+        transition: background 100ms ease;
+      }
+      tbody tr:hover {
+        background: rgb(49 85 217 / 4%);
+      }
+      tbody tr:focus {
+        background: rgb(49 85 217 / 7%);
+        outline-offset: -3px;
+      }
+      .run-title {
+        max-width: 330px;
+        font-weight: 700;
+      }
+      .run-meta {
+        display: block;
+        margin-top: 3px;
+        color: var(--muted);
+        font:
+          11px ui-monospace,
+          monospace;
+      }
+      .score-pill {
+        display: inline-block;
+        min-width: 35px;
+        padding: 3px 7px;
+        border-radius: 999px;
+        text-align: center;
+        font:
+          750 12px ui-monospace,
+          monospace;
+      }
+      .score-good {
+        color: #285944;
+        background: #dcece4;
+      }
+      .score-mid {
+        color: #725716;
+        background: #f5eacb;
+      }
+      .score-low {
+        color: #8b3d30;
+        background: #f6ddd7;
+      }
+      .score-na {
+        color: var(--muted);
+        background: #e8e9e5;
+      }
+      .version {
+        white-space: nowrap;
+        font:
+          11px ui-monospace,
+          monospace;
+      }
+
+      .empty {
+        padding: 48px 24px;
+        color: var(--muted);
+        text-align: center;
+      }
+      .empty strong {
+        display: block;
+        margin-bottom: 6px;
+        color: var(--ink);
+        font:
+          680 22px Georgia,
+          serif;
+      }
+
+      .foot {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: 24px;
+        margin-top: 28px;
+        padding-top: 18px;
+        border-top: 1px solid var(--line-strong);
+        color: var(--muted);
+        font-size: 12px;
+      }
+      .foot code {
+        color: var(--ink);
+        font-family: ui-monospace, monospace;
+      }
+
+      dialog {
+        width: min(820px, calc(100% - 32px));
+        max-height: calc(100vh - 40px);
+        padding: 0;
+        overflow: hidden;
+        border: 1px solid var(--ink);
+        border-radius: 18px;
+        color: var(--ink);
+        background: var(--sheet);
+        box-shadow: 0 30px 90px rgb(20 33 61 / 28%);
+      }
+      dialog::backdrop {
+        background: rgb(20 33 61 / 45%);
+        backdrop-filter: blur(3px);
+      }
+      .dialog-head {
+        position: sticky;
+        top: 0;
+        z-index: 1;
+        display: flex;
+        justify-content: space-between;
+        align-items: start;
+        gap: 20px;
+        padding: 22px 24px;
+        border-bottom: 1px solid var(--line);
+        background: var(--sheet);
+      }
+      .dialog-head h2 {
+        margin: 0;
+        font:
+          680 28px/1.1 Georgia,
+          serif;
+      }
+      .dialog-head p {
+        margin: 7px 0 0;
+        color: var(--muted);
+        font:
+          11px ui-monospace,
+          monospace;
+      }
+      .close {
+        flex: none;
+        width: 36px;
+        height: 36px;
+        border: 1px solid var(--line-strong);
+        border-radius: 50%;
+        color: var(--ink);
+        background: white;
+        cursor: pointer;
+      }
+      .dialog-body {
+        max-height: calc(100vh - 150px);
+        padding: 22px 24px 30px;
+        overflow-y: auto;
+      }
+      .detail-scores {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 9px;
+      }
+      .detail-score {
+        padding: 11px;
+        border: 1px solid var(--line);
+        border-radius: 10px;
+      }
+      .detail-score strong {
+        display: block;
+        font:
+          700 23px Georgia,
+          serif;
+      }
+      .detail-score span {
+        display: block;
+        margin-top: 3px;
+        font-size: 11px;
+        font-weight: 700;
+      }
+      .detail-score p {
+        margin: 8px 0 0;
+        color: var(--muted);
+        font-size: 12px;
+      }
+      .detail-section {
+        margin-top: 24px;
+      }
+      .detail-section h3 {
+        margin: 0 0 10px;
+        font:
+          680 19px Georgia,
+          serif;
+      }
+      .detail-section ul {
+        margin: 0;
+        padding-left: 20px;
+      }
+      .finding-card {
+        margin-top: 10px;
+        padding: 14px;
+        border: 1px solid var(--line);
+        border-left: 4px solid var(--coral);
+        border-radius: 8px;
+        background: white;
+      }
+      .finding-card h4 {
+        margin: 0;
+        font-size: 14px;
+      }
+      .finding-card p {
+        margin: 8px 0 0;
+        color: #4d5870;
+        font-size: 13px;
+      }
+      .finding-metrics {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        margin-top: 10px;
+      }
+
+      @media (max-width: 960px) {
+        .masthead {
+          grid-template-columns: 1fr;
+        }
+        .status-stamp {
+          width: max-content;
+        }
+        .toolbar {
+          position: static;
+          grid-template-columns: repeat(2, 1fr);
+        }
+        .stat-grid {
+          grid-template-columns: repeat(2, 1fr);
+        }
+        .detail-scores {
+          grid-template-columns: repeat(2, 1fr);
+        }
+      }
+
+      @media (max-width: 560px) {
+        .shell {
+          width: min(100% - 22px, 1500px);
+          padding-top: 22px;
+        }
+        .toolbar,
+        .stat-grid {
+          grid-template-columns: 1fr;
+        }
+        .panel-head {
+          display: block;
+        }
+        .panel-tag {
+          display: inline-block;
+          margin-top: 12px;
+        }
+        .panel-tools {
+          justify-items: start;
+          margin-top: 14px;
+        }
+        .panel-tools .panel-tag {
+          margin-top: 0;
+        }
+        .foot {
+          grid-template-columns: 1fr;
+        }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        html {
+          scroll-behavior: auto;
+        }
+        *,
+        *::before,
+        *::after {
+          transition-duration: 0.01ms !important;
+        }
+      }
+
+      @media print {
+        body {
+          background: white;
+        }
+        .shell {
+          width: 100%;
+          padding: 0;
+        }
+        .toolbar,
+        .close {
+          display: none;
+        }
+        .panel,
+        .stat {
+          break-inside: avoid;
+          box-shadow: none;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="shell">
+      <header class="masthead">
+        <div>
+          <p class="eyebrow">ReviewPhin / quality telemetry</p>
+          <h1>Are review comments getting better?</h1>
+          <p class="lede" id="lede">
+            An evidence-relative benchmark of reviewer output over time.
+          </p>
+        </div>
+        <div class="status-stamp" aria-label="Benchmark coverage">
+          <strong id="coverage">—</strong>
+          <span id="coverage-note">scored runs</span>
+        </div>
+      </header>
+
+      <section class="toolbar" aria-label="Report filters">
+        <div class="field">
+          <label for="tenant-filter">Tenant</label
+          ><select id="tenant-filter"></select>
+        </div>
+        <div class="field">
+          <label for="mode-filter">Prompt mode</label
+          ><select id="mode-filter"></select>
+        </div>
+        <div class="field">
+          <label for="model-filter">Review model</label
+          ><select id="model-filter"></select>
+        </div>
+        <div class="field">
+          <label for="prompt-filter">Prompt fingerprint</label
+          ><select id="prompt-filter"></select>
+        </div>
+        <button class="reset" id="reset-filters" type="button">
+          Reset filters
+        </button>
+      </section>
+
+      <section
+        class="stat-grid"
+        id="stats"
+        aria-label="Benchmark summary"
+      ></section>
+
+      <section class="panel" aria-labelledby="timeline-heading">
+        <div class="panel-head">
+          <div>
+            <h2 id="timeline-heading">Quality lanes</h2>
+            <p>
+              Each dot is one completed review run. Gaps mean a category was not
+              applicable, not a zero. Select a dot to inspect its
+              evidence-relative score.
+            </p>
+          </div>
+          <div class="panel-tools">
+            <span class="panel-tag" id="scale-readout">Full scale · 0–10</span>
+            <div
+              class="scale-toggle"
+              role="group"
+              aria-label="Chart score range"
+            >
+              <button
+                class="scale-button"
+                type="button"
+                data-scale="fixed"
+                aria-pressed="true"
+              >
+                Full 0–10
+              </button>
+              <button
+                class="scale-button"
+                type="button"
+                data-scale="fitted"
+                aria-pressed="false"
+              >
+                Fit visible
+              </button>
+            </div>
+          </div>
+        </div>
+        <div class="chart-wrap" id="timeline"></div>
+        <div class="legend" id="legend"></div>
+      </section>
+
+      <section class="panel" aria-labelledby="dimensions-heading">
+        <div class="panel-head">
+          <div>
+            <h2 id="dimensions-heading">Period profile</h2>
+            <p>
+              Mean scores for the current filter. Importance and targeting
+              exclude runs without findings.
+            </p>
+          </div>
+          <span class="panel-tag" id="profile-count">— runs</span>
+        </div>
+        <div class="dimension-grid" id="dimensions"></div>
+      </section>
+
+      <section class="panel" aria-labelledby="ledger-heading">
+        <div class="panel-head">
+          <div>
+            <h2 id="ledger-heading">Run ledger</h2>
+            <p>
+              Open a run for score reasons, strengths, weaknesses, and
+              per-finding targeting checks.
+            </p>
+          </div>
+          <span class="panel-tag" id="ledger-count">— visible</span>
+        </div>
+        <div class="table-wrap" id="ledger"></div>
+      </section>
+
+      <footer class="foot">
+        <span id="generated"></span>
+        <span
+          >Evaluator <code id="evaluator"></code> · Judge
+          <code id="judge"></code
+        ></span>
+      </footer>
+    </main>
+
+    <dialog id="run-dialog" aria-labelledby="dialog-title">
+      <div class="dialog-head">
+        <div>
+          <h2 id="dialog-title"></h2>
+          <p id="dialog-meta"></p>
+        </div>
+        <button
+          class="close"
+          id="dialog-close"
+          type="button"
+          aria-label="Close run details"
+        >
+          ×
+        </button>
+      </div>
+      <div class="dialog-body" id="dialog-body"></div>
+    </dialog>
+
+    <script id="benchmark-data" type="application/json">
+      __REVIEW_BENCHMARK_DATA__
+    </script>
+    <script>
+      (() => {
+        "use strict";
+        const data = JSON.parse(
+          document.getElementById("benchmark-data").textContent,
+        );
+        const dimensions = data.dimensions || [];
+        const allRuns = [...(data.runs || [])].sort(
+          (a, b) => new Date(a.startedAt) - new Date(b.startedAt),
+        );
+        const state = {
+          tenantKey: "",
+          promptMode: "",
+          reviewModel: "",
+          promptFingerprint: "",
+        };
+        let scaleMode = "fixed";
+        const selectors = {
+          tenantKey: document.getElementById("tenant-filter"),
+          promptMode: document.getElementById("mode-filter"),
+          reviewModel: document.getElementById("model-filter"),
+          promptFingerprint: document.getElementById("prompt-filter"),
+        };
+        const fmtDate = new Intl.DateTimeFormat(undefined, {
+          dateStyle: "medium",
+          timeStyle: "short",
+        });
+        const fmtDay = new Intl.DateTimeFormat(undefined, {
+          month: "short",
+          day: "numeric",
+        });
+        const escapeHtml = (value) =>
+          String(value ?? "").replace(
+            /[&<>"']/g,
+            (character) =>
+              ({
+                "&": "&amp;",
+                "<": "&lt;",
+                ">": "&gt;",
+                '"': "&quot;",
+                "'": "&#39;",
+              })[character],
+          );
+        const scoreValue = (run, key) => run.categories?.[key]?.score ?? null;
+        const scoreClass = (value) =>
+          value == null
+            ? "score-na"
+            : value >= 8
+              ? "score-good"
+              : value >= 5
+                ? "score-mid"
+                : "score-low";
+        const shortHash = (value) =>
+          value ? String(value).slice(0, 8) : "unknown";
+        const mean = (values) => {
+          const numeric = values.filter(Number.isFinite);
+          return numeric.length
+            ? numeric.reduce((sum, value) => sum + value, 0) / numeric.length
+            : null;
+        };
+        const averageRunScore = (run) =>
+          mean(dimensions.map((dimension) => scoreValue(run, dimension.key)));
+        const visibleRuns = () =>
+          allRuns.filter((run) =>
+            Object.entries(state).every(
+              ([key, value]) => !value || String(run[key] ?? "") === value,
+            ),
+          );
+
+        function optionLabel(key, value) {
+          if (key === "promptFingerprint") return shortHash(value);
+          return value || "Unknown";
+        }
+
+        function populateFilters() {
+          for (const [key, select] of Object.entries(selectors)) {
+            const values = [
+              ...new Set(
+                allRuns
+                  .map((run) => run[key])
+                  .filter((value) => value != null && value !== ""),
+              ),
+            ].sort();
+            select.innerHTML = `<option value="">All</option>${values.map((value) => `<option value="${escapeHtml(value)}">${escapeHtml(optionLabel(key, value))}</option>`).join("")}`;
+            select.addEventListener("change", () => {
+              state[key] = select.value;
+              render();
+            });
+          }
+          document
+            .getElementById("reset-filters")
+            .addEventListener("click", () => {
+              Object.keys(state).forEach((key) => {
+                state[key] = "";
+                selectors[key].value = "";
+              });
+              render();
+            });
+        }
+
+        function populateScaleToggle() {
+          document.querySelectorAll("[data-scale]").forEach((button) => {
+            button.addEventListener("click", () => {
+              scaleMode = button.dataset.scale;
+              document
+                .querySelectorAll("[data-scale]")
+                .forEach((candidate) =>
+                  candidate.setAttribute(
+                    "aria-pressed",
+                    String(candidate === button),
+                  ),
+                );
+              render();
+            });
+          });
+        }
+
+        function resolveScaleDomain(runs) {
+          if (scaleMode === "fixed") return { min: 0, max: 10 };
+          const scores = runs.flatMap((run) =>
+            dimensions
+              .map((dimension) => scoreValue(run, dimension.key))
+              .filter(Number.isFinite),
+          );
+          if (!scores.length) return { min: 0, max: 10 };
+          let min = Math.max(0, Math.floor(Math.min(...scores)));
+          let max = Math.min(10, Math.ceil(Math.max(...scores)));
+          if (min === max) {
+            min = Math.max(0, min - 1);
+            max = Math.min(10, max + 1);
+          } else if (max - min < 2) {
+            if (min > 0) min -= 1;
+            else max = Math.min(10, max + 1);
+          }
+          return { min, max };
+        }
+
+        function renderMetadata() {
+          const metadata = data.metadata;
+          const range = metadata.range;
+          document.getElementById("lede").textContent =
+            `${range.fromInput} through ${range.toInput} · ${metadata.modes.join(", ")} · UTC selection window`;
+          document.getElementById("coverage").textContent =
+            `${metadata.scoredCount}/${metadata.selectedCount}`;
+          document.getElementById("coverage-note").textContent =
+            metadata.missingCount
+              ? `scored runs · ${metadata.missingCount} awaiting assessment`
+              : "selected runs scored";
+          document.getElementById("generated").textContent =
+            `Generated ${fmtDate.format(new Date(metadata.generatedAt))} · ${metadata.cacheReuseCount} reused from cache · ${metadata.newlyAssessedCount} newly assessed`;
+          document.getElementById("evaluator").textContent = shortHash(
+            metadata.evaluatorVersion,
+          );
+          document.getElementById("judge").textContent = metadata.judgeModel;
+        }
+
+        function renderStats(runs) {
+          const overall = mean(runs.map(averageRunScore));
+          const versions = [
+            ...new Set(
+              runs.map((run) => run.reviewPhinVersion).filter(Boolean),
+            ),
+          ];
+          const prompts = new Set(
+            runs.map((run) => run.promptFingerprint).filter(Boolean),
+          );
+          const findingCount = runs.reduce(
+            (sum, run) => sum + (run.findingCount || 0),
+            0,
+          );
+          const stats = [
+            [
+              overall == null ? "—" : overall.toFixed(1),
+              "Mean quality",
+              `${dimensions.length} evidence-relative dimensions`,
+            ],
+            [
+              String(runs.length),
+              "Runs visible",
+              `${findingCount} emitted findings`,
+            ],
+            [
+              String(prompts.size),
+              "Prompt eras",
+              "Distinct reviewer prompt fingerprints",
+            ],
+            [
+              versions.length ? versions.length : "—",
+              "App versions",
+              versions.length
+                ? versions.join(" · ")
+                : "Not recorded in these runs",
+            ],
+          ];
+          document.getElementById("stats").innerHTML = stats
+            .map(
+              ([value, label, note]) =>
+                `<article class="stat"><span class="stat-label">${escapeHtml(label)}</span><strong class="stat-value">${escapeHtml(value)}</strong><span class="stat-note">${escapeHtml(note)}</span></article>`,
+            )
+            .join("");
+        }
+
+        function versionMarkers(runs) {
+          const markers = [];
+          let previous = null;
+          for (const run of runs) {
+            const version = run.reviewPhinVersion;
+            if (!version) continue;
+            if (version !== previous) markers.push({ run, version });
+            previous = version;
+          }
+          return markers;
+        }
+
+        function promptMarkers(runs) {
+          const markers = [];
+          let previous = null;
+          for (const run of runs) {
+            const fingerprint = run.promptFingerprint;
+            if (!fingerprint) continue;
+            if (previous && fingerprint !== previous)
+              markers.push({ run, fingerprint });
+            previous = fingerprint;
+          }
+          return markers;
+        }
+
+        function renderTimeline(runs) {
+          const host = document.getElementById("timeline");
+          const scale = resolveScaleDomain(runs);
+          document.getElementById("scale-readout").textContent =
+            `${scaleMode === "fixed" ? "Full scale" : "Fit visible"} · ${scale.min}–${scale.max}`;
+          if (!runs.length) {
+            host.innerHTML = `<div class="empty"><strong>No scored runs match these filters.</strong>Reset one or more filters to restore the timeline.</div>`;
+            document.getElementById("legend").innerHTML = "";
+            return;
+          }
+          const width = Math.max(
+            920,
+            host.clientWidth - 40,
+            runs.length * 45 + 210,
+          );
+          const left = 132,
+            right = 30,
+            top = 42,
+            laneHeight = 72,
+            bottom = 38;
+          const height = top + dimensions.length * laneHeight + bottom;
+          const timestamps = runs.map((run) =>
+            new Date(run.startedAt).getTime(),
+          );
+          let minTime = Math.min(...timestamps),
+            maxTime = Math.max(...timestamps);
+          if (minTime === maxTime) {
+            minTime -= 1;
+            maxTime += 1;
+          }
+          const x = (run) =>
+            left +
+            ((new Date(run.startedAt).getTime() - minTime) /
+              (maxTime - minTime)) *
+              (width - left - right);
+          const y = (lane, score) =>
+            top +
+            lane * laneHeight +
+            53 -
+            ((score - scale.min) / (scale.max - scale.min)) * 38;
+          const parts = [
+            `<svg viewBox="0 0 ${width} ${height}" width="${width}" height="${height}" role="img" aria-labelledby="chart-title chart-desc"><title id="chart-title">Review quality scores over time</title><desc id="chart-desc">Seven horizontal score lanes from ${scale.min} to ${scale.max}, with application release and prompt-change markers.</desc>`,
+          ];
+          dimensions.forEach((dimension, lane) => {
+            const topY = y(lane, scale.max),
+              middleY = y(lane, (scale.min + scale.max) / 2),
+              bottomY = y(lane, scale.min);
+            parts.push(
+              `<text class="lane-label" x="0" y="${middleY + 4}">${escapeHtml(dimension.shortLabel)}</text>`,
+            );
+            [topY, middleY, bottomY].forEach((lineY) =>
+              parts.push(
+                `<line class="grid-line" x1="${left}" x2="${width - right}" y1="${lineY}" y2="${lineY}"/>`,
+              ),
+            );
+            parts.push(
+              `<text class="axis-label" x="${left - 9}" y="${topY + 3}" text-anchor="end">${scale.max}</text><text class="axis-label" x="${left - 9}" y="${bottomY + 3}" text-anchor="end">${scale.min}</text>`,
+            );
+          });
+          for (const marker of promptMarkers(runs)) {
+            const markerX = x(marker.run);
+            parts.push(
+              `<line class="prompt-line" x1="${markerX}" x2="${markerX}" y1="${top}" y2="${height - bottom}"/>`,
+            );
+          }
+          for (const marker of versionMarkers(runs)) {
+            const markerX = x(marker.run);
+            parts.push(
+              `<line class="release-line" x1="${markerX}" x2="${markerX}" y1="24" y2="${height - bottom}"/><text class="marker-label" x="${Math.min(markerX + 4, width - 70)}" y="18">v${escapeHtml(marker.version)}</text>`,
+            );
+          }
+          dimensions.forEach((dimension, lane) => {
+            let segment = [];
+            const flush = () => {
+              if (segment.length > 1)
+                parts.push(
+                  `<path class="score-line" stroke="${dimension.color}" d="${segment.map((point, index) => `${index ? "L" : "M"}${point[0].toFixed(1)},${point[1].toFixed(1)}`).join(" ")}"/>`,
+                );
+              segment = [];
+            };
+            runs.forEach((run) => {
+              const score = scoreValue(run, dimension.key);
+              if (score == null) {
+                flush();
+                return;
+              }
+              segment.push([x(run), y(lane, score)]);
+            });
+            flush();
+            runs.forEach((run) => {
+              const score = scoreValue(run, dimension.key);
+              if (score == null) return;
+              const label = `${dimension.label}: ${score}/10 · ${run.title} · ${fmtDate.format(new Date(run.startedAt))}`;
+              parts.push(
+                `<circle class="score-dot" data-run-id="${escapeHtml(run.runId)}" tabindex="0" role="button" aria-label="${escapeHtml(label)}" cx="${x(run).toFixed(1)}" cy="${y(lane, score).toFixed(1)}" r="4.5" fill="${dimension.color}"><title>${escapeHtml(label)}</title></circle>`,
+              );
+            });
+          });
+          const ticks = [
+            ...new Set([0, Math.floor((runs.length - 1) / 2), runs.length - 1]),
+          ];
+          ticks.forEach((index) =>
+            parts.push(
+              `<text class="axis-label" x="${x(runs[index])}" y="${height - 9}" text-anchor="middle">${escapeHtml(fmtDay.format(new Date(runs[index].startedAt)))}</text>`,
+            ),
+          );
+          parts.push("</svg>");
+          host.innerHTML = parts.join("");
+          host.querySelectorAll(".score-dot").forEach((dot) => {
+            const open = () => openRun(dot.dataset.runId);
+            dot.addEventListener("click", open);
+            dot.addEventListener("keydown", (event) => {
+              if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                open();
+              }
+            });
+          });
+          document.getElementById("legend").innerHTML =
+            `${dimensions.map((dimension) => `<span><i class="swatch" style="--swatch:${dimension.color}"></i>${escapeHtml(dimension.shortLabel)}</span>`).join("")}<span><i class="swatch release"></i>ReviewPhin release</span><span><i class="swatch prompt"></i>Prompt change</span>`;
+        }
+
+        function renderDimensions(runs) {
+          document.getElementById("profile-count").textContent =
+            `${runs.length} run${runs.length === 1 ? "" : "s"}`;
+          document.getElementById("dimensions").innerHTML = dimensions
+            .map((dimension) => {
+              const values = runs.map((run) => scoreValue(run, dimension.key));
+              const value = mean(values);
+              const count = values.filter(Number.isFinite).length;
+              return `<article class="dimension" style="--accent:${dimension.color}"><strong>${value == null ? "—" : value.toFixed(1)}</strong><span>${escapeHtml(dimension.label)}</span><small>${escapeHtml(dimension.description)}<br>${count}/${runs.length} applicable</small></article>`;
+            })
+            .join("");
+        }
+
+        function renderLedger(runs) {
+          document.getElementById("ledger-count").textContent =
+            `${runs.length} visible`;
+          const host = document.getElementById("ledger");
+          if (!runs.length) {
+            host.innerHTML = `<div class="empty"><strong>No matching runs.</strong>Change the filters above.</div>`;
+            return;
+          }
+          host.innerHTML = `<table><thead><tr><th>Run</th><th>Date</th><th>Mode</th><th>Version</th><th>Mean</th><th>Findings</th><th>Scope</th><th>Evidence</th></tr></thead><tbody>${[
+            ...runs,
+          ]
+            .reverse()
+            .map((run) => {
+              const overall = averageRunScore(run);
+              const scope = scoreValue(run, "assessmentScope"),
+                groundedness = scoreValue(run, "groundedness");
+              return `<tr tabindex="0" data-run-id="${escapeHtml(run.runId)}"><td class="run-title">${escapeHtml(run.title)}<span class="run-meta">${escapeHtml(run.runId)}</span></td><td>${escapeHtml(fmtDate.format(new Date(run.startedAt)))}</td><td>${escapeHtml(run.promptMode)}</td><td class="version">${run.reviewPhinVersion ? `v${escapeHtml(run.reviewPhinVersion)}` : "unknown"}</td><td><span class="score-pill ${scoreClass(overall)}">${overall == null ? "—" : overall.toFixed(1)}</span></td><td>${run.findingCount}</td><td><span class="score-pill ${scoreClass(scope)}">${scope ?? "—"}</span></td><td><span class="score-pill ${scoreClass(groundedness)}">${groundedness ?? "—"}</span></td></tr>`;
+            })
+            .join("")}</tbody></table>`;
+          host.querySelectorAll("tbody tr").forEach((row) => {
+            const open = () => openRun(row.dataset.runId);
+            row.addEventListener("click", open);
+            row.addEventListener("keydown", (event) => {
+              if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                open();
+              }
+            });
+          });
+        }
+
+        function openRun(runId) {
+          const run = allRuns.find((candidate) => candidate.runId === runId);
+          if (!run) return;
+          document.getElementById("dialog-title").textContent = run.title;
+          document.getElementById("dialog-meta").textContent =
+            `${run.runId} · ${fmtDate.format(new Date(run.startedAt))} · ${run.promptMode} · ${run.reviewPhinVersion ? `ReviewPhin v${run.reviewPhinVersion}` : "ReviewPhin version unknown"}`;
+          const scoreCards = dimensions
+            .map((dimension) => {
+              const category = run.categories?.[dimension.key];
+              return `<article class="detail-score" style="border-top:3px solid ${dimension.color}"><strong>${category?.score ?? "—"}</strong><span>${escapeHtml(dimension.label)}</span><p>${escapeHtml(category?.reason || "Not applicable")}</p></article>`;
+            })
+            .join("");
+          const list = (items, empty) =>
+            items?.length
+              ? `<ul>${items.map((item) => `<li>${escapeHtml(item)}</li>`).join("")}</ul>`
+              : `<p>${escapeHtml(empty)}</p>`;
+          const findingById = new Map(
+            (run.findings || []).map((finding) => [finding.id, finding]),
+          );
+          const findingCards = (run.findingAssessments || [])
+            .map((assessment) => {
+              const finding = findingById.get(assessment.findingId) || {};
+              const targeting = assessment.targeting || {};
+              return `<article class="finding-card"><h4>${escapeHtml(finding.title || assessment.findingId)}</h4><p>${escapeHtml(assessment.reason)}</p><div class="finding-metrics"><span class="score-pill ${scoreClass(assessment.importance)}">importance ${assessment.importance}</span><span class="score-pill ${scoreClass(targeting.score)}">targeting ${targeting.score}</span><span class="score-pill ${scoreClass(assessment.groundedness)}">evidence ${assessment.groundedness}</span></div><p><strong>Anchor:</strong> ${escapeHtml(targeting.anchorQuality || "Not assessed")}<br><strong>Suggestion:</strong> ${escapeHtml(targeting.suggestionQuality || "Not assessed")}</p></article>`;
+            })
+            .join("");
+          document.getElementById("dialog-body").innerHTML =
+            `<div class="detail-scores">${scoreCards}</div><section class="detail-section"><h3>Strengths</h3>${list(run.strengths, "No strengths recorded.")}</section><section class="detail-section"><h3>Weaknesses</h3>${list(run.weaknesses, "No weaknesses recorded.")}</section><section class="detail-section"><h3>Finding checks</h3>${findingCards || "<p>No findings were emitted, so importance and targeting are not applicable.</p>"}</section>`;
+          document.getElementById("run-dialog").showModal();
+        }
+
+        function render() {
+          const runs = visibleRuns();
+          renderStats(runs);
+          renderTimeline(runs);
+          renderDimensions(runs);
+          renderLedger(runs);
+        }
+
+        document
+          .getElementById("dialog-close")
+          .addEventListener("click", () =>
+            document.getElementById("run-dialog").close(),
+          );
+        document
+          .getElementById("run-dialog")
+          .addEventListener("click", (event) => {
+            if (event.target === event.currentTarget)
+              event.currentTarget.close();
+          });
+        populateFilters();
+        populateScaleToggle();
+        renderMetadata();
+        render();
+      })();
+    </script>
+  </body>
+</html>

--- a/.agents/skills/review-quality-benchmark/references/assessment-schema.json
+++ b/.agents/skills/review-quality-benchmark/references/assessment-schema.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Review quality benchmark assessment",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "runId",
+    "inputDigest",
+    "evaluatorVersion",
+    "judgeModel",
+    "categories",
+    "findings",
+    "strengths",
+    "weaknesses"
+  ],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "runId": { "type": "string", "minLength": 1 },
+    "inputDigest": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "evaluatorVersion": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+    "judgeModel": { "type": "string", "minLength": 1 },
+    "categories": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "noobFriendliness",
+        "unjargonity",
+        "readability",
+        "importance",
+        "targeting",
+        "assessmentScope",
+        "groundedness"
+      ],
+      "properties": {
+        "noobFriendliness": { "$ref": "#/$defs/score" },
+        "unjargonity": { "$ref": "#/$defs/score" },
+        "readability": { "$ref": "#/$defs/score" },
+        "importance": { "$ref": "#/$defs/nullableScore" },
+        "targeting": { "$ref": "#/$defs/nullableScore" },
+        "assessmentScope": { "$ref": "#/$defs/score" },
+        "groundedness": { "$ref": "#/$defs/score" }
+      }
+    },
+    "findings": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/findingAssessment" }
+    },
+    "strengths": {
+      "type": "array",
+      "maxItems": 5,
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "weaknesses": {
+      "type": "array",
+      "maxItems": 5,
+      "items": { "type": "string", "minLength": 1 }
+    }
+  },
+  "$defs": {
+    "score": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["score", "reason"],
+      "properties": {
+        "score": { "type": "integer", "minimum": 0, "maximum": 10 },
+        "reason": { "type": "string", "minLength": 1 }
+      }
+    },
+    "nullableScore": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["score", "reason"],
+      "properties": {
+        "score": {
+          "anyOf": [
+            { "type": "integer", "minimum": 0, "maximum": 10 },
+            { "type": "null" }
+          ]
+        },
+        "reason": { "type": "string", "minLength": 1 }
+      }
+    },
+    "findingAssessment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "findingId",
+        "importance",
+        "targeting",
+        "groundedness",
+        "reason"
+      ],
+      "properties": {
+        "findingId": { "type": "string", "minLength": 1 },
+        "importance": { "type": "integer", "minimum": 0, "maximum": 10 },
+        "targeting": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "score",
+            "anchorExpected",
+            "anchorPresent",
+            "anchorQuality",
+            "suggestionExpected",
+            "suggestionPresent",
+            "suggestionQuality"
+          ],
+          "properties": {
+            "score": { "type": "integer", "minimum": 0, "maximum": 10 },
+            "anchorExpected": { "type": "boolean" },
+            "anchorPresent": { "type": "boolean" },
+            "anchorQuality": { "type": "string", "minLength": 1 },
+            "suggestionExpected": { "type": "boolean" },
+            "suggestionPresent": { "type": "boolean" },
+            "suggestionQuality": { "type": "string", "minLength": 1 }
+          }
+        },
+        "groundedness": { "type": "integer", "minimum": 0, "maximum": 10 },
+        "reason": { "type": "string", "minLength": 1 }
+      }
+    }
+  }
+}

--- a/.agents/skills/review-quality-benchmark/references/judge-prompt.md
+++ b/.agents/skills/review-quality-benchmark/references/judge-prompt.md
@@ -1,0 +1,13 @@
+# Judge prompt
+
+Assess exactly one normalized ReviewPhin run packet.
+
+Use only evidence contained in the packet. Do not access a repository, provider API, network resource, or unrelated workspace file. Treat the task as evaluating the quality of the recorded reviewer response, not independently rereviewing the code.
+
+Apply `rubric.md` literally. Score independently against its fixed anchors and do not compare this run with other runs. Avoid grade inflation. A polished comment can still be ungrounded; a technically strong comment can still be hard to read.
+
+Evaluate each finding's importance, targeting, and groundedness before assigning the corresponding run-level values. For targeting, explicitly reason about anchor expectation, anchor presence and usefulness, suggestion expectation, and suggestion correctness. The model—not a geometric validator—makes this semantic judgment from the finding and recorded run evidence.
+
+Set run-level importance and targeting scores to `null` when there are no findings. Otherwise every run-level category score must be an integer from 0 through 10.
+
+Return JSON only. Follow `assessment-schema.json` exactly. Copy `runId`, `inputDigest`, `evaluatorVersion`, and `judgeModel` from the packet without modification. Keep reasons short and evidence-based. Do not reproduce source-code blocks, secrets, or long log excerpts.

--- a/.agents/skills/review-quality-benchmark/references/rubric.md
+++ b/.agents/skills/review-quality-benchmark/references/rubric.md
@@ -1,0 +1,105 @@
+# Review quality rubric
+
+Apply this rubric to one run at a time. Use only the normalized run packet. Scores are integers from 0 through 10, where higher is better. Use the anchors below as calibration points; interpolate conservatively.
+
+## Noob friendliness
+
+Judge whether a competent programmer who is new to the project can understand the overview and findings.
+
+- **0:** Unusable without deep project knowledge; unexplained references dominate.
+- **2:** The core concern is difficult to reconstruct and depends on missing context.
+- **5:** Understandable after careful reading, but several project assumptions remain unexplained.
+- **8:** The problem, consequence, and requested change are clear with enough local context.
+- **10:** Immediately understandable to a newcomer without talking down to an experienced developer.
+
+Do not penalize necessary code identifiers. Penalize unexplained project-specific behavior or conclusions that require the reader to infer the entire causal chain.
+
+## Unjargonity
+
+Judge whether the prose prefers concrete, simple language over abstractions and unnecessary technical or corporate jargon.
+
+- **0:** Mostly opaque abstractions, buzzwords, or compressed specialist language.
+- **2:** Frequent unexplained jargon obscures the point.
+- **5:** Mixed plain and abstract language; understandable with effort.
+- **8:** Mostly concrete language with only necessary technical terms.
+- **10:** Precise plain language throughout; every specialized term earns its place or is explained.
+
+Do not reward imprecision merely because words are simple.
+
+## Readability
+
+Judge sentence and paragraph shape, information order, scanability, and cognitive load. Use the packet's deterministic text metrics as supporting evidence, not as an automatic score.
+
+- **0:** Dense walls of text, broken structure, or extremely difficult sentences.
+- **2:** Repeated long sentences or paragraphs make the reasoning hard to follow.
+- **5:** Generally readable but with noticeable compression, repetition, or awkward organization.
+- **8:** Short purposeful paragraphs, sensible sentence lengths, and a clear reading order.
+- **10:** Exceptionally economical and effortless to scan without losing necessary detail.
+
+Prefer paragraph breaks between problem/effect and required action when both need explanation. Do not require lists when prose is clearer.
+
+## Importance
+
+Judge whether emitted findings provide material engineering value rather than minor nitpicks. Score each finding first, then derive the run score. Use `null` when the run emitted no findings.
+
+- **0:** Incorrectly elevates cosmetic preferences or irrelevant observations.
+- **2:** Mostly low-value cleanup with little practical consequence.
+- **5:** A mixture of useful concerns and minor or overstated points.
+- **8:** Findings identify consequential correctness, security, performance, or maintainability risks.
+- **10:** Every finding exposes a material, decision-relevant risk with calibrated severity and no noise.
+
+A valid low-severity defect can still be useful, but a run dominated by trivial findings should not score highly.
+
+## Targeting
+
+Judge review placement and fix assistance semantically from recorded evidence. Score each finding first, then derive the run score. Use `null` when the run emitted no findings.
+
+For every finding, decide:
+
+1. Whether an inline anchor should be available for this type of concern.
+2. Whether the anchor is present when expected, or correctly omitted for a repository-wide or omission-based concern.
+3. Whether the chosen path and range usefully locate the causal or best review location.
+4. Whether the range is tight enough without losing necessary context.
+5. Whether a safe replacement suggestion should reasonably be provided.
+6. Whether an emitted suggestion matches the anchor range and appears complete, syntactically plausible, and consistent with the requested fix.
+
+Calibration:
+
+- **0:** Misleading or invalid placement, or a dangerous replacement.
+- **2:** Anchor or suggestion is materially disconnected from the concern.
+- **5:** Usable placement but loose, incomplete, or missing an obvious safe suggestion.
+- **8:** Relevant tight placement and a sound decision about whether to suggest code.
+- **10:** Ideal review location plus an exact safe suggestion whenever one is clearly warranted.
+
+Do not demand a suggestion for broad, multi-file, design-dependent, or unsafe fixes. Do not penalize a correctly unanchored repository-wide finding.
+
+## Assessment scope
+
+Judge whether the overview represents the current state of the complete PR/MR under the run's review mode.
+
+- **0:** Describes the wrong change boundary or materially misrepresents review state.
+- **2:** Treats a small delta as the whole review or ignores known prior findings.
+- **5:** Broadly relevant but incomplete, stale, or inconsistent with parts of the run evidence.
+- **8:** Correctly synthesizes the complete review state and merge readiness for the mode.
+- **10:** Concise whole-review assessment that integrates prior state, current evidence, findings, and readiness without overclaiming.
+
+For incremental rereviews, allow finding inspection to focus on the delta, but require the overview to describe the whole current review state. Consider the changed-file manifest and recorded inspection trace; do not require every file to be opened.
+
+## Groundedness
+
+Judge whether overview and finding claims are supported by evidence recorded in the run. This is not an independent repository audit.
+
+- **0:** Central claims contradict or invent evidence.
+- **2:** Major causal or behavioral claims are unsupported by the recorded trace.
+- **5:** Core direction is plausible but important details overreach available evidence.
+- **8:** Claims are well supported and uncertainty is appropriately bounded.
+- **10:** Every material statement has a clear evidence chain and severity is calibrated precisely.
+
+Do not penalize the run merely because external repository evidence is unavailable. Penalize it when the output claims more than its own recorded evidence supports.
+
+## Aggregation
+
+- Average applicable per-finding scores to obtain run-level `importance` and `targeting`.
+- Derive run-level `groundedness` from both per-finding evidence and overview consistency.
+- Do not manufacture an overall score. Keep dimensions separate.
+- Use a concise reason for each run-level score and each finding assessment.

--- a/.agents/skills/review-quality-benchmark/scripts/benchmark.mjs
+++ b/.agents/skills/review-quality-benchmark/scripts/benchmark.mjs
@@ -783,6 +783,28 @@ function prepare(options) {
       selectedRuns.push(summary);
       (cached ? cachedRuns : pendingRuns).push(run.id);
     }
+    if (options.force === true) {
+      const invalidate = cache.prepare(
+        `DELETE FROM assessments
+         WHERE run_id = ? AND input_digest = ?
+           AND evaluator_version = ? AND judge_model = ?`,
+      );
+      cache.exec("BEGIN IMMEDIATE");
+      try {
+        for (const selected of selectedRuns) {
+          invalidate.run(
+            selected.runId,
+            selected.inputDigest,
+            identity.evaluatorVersion,
+            identity.judgeModel,
+          );
+        }
+        cache.exec("COMMIT");
+      } catch (error) {
+        cache.exec("ROLLBACK");
+        throw error;
+      }
+    }
     const manifest = {
       schemaVersion: 1,
       generatedAt: new Date().toISOString(),

--- a/.agents/skills/review-quality-benchmark/scripts/benchmark.mjs
+++ b/.agents/skills/review-quality-benchmark/scripts/benchmark.mjs
@@ -1,0 +1,1214 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import { DatabaseSync } from "node:sqlite";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const SKILL_DIR = resolve(SCRIPT_DIR, "..");
+const REFERENCE_DIR = join(SKILL_DIR, "references");
+const TEMPLATE_PATH = join(SKILL_DIR, "assets", "report-template.html");
+const REPORT_DIRECTORY_NAME = "benchmark-report";
+const DEFAULT_MODES = ["review", "first-pass-full", "incremental-rereview"];
+const CATEGORY_NAMES = [
+  "noobFriendliness",
+  "unjargonity",
+  "readability",
+  "importance",
+  "targeting",
+  "assessmentScope",
+  "groundedness",
+];
+const REPORT_DIMENSIONS = [
+  {
+    key: "noobFriendliness",
+    label: "Noob friendliness",
+    shortLabel: "Newcomer",
+    color: "#3155d9",
+    description: "Can a programmer new to the project understand the review?",
+  },
+  {
+    key: "unjargonity",
+    label: "Unjargonity",
+    shortLabel: "Plain language",
+    color: "#7a55c5",
+    description: "Does the response prefer precise simple language?",
+  },
+  {
+    key: "readability",
+    label: "Readability",
+    shortLabel: "Readability",
+    color: "#b34872",
+    description:
+      "Are sentences, paragraphs, and information order easy to scan?",
+  },
+  {
+    key: "importance",
+    label: "Importance",
+    shortLabel: "Importance",
+    color: "#d16d3f",
+    description: "Do emitted findings provide material engineering value?",
+  },
+  {
+    key: "targeting",
+    label: "Targeting",
+    shortLabel: "Targeting",
+    color: "#b7891d",
+    description: "Are anchors and replacement suggestions chosen well?",
+  },
+  {
+    key: "assessmentScope",
+    label: "Assessment scope",
+    shortLabel: "Whole review",
+    color: "#3d8266",
+    description: "Does the overview represent the complete current PR or MR?",
+  },
+  {
+    key: "groundedness",
+    label: "Groundedness",
+    shortLabel: "Evidence",
+    color: "#177b8f",
+    description: "Are claims supported by evidence recorded in the run?",
+  },
+];
+
+function printHelp() {
+  process.stdout.write(`Review quality benchmark\n\n`);
+  process.stdout.write(`Commands:\n`);
+  process.stdout.write(
+    `  prepare --from <date> --to <date> [--db <path>] [--logs <path>] [--workspace <path>] [--modes <csv>] [--judge-model <id>] [--force]\n`,
+  );
+  process.stdout.write(
+    `  store --file <assessment.json> [--workspace <path>]\n`,
+  );
+  process.stdout.write(
+    `  render [--workspace <path>] [--output-name <file.html>]\n`,
+  );
+  process.stdout.write(`  help\n\n`);
+  process.stdout.write(`Defaults:\n`);
+  process.stdout.write(`  database: data/review-worker.sqlite\n`);
+  process.stdout.write(`  logs: data/run-logs\n`);
+  process.stdout.write(`  workspace: current directory\n`);
+  process.stdout.write(`  modes: ${DEFAULT_MODES.join(",")}\n`);
+  process.stdout.write(`  generated state: benchmark-report/\n`);
+}
+
+function parseArguments(argv) {
+  const [command = "help", ...tokens] = argv;
+  const options = {};
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (!token.startsWith("--")) {
+      throw new Error(`Unexpected argument: ${token}`);
+    }
+    const key = token.slice(2);
+    const next = tokens[index + 1];
+    if (!next || next.startsWith("--")) {
+      options[key] = true;
+      continue;
+    }
+    options[key] = next;
+    index += 1;
+  }
+  return { command, options };
+}
+
+function requireString(options, key) {
+  const value = options[key];
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`Missing required --${key} value.`);
+  }
+  return value.trim();
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function canonicalStringify(value) {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => canonicalStringify(entry)).join(",")}]`;
+  }
+  const keys = Object.keys(value).sort();
+  return `{${keys
+    .map((key) => `${JSON.stringify(key)}:${canonicalStringify(value[key])}`)
+    .join(",")}}`;
+}
+
+function readUtf8(path) {
+  return readFileSync(path, "utf8");
+}
+
+function readJson(path) {
+  return JSON.parse(readUtf8(path));
+}
+
+function parseJson(value, fallback) {
+  if (typeof value !== "string" || value.trim() === "") return fallback;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return fallback;
+  }
+}
+
+function readReviewPhinVersion(runDirectory) {
+  const appLogPath = join(runDirectory, "app.ndjson");
+  if (!existsSync(appLogPath)) return null;
+  try {
+    for (const line of readUtf8(appLogPath).split(/\r?\n/u)) {
+      if (line.trim() === "") continue;
+      const entry = parseJson(line, null);
+      const value = entry?.data?.reviewPhinVersion;
+      if (typeof value === "string" && value.trim() !== "") {
+        return value.trim();
+      }
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function ensureDirectory(path) {
+  mkdirSync(path, { recursive: true });
+}
+
+function atomicWrite(path, contents) {
+  ensureDirectory(dirname(path));
+  const temporaryPath = `${path}.tmp-${process.pid}`;
+  writeFileSync(temporaryPath, contents, "utf8");
+  renameSync(temporaryPath, path);
+}
+
+function assertInside(parent, child) {
+  const resolvedParent = resolve(parent);
+  const resolvedChild = resolve(child);
+  if (
+    resolvedChild !== resolvedParent &&
+    !resolvedChild.startsWith(`${resolvedParent}${sep}`)
+  ) {
+    throw new Error(
+      `Refusing to operate outside ${resolvedParent}: ${resolvedChild}`,
+    );
+  }
+}
+
+function replaceDirectory(parent, path) {
+  assertInside(parent, path);
+  rmSync(path, { recursive: true, force: true });
+  ensureDirectory(path);
+}
+
+function resolveWorkspace(options) {
+  return resolve(
+    typeof options.workspace === "string" ? options.workspace : process.cwd(),
+  );
+}
+
+function workspacePaths(options) {
+  const workspace = resolveWorkspace(options);
+  const reportRoot = join(workspace, REPORT_DIRECTORY_NAME);
+  return {
+    workspace,
+    reportRoot,
+    cachePath: join(reportRoot, "cache.sqlite"),
+    manifestPath: join(reportRoot, "tmp", "manifest.json"),
+    packetsDirectory: join(reportRoot, "tmp", "packets"),
+    assessmentsDirectory: join(reportRoot, "tmp", "assessments"),
+    reportsDirectory: join(reportRoot, "reports"),
+  };
+}
+
+function parseRangeBoundary(value, isEnd) {
+  const dateOnly = /^\d{4}-\d{2}-\d{2}$/u.test(value);
+  const parsed = new Date(dateOnly ? `${value}T00:00:00.000Z` : value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`Invalid ISO date: ${value}`);
+  }
+  if (!isEnd) return parsed.toISOString();
+  const increment = dateOnly ? 24 * 60 * 60 * 1000 : 1;
+  return new Date(parsed.getTime() + increment).toISOString();
+}
+
+function rangeSlug(value) {
+  return value.replace(/[^0-9A-Za-z_-]+/gu, "-").replace(/-+$/u, "");
+}
+
+function openCache(path) {
+  ensureDirectory(dirname(path));
+  const database = new DatabaseSync(path);
+  database.exec(`
+    PRAGMA journal_mode = WAL;
+    CREATE TABLE IF NOT EXISTS assessments (
+      run_id TEXT NOT NULL,
+      input_digest TEXT NOT NULL,
+      evaluator_version TEXT NOT NULL,
+      judge_model TEXT NOT NULL,
+      assessed_at TEXT NOT NULL,
+      assessment_json TEXT NOT NULL,
+      PRIMARY KEY (run_id, input_digest, evaluator_version, judge_model)
+    );
+    CREATE INDEX IF NOT EXISTS assessments_run_id_idx
+      ON assessments (run_id);
+  `);
+  return database;
+}
+
+function evaluatorVersion() {
+  const resources = [
+    readUtf8(join(REFERENCE_DIR, "rubric.md")),
+    readUtf8(join(REFERENCE_DIR, "judge-prompt.md")),
+    readUtf8(join(REFERENCE_DIR, "assessment-schema.json")),
+  ];
+  return sha256(resources.join("\n---review-quality-resource---\n"));
+}
+
+function listSessionFiles(directory) {
+  if (!existsSync(directory)) return [];
+  const found = [];
+  const visit = (path, depth) => {
+    if (depth > 6) return;
+    for (const entry of readdirSync(path, { withFileTypes: true })) {
+      const child = join(path, entry.name);
+      if (entry.isDirectory()) visit(child, depth + 1);
+      if (entry.isFile() && entry.name === "session.json") found.push(child);
+    }
+  };
+  visit(directory, 0);
+  return found.sort((left, right) => {
+    const leftReviewer = /[\\/]reviewer[\\/]/u.test(left) ? 1 : 0;
+    const rightReviewer = /[\\/]reviewer[\\/]/u.test(right) ? 1 : 0;
+    if (leftReviewer !== rightReviewer) return rightReviewer - leftReviewer;
+    return statSync(right).size - statSync(left).size;
+  });
+}
+
+function extractAgentInstructions(content) {
+  if (typeof content !== "string") return "";
+  const match = content.match(
+    /<agent_instructions>([\s\S]*?)<\/agent_instructions>/u,
+  );
+  return match?.[1]?.trim() ?? "";
+}
+
+function eventResultText(event) {
+  const candidates = [
+    event?.data?.result?.content,
+    event?.data?.result?.detailedContent,
+    event?.data?.content,
+  ];
+  return candidates.find((value) => typeof value === "string") ?? "";
+}
+
+function truncateText(value, maximum) {
+  if (typeof value !== "string") return "";
+  if (value.length <= maximum) return value;
+  return `${value.slice(0, maximum)}\n[…truncated ${value.length - maximum} characters]`;
+}
+
+function tokenizeEvidence(findings, changedFiles, result) {
+  const terms = new Set();
+  const addTerm = (term) => {
+    const normalized = String(term ?? "").trim();
+    if (normalized.length >= 4 && normalized.length <= 100)
+      terms.add(normalized);
+  };
+  for (const finding of findings) {
+    const anchor = parseJson(finding.anchor_json, finding.anchor ?? null);
+    if (anchor?.path) {
+      addTerm(anchor.path);
+      addTerm(anchor.path.split(/[\\/]/u).at(-1));
+    }
+    for (const match of `${finding.title ?? ""}\n${finding.body ?? ""}`.matchAll(
+      /`([^`\n]{2,100})`/gu,
+    )) {
+      addTerm(match[1]);
+    }
+    for (const word of `${finding.title ?? ""}`.match(/[\p{L}\p{N}_-]{6,}/gu) ??
+      []) {
+      addTerm(word);
+    }
+  }
+  for (const change of changedFiles.slice(0, 250)) {
+    const path = change.newPath ?? change.oldPath ?? change.path;
+    if (path) addTerm(path.split(/[\\/]/u).at(-1));
+  }
+  const summary = result?.overview?.summary ?? "";
+  for (const word of summary.match(/[\p{L}\p{N}_-]{7,}/gu) ?? []) addTerm(word);
+  return [...terms].slice(0, 400);
+}
+
+function summarizeSessions(runDirectory, logsRoot, terms) {
+  const paths = listSessionFiles(runDirectory);
+  if (paths.length === 0) {
+    return {
+      available: false,
+      promptFingerprint: null,
+      sessions: [],
+      inspectionEvidence: [],
+    };
+  }
+
+  const sessions = [];
+  const evidenceCandidates = [];
+  let promptFingerprint = null;
+
+  for (const path of paths.slice(0, 3)) {
+    let session;
+    try {
+      session = readJson(path);
+    } catch {
+      continue;
+    }
+    const events = Array.isArray(session.events) ? session.events : [];
+    const eventCounts = {};
+    for (const event of events) {
+      const type = String(event?.type ?? "unknown");
+      eventCounts[type] = (eventCounts[type] ?? 0) + 1;
+    }
+    const systemContent = events.find(
+      (event) => event?.type === "system.message",
+    )?.data?.content;
+    const agentInstructions = extractAgentInstructions(systemContent);
+    const currentFingerprint = agentInstructions
+      ? sha256(agentInstructions).slice(0, 16)
+      : null;
+    promptFingerprint ??= currentFingerprint;
+
+    const calls = events
+      .filter(
+        (event) =>
+          event?.type === "tool.execution_start" ||
+          event?.type === "external_tool.requested",
+      )
+      .slice(0, 250)
+      .map((event) => ({
+        type: event.type,
+        toolCallId: event?.data?.toolCallId ?? event?.data?.id ?? null,
+        detail: truncateText(
+          canonicalStringify(
+            Object.fromEntries(
+              Object.entries(event?.data ?? {}).filter(
+                ([key]) => !["interactionId", "turnId", "model"].includes(key),
+              ),
+            ),
+          ),
+          1800,
+        ),
+      }));
+
+    for (const event of events) {
+      if (
+        event?.type !== "tool.execution_complete" &&
+        event?.type !== "external_tool.completed"
+      ) {
+        continue;
+      }
+      const text = eventResultText(event);
+      if (!text) continue;
+      const lower = text.toLocaleLowerCase();
+      let relevance = 0;
+      for (const term of terms) {
+        if (lower.includes(term.toLocaleLowerCase())) {
+          relevance += term.includes("/") || term.includes("\\") ? 8 : 2;
+        }
+      }
+      if (/\[git_readonly operation=(diff|view|show|blame)/u.test(text)) {
+        relevance += 3;
+      }
+      evidenceCandidates.push({
+        relevance,
+        sessionPath: relative(logsRoot, path).replaceAll("\\", "/"),
+        toolCallId: event?.data?.toolCallId ?? null,
+        content: text,
+      });
+    }
+
+    sessions.push({
+      path: relative(logsRoot, path).replaceAll("\\", "/"),
+      startedAt: session.startedAt ?? null,
+      finishedAt: session.finishedAt ?? null,
+      prompt: truncateText(session.prompt ?? "", 12_000),
+      response: truncateText(
+        typeof session.response === "string"
+          ? session.response
+          : canonicalStringify(session.response ?? null),
+        20_000,
+      ),
+      promptFingerprint: currentFingerprint,
+      eventCounts,
+      calls,
+    });
+  }
+
+  evidenceCandidates.sort(
+    (left, right) =>
+      right.relevance - left.relevance ||
+      right.content.length - left.content.length,
+  );
+  const inspectionEvidence = [];
+  let totalCharacters = 0;
+  for (const candidate of evidenceCandidates) {
+    if (inspectionEvidence.length >= 20 || totalCharacters >= 120_000) break;
+    const content = truncateText(candidate.content, 14_000);
+    if (totalCharacters + content.length > 120_000) continue;
+    inspectionEvidence.push({ ...candidate, content });
+    totalCharacters += content.length;
+  }
+
+  return {
+    available: sessions.length > 0,
+    promptFingerprint,
+    sessions,
+    inspectionEvidence,
+  };
+}
+
+function cleanProse(value) {
+  return String(value ?? "")
+    .replace(/```[\s\S]*?```/gu, " code block ")
+    .replace(/`[^`\n]+`/gu, " identifier ")
+    .replace(/https?:\/\/\S+/gu, " link ")
+    .replace(/^\s*[-*+]\s+/gmu, "")
+    .replace(/^\s*#{1,6}\s+/gmu, "")
+    .trim();
+}
+
+function countWords(value) {
+  return value.match(/[\p{L}\p{N}]+(?:['’-][\p{L}\p{N}]+)*/gu)?.length ?? 0;
+}
+
+function summarizeTextMetrics(result, findings) {
+  const overview = result?.overview ?? {};
+  const texts = [
+    overview.summary,
+    overview.overallAssessment,
+    overview.mergeReadiness?.summary,
+    ...findings.flatMap((finding) => [finding.title, finding.body]),
+  ]
+    .filter((value) => typeof value === "string" && value.trim() !== "")
+    .map(cleanProse);
+  const combined = texts.join("\n\n");
+  const paragraphs = combined.split(/\n\s*\n/gu).filter(Boolean);
+  const sentences = combined
+    .split(/(?<=[.!?])\s+|\n+/gu)
+    .map((sentence) => sentence.trim())
+    .filter(Boolean);
+  const sentenceWords = sentences.map(countWords);
+  const paragraphWords = paragraphs.map(countWords);
+  const average = (values) =>
+    values.length === 0
+      ? 0
+      : Math.round(
+          (values.reduce((sum, value) => sum + value, 0) / values.length) * 10,
+        ) / 10;
+  return {
+    totalWords: countWords(combined),
+    sentenceCount: sentences.length,
+    averageSentenceWords: average(sentenceWords),
+    longestSentenceWords: Math.max(0, ...sentenceWords),
+    paragraphCount: paragraphs.length,
+    averageParagraphWords: average(paragraphWords),
+    longestParagraphWords: Math.max(0, ...paragraphWords),
+  };
+}
+
+function selectRuns(source, fromInclusive, toExclusive, modes) {
+  const placeholders = modes.map(() => "?").join(", ");
+  return source
+    .prepare(
+      `SELECT
+         r.id,
+         r.interaction_job_id,
+         r.tenant_id,
+         r.provider,
+         r.model,
+         r.status,
+         r.result_json,
+         r.error,
+         r.started_at,
+         r.finished_at,
+         r.model_profile_name,
+         r.provider_type,
+         r.text_generation_model,
+         j.code_review_id,
+         j.trigger_json,
+         j.head_sha,
+         t.tenant_key,
+         t.platform,
+         (
+           SELECT m.prompt_mode
+           FROM interaction_run_metrics m
+           WHERE m.interaction_run_id = r.id
+             AND m.prompt_mode IN (${placeholders})
+           ORDER BY m.created_at ASC
+           LIMIT 1
+         ) AS prompt_mode
+       FROM interaction_runs r
+       JOIN interaction_jobs j ON j.id = r.interaction_job_id
+       JOIN tenants t ON t.id = r.tenant_id
+       WHERE r.status = 'completed'
+         AND r.started_at >= ?
+         AND r.started_at < ?
+         AND EXISTS (
+           SELECT 1
+           FROM interaction_run_metrics m
+           WHERE m.interaction_run_id = r.id
+             AND m.prompt_mode IN (${placeholders})
+         )
+       ORDER BY r.started_at ASC, r.id ASC`,
+    )
+    .all(...modes, fromInclusive, toExclusive, ...modes);
+}
+
+function loadSnapshot(source, run) {
+  const direct = source
+    .prepare(
+      `SELECT * FROM code_review_snapshots
+       WHERE interaction_run_id = ?
+       ORDER BY created_at DESC
+       LIMIT 1`,
+    )
+    .get(run.id);
+  if (direct) return direct;
+  return (
+    source
+      .prepare(
+        `SELECT * FROM code_review_snapshots
+         WHERE interaction_job_id = ?
+         ORDER BY created_at DESC
+         LIMIT 1`,
+      )
+      .get(run.interaction_job_id) ?? null
+  );
+}
+
+function loadFindings(source, runId) {
+  return source
+    .prepare(
+      `SELECT id, identity_key, severity, category, title, body,
+              anchor_json, suggestion_json, status, created_at
+       FROM review_findings
+       WHERE interaction_run_id = ?
+       ORDER BY created_at ASC, id ASC`,
+    )
+    .all(runId);
+}
+
+function loadMetrics(source, runId) {
+  return source
+    .prepare(
+      `SELECT harness, harness_session_key, session_type, trigger_kind,
+              prompt_mode, prompt_chars, prompt_context_changed_files,
+              prompt_context_prior_discussions, prompt_context_comments,
+              assistant_turns, assistant_calls, tool_executions,
+              view_tool_calls, glob_tool_calls, input_tokens, output_tokens,
+              cache_read_tokens, cache_write_tokens, reasoning_tokens,
+              api_duration_ms, usage_unit, usage_amount, repeated_view_reads,
+              repeated_view_paths_json
+       FROM interaction_run_metrics
+       WHERE interaction_run_id = ?
+       ORDER BY created_at ASC, id ASC`,
+    )
+    .all(runId)
+    .map((metric) => ({
+      ...metric,
+      repeated_view_paths: parseJson(metric.repeated_view_paths_json, []),
+      repeated_view_paths_json: undefined,
+    }));
+}
+
+function buildPacket(source, run, logsRoot, identity) {
+  const snapshot = loadSnapshot(source, run);
+  const findings = loadFindings(source, run.id);
+  const metrics = loadMetrics(source, run.id);
+  const result = parseJson(run.result_json, null);
+  const changedFiles = parseJson(snapshot?.changes_json, []);
+  const terms = tokenizeEvidence(findings, changedFiles, result);
+  const sessions = summarizeSessions(join(logsRoot, run.id), logsRoot, terms);
+  const reviewPhinVersion = readReviewPhinVersion(join(logsRoot, run.id));
+  const normalizedFindings = findings.map((finding) => ({
+    id: finding.id,
+    identityKey: finding.identity_key,
+    severity: finding.severity,
+    category: finding.category,
+    title: finding.title,
+    body: finding.body,
+    anchor: parseJson(finding.anchor_json, null),
+    suggestion: parseJson(finding.suggestion_json, null),
+    status: finding.status,
+    createdAt: finding.created_at,
+  }));
+  const evidence = {
+    run: {
+      id: run.id,
+      startedAt: run.started_at,
+      finishedAt: run.finished_at,
+      provider: run.provider,
+      model: run.model,
+      providerType: run.provider_type,
+      modelProfileName: run.model_profile_name,
+      textGenerationModel: run.text_generation_model,
+      promptMode: run.prompt_mode,
+      reviewPhinVersion,
+      trigger: parseJson(run.trigger_json, null),
+    },
+    codeReview: {
+      id: run.code_review_id,
+      tenantKey: run.tenant_key,
+      platform: run.platform,
+      headSha: run.head_sha,
+      details: parseJson(snapshot?.code_review_json, null),
+      versions: parseJson(snapshot?.versions_json, null),
+      changedFiles,
+      comments: parseJson(snapshot?.comments_json, []),
+      discussions: parseJson(snapshot?.discussions_json, []),
+      instructions: parseJson(snapshot?.instructions_json, []),
+      projectMemory: parseJson(snapshot?.project_memory_json, null),
+    },
+    reviewOutput: {
+      result,
+      findings: normalizedFindings,
+    },
+    metrics,
+    textMetrics: summarizeTextMetrics(result, normalizedFindings),
+    sessionEvidence: sessions,
+  };
+  const inputDigest = sha256(canonicalStringify(evidence));
+  return {
+    schemaVersion: 1,
+    runId: run.id,
+    inputDigest,
+    evaluatorVersion: identity.evaluatorVersion,
+    judgeModel: identity.judgeModel,
+    evidence,
+  };
+}
+
+function cacheContains(cache, packet) {
+  return Boolean(
+    cache
+      .prepare(
+        `SELECT 1 FROM assessments
+         WHERE run_id = ? AND input_digest = ?
+           AND evaluator_version = ? AND judge_model = ?`,
+      )
+      .get(
+        packet.runId,
+        packet.inputDigest,
+        packet.evaluatorVersion,
+        packet.judgeModel,
+      ),
+  );
+}
+
+function prepare(options) {
+  const paths = workspacePaths(options);
+  const fromInput = requireString(options, "from");
+  const toInput = requireString(options, "to");
+  const fromInclusive = parseRangeBoundary(fromInput, false);
+  const toExclusive = parseRangeBoundary(toInput, true);
+  if (fromInclusive >= toExclusive) {
+    throw new Error("The --from boundary must be earlier than --to.");
+  }
+  const databasePath = resolve(
+    paths.workspace,
+    typeof options.db === "string" ? options.db : "data/review-worker.sqlite",
+  );
+  const logsRoot = resolve(
+    paths.workspace,
+    typeof options.logs === "string" ? options.logs : "data/run-logs",
+  );
+  if (!existsSync(databasePath))
+    throw new Error(`Database not found: ${databasePath}`);
+  if (!existsSync(logsRoot)) throw new Error(`Run logs not found: ${logsRoot}`);
+  const modes = (
+    typeof options.modes === "string" ? options.modes.split(",") : DEFAULT_MODES
+  )
+    .map((mode) => mode.trim())
+    .filter(Boolean);
+  if (modes.length === 0)
+    throw new Error("At least one prompt mode is required.");
+  const judgeModel =
+    typeof options["judge-model"] === "string"
+      ? options["judge-model"].trim()
+      : "codex-current";
+  const identity = { evaluatorVersion: evaluatorVersion(), judgeModel };
+
+  ensureDirectory(paths.reportRoot);
+  replaceDirectory(paths.reportRoot, paths.packetsDirectory);
+  replaceDirectory(paths.reportRoot, paths.assessmentsDirectory);
+  ensureDirectory(paths.reportsDirectory);
+
+  const source = new DatabaseSync(databasePath, { readOnly: true });
+  const cache = openCache(paths.cachePath);
+  let runs;
+  try {
+    runs = selectRuns(source, fromInclusive, toExclusive, modes);
+    const selectedRuns = [];
+    const cachedRuns = [];
+    const pendingRuns = [];
+    for (const run of runs) {
+      const packet = buildPacket(source, run, logsRoot, identity);
+      const packetPath = join(paths.packetsDirectory, `${run.id}.json`);
+      atomicWrite(packetPath, `${JSON.stringify(packet, null, 2)}\n`);
+      const cached =
+        options.force === true ? false : cacheContains(cache, packet);
+      const title =
+        packet.evidence.codeReview.details?.title ??
+        `Code review ${packet.evidence.codeReview.id}`;
+      const summary = {
+        runId: run.id,
+        inputDigest: packet.inputDigest,
+        startedAt: run.started_at,
+        finishedAt: run.finished_at,
+        codeReviewId: run.code_review_id,
+        title,
+        tenantKey: run.tenant_key,
+        platform: run.platform,
+        promptMode: run.prompt_mode,
+        reviewPhinVersion: packet.evidence.run.reviewPhinVersion,
+        reviewModel: run.model,
+        promptFingerprint: packet.evidence.sessionEvidence.promptFingerprint,
+        findingCount: packet.evidence.reviewOutput.findings.length,
+        changedFileCount: packet.evidence.codeReview.changedFiles.length,
+        packetPath: relative(paths.workspace, packetPath).replaceAll("\\", "/"),
+      };
+      selectedRuns.push(summary);
+      (cached ? cachedRuns : pendingRuns).push(run.id);
+    }
+    const manifest = {
+      schemaVersion: 1,
+      generatedAt: new Date().toISOString(),
+      workspace: paths.workspace,
+      databasePath,
+      logsRoot,
+      reportRoot: paths.reportRoot,
+      range: {
+        fromInput,
+        toInput,
+        fromInclusive,
+        toExclusive,
+        slug: `${rangeSlug(fromInput)}--${rangeSlug(toInput)}`,
+      },
+      modes,
+      judgeModel,
+      evaluatorVersion: identity.evaluatorVersion,
+      force: options.force === true,
+      selectedRuns,
+      cachedRuns,
+      pendingRuns,
+    };
+    atomicWrite(paths.manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          manifest: relative(paths.workspace, paths.manifestPath).replaceAll(
+            "\\",
+            "/",
+          ),
+          selected: selectedRuns.length,
+          cached: cachedRuns.length,
+          pending: pendingRuns.length,
+          pendingRuns,
+          evaluatorVersion: identity.evaluatorVersion,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+  } finally {
+    source.close();
+    cache.close();
+  }
+}
+
+function assertPlainObject(value, label) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object.`);
+  }
+}
+
+function assertIntegerScore(value, label, nullable = false) {
+  assertPlainObject(value, label);
+  if (value.score === null && nullable) {
+    if (typeof value.reason !== "string" || value.reason.trim() === "") {
+      throw new Error(`${label}.reason must be a non-empty string.`);
+    }
+    return;
+  }
+  if (!Number.isInteger(value.score) || value.score < 0 || value.score > 10) {
+    throw new Error(`${label}.score must be an integer from 0 through 10.`);
+  }
+  if (typeof value.reason !== "string" || value.reason.trim() === "") {
+    throw new Error(`${label}.reason must be a non-empty string.`);
+  }
+}
+
+function assertStringArray(value, label) {
+  if (
+    !Array.isArray(value) ||
+    value.length > 5 ||
+    value.some((entry) => typeof entry !== "string" || entry.trim() === "")
+  ) {
+    throw new Error(`${label} must contain at most five non-empty strings.`);
+  }
+}
+
+function validateAssessment(assessment, packet) {
+  assertPlainObject(assessment, "assessment");
+  if (assessment.schemaVersion !== 1)
+    throw new Error("schemaVersion must be 1.");
+  for (const key of [
+    "runId",
+    "inputDigest",
+    "evaluatorVersion",
+    "judgeModel",
+  ]) {
+    if (assessment[key] !== packet[key]) {
+      throw new Error(`${key} does not match the prepared packet.`);
+    }
+  }
+  assertPlainObject(assessment.categories, "categories");
+  for (const category of CATEGORY_NAMES) {
+    assertIntegerScore(
+      assessment.categories[category],
+      `categories.${category}`,
+      category === "importance" || category === "targeting",
+    );
+  }
+  assertStringArray(assessment.strengths, "strengths");
+  assertStringArray(assessment.weaknesses, "weaknesses");
+  if (!Array.isArray(assessment.findings)) {
+    throw new Error("findings must be an array.");
+  }
+  const expectedFindings = packet.evidence.reviewOutput.findings;
+  const expectedIds = new Set(expectedFindings.map((finding) => finding.id));
+  const actualIds = new Set();
+  for (const [index, finding] of assessment.findings.entries()) {
+    const label = `findings[${index}]`;
+    assertPlainObject(finding, label);
+    if (
+      !expectedIds.has(finding.findingId) ||
+      actualIds.has(finding.findingId)
+    ) {
+      throw new Error(
+        `${label}.findingId is missing, unexpected, or duplicated.`,
+      );
+    }
+    actualIds.add(finding.findingId);
+    if (
+      !Number.isInteger(finding.importance) ||
+      finding.importance < 0 ||
+      finding.importance > 10
+    ) {
+      throw new Error(
+        `${label}.importance must be an integer from 0 through 10.`,
+      );
+    }
+    if (
+      !Number.isInteger(finding.groundedness) ||
+      finding.groundedness < 0 ||
+      finding.groundedness > 10
+    ) {
+      throw new Error(
+        `${label}.groundedness must be an integer from 0 through 10.`,
+      );
+    }
+    if (typeof finding.reason !== "string" || finding.reason.trim() === "") {
+      throw new Error(`${label}.reason must be a non-empty string.`);
+    }
+    assertPlainObject(finding.targeting, `${label}.targeting`);
+    if (
+      !Number.isInteger(finding.targeting.score) ||
+      finding.targeting.score < 0 ||
+      finding.targeting.score > 10
+    ) {
+      throw new Error(
+        `${label}.targeting.score must be an integer from 0 through 10.`,
+      );
+    }
+    for (const key of [
+      "anchorExpected",
+      "anchorPresent",
+      "suggestionExpected",
+      "suggestionPresent",
+    ]) {
+      if (typeof finding.targeting[key] !== "boolean") {
+        throw new Error(`${label}.targeting.${key} must be boolean.`);
+      }
+    }
+    for (const key of ["anchorQuality", "suggestionQuality"]) {
+      if (
+        typeof finding.targeting[key] !== "string" ||
+        finding.targeting[key].trim() === ""
+      ) {
+        throw new Error(
+          `${label}.targeting.${key} must be a non-empty string.`,
+        );
+      }
+    }
+  }
+  if (actualIds.size !== expectedIds.size) {
+    throw new Error(
+      "Assessment must contain exactly one entry for every emitted finding.",
+    );
+  }
+  if (expectedIds.size === 0) {
+    if (
+      assessment.categories.importance.score !== null ||
+      assessment.categories.targeting.score !== null
+    ) {
+      throw new Error(
+        "Runs without findings require null importance and targeting scores.",
+      );
+    }
+  } else {
+    if (
+      assessment.categories.importance.score === null ||
+      assessment.categories.targeting.score === null
+    ) {
+      throw new Error(
+        "Runs with findings require numeric importance and targeting scores.",
+      );
+    }
+    const roundedImportance = Math.round(
+      assessment.findings.reduce(
+        (sum, finding) => sum + finding.importance,
+        0,
+      ) / assessment.findings.length,
+    );
+    const roundedTargeting = Math.round(
+      assessment.findings.reduce(
+        (sum, finding) => sum + finding.targeting.score,
+        0,
+      ) / assessment.findings.length,
+    );
+    if (assessment.categories.importance.score !== roundedImportance) {
+      throw new Error(
+        `Run importance must equal rounded per-finding average (${roundedImportance}).`,
+      );
+    }
+    if (assessment.categories.targeting.score !== roundedTargeting) {
+      throw new Error(
+        `Run targeting must equal rounded per-finding average (${roundedTargeting}).`,
+      );
+    }
+  }
+}
+
+function store(options) {
+  const paths = workspacePaths(options);
+  const file = resolve(paths.workspace, requireString(options, "file"));
+  assertInside(paths.reportRoot, file);
+  if (!existsSync(file)) throw new Error(`Assessment file not found: ${file}`);
+  if (!existsSync(paths.manifestPath)) {
+    throw new Error("Prepare a benchmark period before storing assessments.");
+  }
+  const assessment = readJson(file);
+  const packetPath = join(paths.packetsDirectory, `${assessment.runId}.json`);
+  if (!existsSync(packetPath)) {
+    throw new Error(`Prepared packet not found for ${assessment.runId}.`);
+  }
+  const packet = readJson(packetPath);
+  validateAssessment(assessment, packet);
+  const cache = openCache(paths.cachePath);
+  try {
+    cache
+      .prepare(
+        `INSERT OR REPLACE INTO assessments (
+           run_id, input_digest, evaluator_version, judge_model,
+           assessed_at, assessment_json
+         ) VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        assessment.runId,
+        assessment.inputDigest,
+        assessment.evaluatorVersion,
+        assessment.judgeModel,
+        new Date().toISOString(),
+        JSON.stringify(assessment),
+      );
+  } finally {
+    cache.close();
+  }
+  process.stdout.write(
+    `${JSON.stringify({ stored: assessment.runId, cache: relative(paths.workspace, paths.cachePath).replaceAll("\\", "/") }, null, 2)}\n`,
+  );
+}
+
+function loadCachedAssessment(cache, selected, manifest) {
+  const row = cache
+    .prepare(
+      `SELECT assessment_json, assessed_at
+       FROM assessments
+       WHERE run_id = ? AND input_digest = ?
+         AND evaluator_version = ? AND judge_model = ?`,
+    )
+    .get(
+      selected.runId,
+      selected.inputDigest,
+      manifest.evaluatorVersion,
+      manifest.judgeModel,
+    );
+  if (!row) return null;
+  return {
+    assessment: JSON.parse(row.assessment_json),
+    assessedAt: row.assessed_at,
+  };
+}
+
+function escapeEmbeddedJson(value) {
+  return JSON.stringify(value)
+    .replaceAll("<", "\\u003c")
+    .replaceAll("\u2028", "\\u2028")
+    .replaceAll("\u2029", "\\u2029");
+}
+
+function render(options) {
+  const paths = workspacePaths(options);
+  if (!existsSync(paths.manifestPath)) {
+    throw new Error("Prepare a benchmark period before rendering.");
+  }
+  if (!existsSync(TEMPLATE_PATH))
+    throw new Error(`Template not found: ${TEMPLATE_PATH}`);
+  const manifest = readJson(paths.manifestPath);
+  const cache = openCache(paths.cachePath);
+  const reportRuns = [];
+  const missingRuns = [];
+  try {
+    for (const selected of manifest.selectedRuns) {
+      const cached = loadCachedAssessment(cache, selected, manifest);
+      if (!cached) {
+        missingRuns.push(selected.runId);
+        continue;
+      }
+      const packetPath = join(paths.packetsDirectory, `${selected.runId}.json`);
+      const packet = existsSync(packetPath) ? readJson(packetPath) : null;
+      reportRuns.push({
+        ...selected,
+        assessedAt: cached.assessedAt,
+        categories: cached.assessment.categories,
+        findingAssessments: cached.assessment.findings,
+        strengths: cached.assessment.strengths,
+        weaknesses: cached.assessment.weaknesses,
+        findings:
+          packet?.evidence?.reviewOutput?.findings?.map((finding) => ({
+            id: finding.id,
+            title: finding.title,
+            severity: finding.severity,
+            category: finding.category,
+            anchor: finding.anchor,
+            suggestion: finding.suggestion,
+          })) ?? [],
+        textMetrics: packet?.evidence?.textMetrics ?? null,
+      });
+    }
+  } finally {
+    cache.close();
+  }
+
+  const cachedAtPrepare = new Set(manifest.cachedRuns);
+  const data = {
+    schemaVersion: 1,
+    metadata: {
+      title: "Review quality benchmark",
+      generatedAt: new Date().toISOString(),
+      range: manifest.range,
+      modes: manifest.modes,
+      judgeModel: manifest.judgeModel,
+      evaluatorVersion: manifest.evaluatorVersion,
+      selectedCount: manifest.selectedRuns.length,
+      scoredCount: reportRuns.length,
+      missingCount: missingRuns.length,
+      cacheReuseCount: reportRuns.filter((run) =>
+        cachedAtPrepare.has(run.runId),
+      ).length,
+      newlyAssessedCount: reportRuns.filter(
+        (run) => !cachedAtPrepare.has(run.runId),
+      ).length,
+      missingRuns,
+    },
+    dimensions: REPORT_DIMENSIONS,
+    runs: reportRuns,
+  };
+  const template = readUtf8(TEMPLATE_PATH);
+  const marker = "__REVIEW_BENCHMARK_DATA__";
+  const markerCount = template.split(marker).length - 1;
+  if (markerCount !== 1) {
+    throw new Error(
+      `Report template must contain exactly one ${marker} marker.`,
+    );
+  }
+  const html = template.replace(marker, escapeEmbeddedJson(data));
+  const outputName =
+    typeof options["output-name"] === "string"
+      ? options["output-name"]
+      : `review-quality-${manifest.range.slug}.html`;
+  if (!/^[A-Za-z0-9._-]+\.html$/u.test(outputName)) {
+    throw new Error("--output-name must be a simple .html filename.");
+  }
+  const outputPath = join(paths.reportsDirectory, outputName);
+  assertInside(paths.reportRoot, outputPath);
+  atomicWrite(outputPath, html);
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        report: relative(paths.workspace, outputPath).replaceAll("\\", "/"),
+        selected: manifest.selectedRuns.length,
+        scored: reportRuns.length,
+        missing: missingRuns.length,
+        cacheReused: data.metadata.cacheReuseCount,
+        newlyAssessed: data.metadata.newlyAssessedCount,
+        missingRuns,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+function main() {
+  const { command, options } = parseArguments(process.argv.slice(2));
+  if (command === "help" || command === "--help" || command === "-h") {
+    printHelp();
+    return;
+  }
+  if (command === "prepare") {
+    prepare(options);
+    return;
+  }
+  if (command === "store") {
+    store(options);
+    return;
+  }
+  if (command === "render") {
+    render(options);
+    return;
+  }
+  throw new Error(`Unknown command: ${command}`);
+}
+
+try {
+  main();
+} catch (error) {
+  process.stderr.write(
+    `review-quality-benchmark: ${error instanceof Error ? error.message : String(error)}\n`,
+  );
+  process.exitCode = 1;
+}

--- a/.agents/skills/review-quality-benchmark/scripts/benchmark.mjs
+++ b/.agents/skills/review-quality-benchmark/scripts/benchmark.mjs
@@ -577,24 +577,15 @@ function selectRuns(source, fromInclusive, toExclusive, modes) {
 }
 
 function loadSnapshot(source, run) {
-  const direct = source
-    .prepare(
-      `SELECT * FROM code_review_snapshots
-       WHERE interaction_run_id = ?
-       ORDER BY created_at DESC
-       LIMIT 1`,
-    )
-    .get(run.id);
-  if (direct) return direct;
   return (
     source
       .prepare(
         `SELECT * FROM code_review_snapshots
-         WHERE interaction_job_id = ?
+         WHERE interaction_run_id = ?
          ORDER BY created_at DESC
          LIMIT 1`,
       )
-      .get(run.interaction_job_id) ?? null
+      .get(run.id) ?? null
   );
 }
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ public/index.html
 public/docs
 public/pagefind
 DOCKERHUB_README.md
+/benchmark-report/

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -141,6 +141,10 @@ export default defineConfig({
           items: [
             { label: "Overview", slug: "docs/development" },
             { label: "Review flow", slug: "docs/development/review-flow" },
+            {
+              label: "Review quality benchmark",
+              slug: "docs/development/review-quality-benchmark",
+            },
             { label: "Providers", slug: "docs/development/providers" },
             {
               label: "Custom platform providers",

--- a/docs/src/content/docs/deployment/index.md
+++ b/docs/src/content/docs/deployment/index.md
@@ -19,6 +19,7 @@ Then make the instance reachable so platforms can deliver webhooks — see [expo
 
 - [Environment variables](environment-variables/) — the full runtime reference.
 - [Storage & migration](storage/) — SQLite, Flotiq, custom adapters, backups, and moving data.
+- [Review quality benchmark](../development/review-quality-benchmark/) — analyze exported review runs and run logs without connecting to reviewed repositories.
 
 ## What one container serves
 

--- a/docs/src/content/docs/development/index.md
+++ b/docs/src/content/docs/development/index.md
@@ -48,6 +48,7 @@ Storage keeps tenants, platform connections, jobs, runs, findings, discussion ma
 ## In this area
 
 - [Review flow](review-flow/) — from webhook to published review.
+- [Review quality benchmark](review-quality-benchmark/) — compare recorded review output across prompt eras and releases.
 - [Providers](providers/) — the platform and storage provider model.
 - [Custom platform providers](custom-platforms/) — add a code review platform.
 - [Custom storage adapters](custom-storage/) — add a persistence backend.

--- a/docs/src/content/docs/development/review-quality-benchmark.md
+++ b/docs/src/content/docs/development/review-quality-benchmark.md
@@ -57,7 +57,7 @@ benchmark-report/
   tmp/               normalized packets, manifest, and pending assessments
 ```
 
-The cache reuses a score only when the normalized evidence, rubric, assessment schema, judge prompt, and judge model still match. Widening the date range assesses only new or invalidated runs before rendering the complete requested period.
+The cache reuses a score only when the normalized evidence, rubric, assessment schema, judge prompt, and judge model still match. Widening the date range assesses only new or invalidated runs before rendering the complete requested period. A forced preparation invalidates matching scores for the selected runs before reassessment while preserving unrelated cache entries.
 
 The HTML report works offline. Use its filters to isolate tenants, review modes, models, or prompt fingerprints. Long periods scroll horizontally so the seven quality lanes keep a readable height. The score range can switch between the fixed 0–10 scale and one shared range fitted to the visible results.
 

--- a/docs/src/content/docs/development/review-quality-benchmark.md
+++ b/docs/src/content/docs/development/review-quality-benchmark.md
@@ -1,0 +1,72 @@
+---
+title: Review quality benchmark
+description: Compare recorded review comments across time, prompt changes, and releases.
+---
+
+The review quality benchmark helps maintainers check whether generated review comments improve after prompt or application changes. It scores completed review runs from an exported SQLite database and their saved run logs, then produces a self-contained HTML report.
+
+The benchmark works from recorded evidence only. It does not open the reviewed repositories or call GitLab, GitHub, model-provider, or storage-provider APIs.
+
+## What you need
+
+Run the benchmark from a ReviewPhin source checkout with the bundled Codex skill available. Copy these artifacts from the instance you want to analyze:
+
+| Input | Default path | Purpose |
+| --- | --- | --- |
+| SQLite database | `data/review-worker.sqlite` | Completed runs, review output, findings, and snapshots. |
+| Run logs | `data/run-logs/` | Prompt, inspection, model, and session evidence recorded for each run. |
+
+The source artifacts are read-only during benchmarking. A run remains usable when some older evidence is absent, but the assessment should state the limitation instead of inferring missing context.
+
+## Generate a report
+
+Ask Codex to use the skill and provide an inclusive UTC date range:
+
+```text
+Use $review-quality-benchmark to assess runs from 2026-08-01 through 2026-08-06.
+```
+
+Mention different database or run-log paths in the request when the exports are not under `data/`.
+
+By default, the benchmark includes completed full reviews, incremental rereviews, and targeted review runs. It excludes chatter, reply-only, and memory sessions because they do not represent a complete review result.
+
+## Scores
+
+Each applicable dimension is scored from 0 through 10. Higher is better.
+
+| Dimension | Question |
+| --- | --- |
+| Noob friendliness | Can a programmer new to the project understand the review? |
+| Unjargonity | Does the response prefer precise, simple language? |
+| Readability | Are sentences, paragraphs, and information order easy to scan? |
+| Importance | Do emitted findings provide material engineering value? |
+| Targeting | Are anchors and replacement suggestions chosen well? |
+| Assessment scope | Does the overview represent the complete current merge request or pull request? |
+| Groundedness | Are claims supported by evidence recorded in the run? |
+
+Importance and targeting are not applicable when a run emitted no findings. The report displays those gaps as missing values, not zero scores.
+
+## Output and cache
+
+All generated files stay under the gitignored `benchmark-report/` directory:
+
+```text
+benchmark-report/
+  cache.sqlite       reusable assessments
+  reports/           self-contained HTML reports
+  tmp/               normalized packets, manifest, and pending assessments
+```
+
+The cache reuses a score only when the normalized evidence, rubric, assessment schema, judge prompt, and judge model still match. Widening the date range assesses only new or invalidated runs before rendering the complete requested period.
+
+The HTML report works offline. Use its filters to isolate tenants, review modes, models, or prompt fingerprints. Long periods scroll horizontally so the seven quality lanes keep a readable height. The score range can switch between the fixed 0–10 scale and one shared range fitted to the visible results.
+
+## Prompt and release markers
+
+Prompt-change markers come from the reviewer prompt fingerprint recorded with each run. Release markers use the ReviewPhin version saved in the run log. Runs created before those fields were recorded remain in the report but cannot contribute the corresponding marker.
+
+Treat small eras cautiously. A handful of runs can suggest a change, but it is not enough to separate prompt effects from different repositories, change sizes, review modes, or models.
+
+## Keep reports private
+
+Reports and normalized packets can contain review titles, tenant identifiers, finding text, anchors, and replacement suggestions. `benchmark-report/` is ignored by Git; keep it that way. Review the generated file before sharing it outside the team.

--- a/src/app-version.ts
+++ b/src/app-version.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs";
+
+interface PackageMetadata {
+  version?: unknown;
+}
+
+export const reviewPhinVersion = readReviewPhinVersion();
+
+function readReviewPhinVersion(): string {
+  try {
+    const packageMetadata = JSON.parse(
+      readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+    ) as PackageMetadata;
+
+    if (
+      typeof packageMetadata.version === "string" &&
+      packageMetadata.version.trim() !== ""
+    ) {
+      return packageMetadata.version.trim();
+    }
+  } catch {
+    // Keep run logging operational even when package metadata is unavailable.
+  }
+
+  return "unknown";
+}

--- a/src/jobs/review-worker.ts
+++ b/src/jobs/review-worker.ts
@@ -1,6 +1,7 @@
 import type { Logger } from "pino";
 import { join } from "node:path";
 
+import { reviewPhinVersion } from "../app-version.js";
 import type {
   IPlatform,
   PlatformMaterializedWorkspace,
@@ -401,6 +402,7 @@ export class ReviewWorker {
       }
 
       await this.logRunEvent(runArtifacts, "info", "interaction run started", {
+        reviewPhinVersion,
         interactionJobId: job.id,
         interactionRunId: interactionRun.id,
         interactionJobClaimToken: context.claimToken,

--- a/test/app-version.test.ts
+++ b/test/app-version.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+import { reviewPhinVersion } from "../src/app-version.js";
+
+describe("ReviewPhin version evidence", () => {
+  it("reads the application version from package metadata", () => {
+    const packageMetadata = JSON.parse(
+      readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+    ) as { version: string };
+
+    expect(reviewPhinVersion).toBe(packageMetadata.version);
+  });
+});

--- a/test/review-quality-benchmark.test.ts
+++ b/test/review-quality-benchmark.test.ts
@@ -1,5 +1,11 @@
 import { execFileSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { DatabaseSync } from "node:sqlite";
@@ -7,7 +13,7 @@ import { DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
 
 describe("review quality benchmark evidence", () => {
-  it("does not borrow a newer job snapshot for an older run", () => {
+  it("keeps snapshots run-scoped and invalidates forced cached scores", () => {
     const workspace = mkdtempSync(join(tmpdir(), "review-quality-benchmark-"));
     const databasePath = join(workspace, "review-worker.sqlite");
     const logsPath = join(workspace, "run-logs");
@@ -176,28 +182,26 @@ describe("review quality benchmark evidence", () => {
     }
 
     try {
-      execFileSync(
-        process.execPath,
-        [
-          resolve(
-            ".agents/skills/review-quality-benchmark/scripts/benchmark.mjs",
-          ),
-          "prepare",
-          "--workspace",
-          workspace,
-          "--db",
-          databasePath,
-          "--logs",
-          logsPath,
-          "--from",
-          "2026-04-28",
-          "--to",
-          "2026-04-28",
-          "--judge-model",
-          "test-judge",
-        ],
-        { stdio: "pipe" },
+      const scriptPath = resolve(
+        ".agents/skills/review-quality-benchmark/scripts/benchmark.mjs",
       );
+      const prepareArguments = [
+        scriptPath,
+        "prepare",
+        "--workspace",
+        workspace,
+        "--db",
+        databasePath,
+        "--logs",
+        logsPath,
+        "--from",
+        "2026-04-28",
+        "--to",
+        "2026-04-28",
+        "--judge-model",
+        "test-judge",
+      ];
+      execFileSync(process.execPath, prepareArguments, { stdio: "pipe" });
 
       const packet = JSON.parse(
         readFileSync(
@@ -211,6 +215,10 @@ describe("review quality benchmark evidence", () => {
           "utf8",
         ),
       ) as {
+        runId: string;
+        inputDigest: string;
+        evaluatorVersion: string;
+        judgeModel: string;
         evidence: {
           codeReview: { details: unknown; changedFiles: unknown[] };
         };
@@ -218,6 +226,75 @@ describe("review quality benchmark evidence", () => {
 
       expect(packet.evidence.codeReview.details).toBeNull();
       expect(packet.evidence.codeReview.changedFiles).toEqual([]);
+
+      const assessmentPath = join(
+        workspace,
+        "benchmark-report",
+        "tmp",
+        "assessments",
+        "run-old.json",
+      );
+      writeFileSync(
+        assessmentPath,
+        JSON.stringify({
+          schemaVersion: 1,
+          runId: packet.runId,
+          inputDigest: packet.inputDigest,
+          evaluatorVersion: packet.evaluatorVersion,
+          judgeModel: packet.judgeModel,
+          categories: {
+            noobFriendliness: { score: 8, reason: "Clear." },
+            unjargonity: { score: 8, reason: "Simple." },
+            readability: { score: 8, reason: "Readable." },
+            importance: { score: null, reason: "No findings." },
+            targeting: { score: null, reason: "No findings." },
+            assessmentScope: { score: 8, reason: "Complete." },
+            groundedness: { score: 8, reason: "Grounded." },
+          },
+          findings: [],
+          strengths: [],
+          weaknesses: [],
+        }),
+      );
+      execFileSync(
+        process.execPath,
+        [
+          scriptPath,
+          "store",
+          "--workspace",
+          workspace,
+          "--file",
+          assessmentPath,
+        ],
+        { stdio: "pipe" },
+      );
+
+      const cachePath = join(workspace, "benchmark-report", "cache.sqlite");
+      const cachedBeforeForce = new DatabaseSync(cachePath, { readOnly: true });
+      try {
+        expect(
+          cachedBeforeForce
+            .prepare("SELECT COUNT(*) AS count FROM assessments")
+            .get(),
+        ).toEqual({ count: 1 });
+      } finally {
+        cachedBeforeForce.close();
+      }
+
+      execFileSync(process.execPath, [...prepareArguments, "--force"], {
+        stdio: "pipe",
+      });
+
+      const cachedAfterForce = new DatabaseSync(cachePath, { readOnly: true });
+      try {
+        expect(
+          cachedAfterForce
+            .prepare("SELECT COUNT(*) AS count FROM assessments")
+            .get(),
+        ).toEqual({ count: 0 });
+      } finally {
+        cachedAfterForce.close();
+      }
     } finally {
       rmSync(workspace, { recursive: true, force: true });
     }

--- a/test/review-quality-benchmark.test.ts
+++ b/test/review-quality-benchmark.test.ts
@@ -1,0 +1,225 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { describe, expect, it } from "vitest";
+
+describe("review quality benchmark evidence", () => {
+  it("does not borrow a newer job snapshot for an older run", () => {
+    const workspace = mkdtempSync(join(tmpdir(), "review-quality-benchmark-"));
+    const databasePath = join(workspace, "review-worker.sqlite");
+    const logsPath = join(workspace, "run-logs");
+    mkdirSync(logsPath);
+
+    const database = new DatabaseSync(databasePath);
+    try {
+      database.exec(`
+        CREATE TABLE tenants (
+          id TEXT PRIMARY KEY,
+          tenant_key TEXT NOT NULL,
+          platform TEXT NOT NULL
+        );
+        CREATE TABLE interaction_jobs (
+          id TEXT PRIMARY KEY,
+          tenant_id TEXT NOT NULL,
+          code_review_id INTEGER NOT NULL,
+          trigger_json TEXT,
+          head_sha TEXT
+        );
+        CREATE TABLE interaction_runs (
+          id TEXT PRIMARY KEY,
+          interaction_job_id TEXT NOT NULL,
+          tenant_id TEXT NOT NULL,
+          provider TEXT NOT NULL,
+          model TEXT,
+          status TEXT NOT NULL,
+          result_json TEXT,
+          error TEXT,
+          started_at TEXT NOT NULL,
+          finished_at TEXT,
+          model_profile_name TEXT,
+          provider_type TEXT,
+          text_generation_model TEXT
+        );
+        CREATE TABLE interaction_run_metrics (
+          id TEXT PRIMARY KEY,
+          interaction_run_id TEXT NOT NULL,
+          harness TEXT,
+          harness_session_key TEXT,
+          session_type TEXT,
+          trigger_kind TEXT,
+          prompt_mode TEXT,
+          prompt_chars INTEGER,
+          prompt_context_changed_files INTEGER,
+          prompt_context_prior_discussions INTEGER,
+          prompt_context_comments INTEGER,
+          assistant_turns INTEGER,
+          assistant_calls INTEGER,
+          tool_executions INTEGER,
+          view_tool_calls INTEGER,
+          glob_tool_calls INTEGER,
+          input_tokens INTEGER,
+          output_tokens INTEGER,
+          cache_read_tokens INTEGER,
+          cache_write_tokens INTEGER,
+          reasoning_tokens INTEGER,
+          api_duration_ms INTEGER,
+          usage_unit TEXT,
+          usage_amount REAL,
+          repeated_view_reads INTEGER,
+          repeated_view_paths_json TEXT,
+          created_at TEXT NOT NULL
+        );
+        CREATE TABLE code_review_snapshots (
+          id TEXT PRIMARY KEY,
+          interaction_job_id TEXT NOT NULL,
+          interaction_run_id TEXT,
+          code_review_json TEXT,
+          versions_json TEXT,
+          changes_json TEXT,
+          comments_json TEXT,
+          discussions_json TEXT,
+          instructions_json TEXT,
+          project_memory_json TEXT,
+          created_at TEXT NOT NULL
+        );
+        CREATE TABLE review_findings (
+          id TEXT PRIMARY KEY,
+          interaction_run_id TEXT NOT NULL,
+          identity_key TEXT,
+          severity TEXT,
+          category TEXT,
+          title TEXT,
+          body TEXT,
+          anchor_json TEXT,
+          suggestion_json TEXT,
+          status TEXT,
+          created_at TEXT NOT NULL
+        );
+      `);
+      database
+        .prepare(
+          "INSERT INTO tenants (id, tenant_key, platform) VALUES (?, ?, ?)",
+        )
+        .run("tenant-1", "https://git.example::1", "gitlab");
+      database
+        .prepare(
+          "INSERT INTO interaction_jobs (id, tenant_id, code_review_id, trigger_json, head_sha) VALUES (?, ?, ?, ?, ?)",
+        )
+        .run("job-1", "tenant-1", 1, "{}", "old-head");
+      database
+        .prepare(
+          `INSERT INTO interaction_runs (
+             id, interaction_job_id, tenant_id, provider, status, result_json,
+             started_at, finished_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          "run-old",
+          "job-1",
+          "tenant-1",
+          "copilot-sdk",
+          "completed",
+          JSON.stringify({
+            overview: {
+              summary: "The older review completed.",
+              overallSeverity: "low",
+              overallAssessment: "Ready.",
+              mergeReadiness: {
+                status: "ready",
+                confidence: "high",
+                summary: "No findings.",
+              },
+              highlights: [],
+            },
+            findings: [],
+            priorDispositions: [],
+          }),
+          "2026-04-28T08:00:00.000Z",
+          "2026-04-28T08:01:00.000Z",
+        );
+      database
+        .prepare(
+          "INSERT INTO interaction_run_metrics (id, interaction_run_id, prompt_mode, created_at) VALUES (?, ?, ?, ?)",
+        )
+        .run(
+          "metric-old",
+          "run-old",
+          "first-pass-full",
+          "2026-04-28T08:01:00.000Z",
+        );
+      database
+        .prepare(
+          `INSERT INTO code_review_snapshots (
+             id, interaction_job_id, interaction_run_id, code_review_json,
+             versions_json, changes_json, comments_json, discussions_json,
+             instructions_json, project_memory_json, created_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          "snapshot-newer",
+          "job-1",
+          "run-newer",
+          JSON.stringify({ title: "Later retry state" }),
+          "[]",
+          JSON.stringify([{ new_path: "later.ts", diff: "+later" }]),
+          "[]",
+          "[]",
+          "[]",
+          "null",
+          "2026-04-28T09:00:00.000Z",
+        );
+    } finally {
+      database.close();
+    }
+
+    try {
+      execFileSync(
+        process.execPath,
+        [
+          resolve(
+            ".agents/skills/review-quality-benchmark/scripts/benchmark.mjs",
+          ),
+          "prepare",
+          "--workspace",
+          workspace,
+          "--db",
+          databasePath,
+          "--logs",
+          logsPath,
+          "--from",
+          "2026-04-28",
+          "--to",
+          "2026-04-28",
+          "--judge-model",
+          "test-judge",
+        ],
+        { stdio: "pipe" },
+      );
+
+      const packet = JSON.parse(
+        readFileSync(
+          join(
+            workspace,
+            "benchmark-report",
+            "tmp",
+            "packets",
+            "run-old.json",
+          ),
+          "utf8",
+        ),
+      ) as {
+        evidence: {
+          codeReview: { details: unknown; changedFiles: unknown[] };
+        };
+      };
+
+      expect(packet.evidence.codeReview.details).toBeNull();
+      expect(packet.evidence.codeReview.changedFiles).toEqual([]);
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- add a standalone Node.js skill that prepares recorded review evidence, caches evidence-relative assessments, and renders a self-contained HTML quality report
- chart seven quality dimensions over time with prompt and release markers, filters, fixed or fitted score ranges, and a horizontally scrolling timeline that keeps its height for long periods
- record the ReviewPhin package version in each run's saved event log so future reports can correlate quality with releases
- keep benchmark databases, packets, assessments, screenshots, and reports under the ignored `benchmark-report/` directory

## Validation

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm docs:build`
- [x] `python C:\Users\riven\.codex\skills\.system\skill-creator\scripts\quick_validate.py .agents\skills\review-quality-benchmark`
- [x] rendered and visually checked a 434-run offline report in a headless browser
- [x] Tests cover new or changed behavior
- [x] Documentation reflects user-facing changes
- [x] The change contains no credentials, private code, sensitive logs, or generated benchmark artifacts

## Changelog

<details><summary>Changelog: minor</summary>

### Added

- Operators can benchmark recorded review quality across date ranges and inspect the results in an offline chart report.

### Changed

- Saved run logs now include the ReviewPhin version so future benchmark reports can correlate quality changes with releases.

</details>
